### PR TITLE
add reveal hand

### DIFF
--- a/src/components/CardSearchModal.test.tsx
+++ b/src/components/CardSearchModal.test.tsx
@@ -71,6 +71,7 @@ describe('CardSearchModal', () => {
 
     expect(screen.getByText('Play to Field')).toBeInTheDocument();
     expect(screen.getByText('Add to Hand')).toBeInTheDocument();
+    expect(screen.getByText('Reveal & Add to Hand')).toBeInTheDocument();
     expect(screen.getByText('Add to EX Area')).toBeInTheDocument();
   });
 
@@ -109,11 +110,13 @@ describe('CardSearchModal', () => {
 
     fireEvent.click(screen.getByText('Play to Field'));
     fireEvent.click(screen.getByText('Add to Hand'));
+    fireEvent.click(screen.getByText('Reveal & Add to Hand'));
     fireEvent.click(screen.getByText('Add to EX Area'));
 
     expect(onExtractCard).toHaveBeenNthCalledWith(1, 'card-1', 'field-host');
     expect(onExtractCard).toHaveBeenNthCalledWith(2, 'card-1', 'hand-host');
-    expect(onExtractCard).toHaveBeenNthCalledWith(3, 'card-1', 'ex-host');
+    expect(onExtractCard).toHaveBeenNthCalledWith(3, 'card-1', 'hand-host', true);
+    expect(onExtractCard).toHaveBeenNthCalledWith(4, 'card-1', 'ex-host');
   });
 
   it('fires evolve-deck usage toggle and shows the unused label when face-up', () => {

--- a/src/components/CardSearchModal.tsx
+++ b/src/components/CardSearchModal.tsx
@@ -7,7 +7,7 @@ interface CardSearchModalProps {
   onClose: () => void;
   title: string;
   cards: CardInstance[];
-  onExtractCard: (cardId: string, destination?: string) => void;
+  onExtractCard: (cardId: string, destination?: string, revealToOpponent?: boolean) => void;
   onToggleFlip?: (cardId: string) => void;
   viewerRole?: PlayerRole;
   targetRole?: PlayerRole;
@@ -18,6 +18,7 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({ isOpen, onClose, titl
   if (!isOpen) return null;
 
   const isPreparingMainDeckSearch = !allowHandExtraction && title.includes('Main Deck');
+  const isMainDeckSearch = title.includes('Main Deck');
   const actionRole = targetRole ?? viewerRole;
 
   return (
@@ -53,6 +54,7 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({ isOpen, onClose, titl
             const isEvolveDeck = title.includes('Evolve');
             const isUsed = isEvolveDeck && !c.isFlipped;
             const canAddToHand = !isPreparingMainDeckSearch && c.owner === viewerRole && !c.isEvolveCard;
+            const canRevealToHand = canAddToHand && isMainDeckSearch;
             const canAddToEx = !isPreparingMainDeckSearch && !c.isEvolveCard;
             const canPlayToField = !isEvolveDeck || allowHandExtraction || isPreparingMainDeckSearch;
             const playToFieldLabel = isPreparingMainDeckSearch ? 'Set Face-Down to Field' : 'Play to Field';
@@ -111,6 +113,19 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({ isOpen, onClose, titl
                         }}
                       >
                         Add to Hand
+                      </button>
+                    )}
+                    {canRevealToHand && actionRole && (
+                      <button 
+                        onClick={() => onExtractCard(c.id, `hand-${actionRole}`, true)}
+                        disabled={!allowHandExtraction}
+                        style={{
+                          width: '100%', background: allowHandExtraction ? '#14b8a6' : '#374151', color: allowHandExtraction ? 'white' : '#949db0', border: 'none',
+                          padding: '3px', borderRadius: '4px', fontSize: '10px', fontWeight: 'bold',
+                          cursor: allowHandExtraction ? 'pointer' : 'not-allowed'
+                        }}
+                      >
+                        Reveal & Add to Hand
                       </button>
                     )}
                     {canAddToEx && actionRole && (

--- a/src/components/TopDeckModal.test.tsx
+++ b/src/components/TopDeckModal.test.tsx
@@ -98,4 +98,24 @@ describe('TopDeckModal', () => {
     expect(screen.getByText('Remaining: 1 cards')).toBeInTheDocument();
     expect(screen.getByAltText('Card c1')).toBeInTheDocument();
   });
+
+  it('supports assigning cards to revealed hand', () => {
+    const onConfirm = vi.fn();
+    render(
+      <TopDeckModal
+        isOpen={true}
+        cards={[createCard('c1')]}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getAllByText('公開して手札')[0]);
+    fireEvent.click(screen.getByAltText('Card c1'));
+    fireEvent.click(screen.getByText('CONFIRM'));
+
+    expect(onConfirm).toHaveBeenCalledWith([
+      { cardId: 'c1', action: 'revealedHand', order: undefined },
+    ]);
+  });
 });

--- a/src/components/TopDeckModal.tsx
+++ b/src/components/TopDeckModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import type { CardInstance } from './Card';
 
-export type TopDeckAction = 'hand' | 'field' | 'ex' | 'cemetery' | 'top' | 'bottom';
+export type TopDeckAction = 'hand' | 'revealedHand' | 'field' | 'ex' | 'cemetery' | 'top' | 'bottom';
 
 interface TopDeckModalProps {
   isOpen: boolean;
@@ -72,6 +72,7 @@ const TopDeckModal: React.FC<TopDeckModalProps> = ({ isOpen, cards, onConfirm, o
   const actionButtons: { id: TopDeckAction; label: string; color: string }[] = [
     { id: 'field', label: '場 (Field)', color: '#f59e0b' },
     { id: 'hand', label: '手札 (Hand)', color: '#10b981' },
+    { id: 'revealedHand', label: '公開して手札', color: '#14b8a6' },
     { id: 'ex', label: 'EXエリア', color: '#ec4899' },
     { id: 'bottom', label: '山下 (Bottom)', color: '#8b5cf6' },
     { id: 'top', label: '山上 (Top)', color: '#3b82f6' },

--- a/src/hooks/useGameBoardLogic.ts
+++ b/src/hooks/useGameBoardLogic.ts
@@ -4,13 +4,15 @@ import Peer, { type DataConnection } from 'peerjs';
 import { type DragEndEvent } from '@dnd-kit/core';
 import { type CardInstance } from '../components/Card';
 import { type PlayerRole, type SyncState, initialState } from '../types/game';
-import { type GameSyncEvent, type SharedUiEffect, type SyncMessage } from '../types/sync';
+import { type GameSyncEvent, type PublicCardView, type SharedUiEffect, type SyncMessage } from '../types/sync';
 import { uuid } from '../utils/helpers';
 import * as CardLogic from '../utils/cardLogic';
 import { canImportDeck } from '../utils/gameRules';
 import { applyGameSyncEvent } from '../utils/gameSyncReducer';
-import { flipSharedCoin, formatSharedUiMessage, rollSharedDie } from '../utils/sharedRandom';
+import { flipSharedCoin, formatSharedUiMessage, getSharedActorLabel, rollSharedDie } from '../utils/sharedRandom';
 import { createEventDeduper } from '../utils/eventDeduper';
+import { buildTopDeckRevealEffect } from '../utils/topDeckReveal';
+import { buildSingleCardRevealEffect } from '../utils/cardReveal';
 
 type DispatchableGameSyncEvent =
   | { type: 'FLIP_SHARED_COIN'; actor?: PlayerRole }
@@ -31,7 +33,7 @@ type DispatchableGameSyncEvent =
   | { type: 'SEND_TO_CEMETERY'; actor?: PlayerRole; cardId: string }
   | { type: 'RETURN_EVOLVE'; actor?: PlayerRole; cardId: string }
   | { type: 'PLAY_TO_FIELD'; actor?: PlayerRole; cardId: string }
-  | { type: 'EXTRACT_CARD'; actor?: PlayerRole; cardId: string; destination?: string }
+  | { type: 'EXTRACT_CARD'; actor?: PlayerRole; cardId: string; destination?: string; revealToOpponent?: boolean }
   | { type: 'SHUFFLE_DECK'; actor?: PlayerRole }
   | { type: 'MODIFY_PLAYER_STAT'; actor?: PlayerRole; playerKey: PlayerRole; stat: 'hp' | 'pp' | 'maxPp' | 'ep' | 'sep' | 'combo'; delta: number }
   | { type: 'DRAW_INITIAL_HAND'; actor?: PlayerRole }
@@ -58,6 +60,7 @@ export const useGameBoardLogic = () => {
   const [showResetConfirm, setShowResetConfirm] = useState(false);
   const [coinMessage, setCoinMessage] = useState<string | null>(null);
   const [turnMessage, setTurnMessage] = useState<string | null>(null);
+  const [revealedCardsOverlay, setRevealedCardsOverlay] = useState<{ title: string; cards: PublicCardView[] } | null>(null);
   const [lastGameState, setLastGameState] = useState<SyncState | null>(null);
   const [isRollingDice, setIsRollingDice] = useState(false);
   const [diceValue, setDiceValue] = useState<number | null>(null);
@@ -73,6 +76,7 @@ export const useGameBoardLogic = () => {
   const diceRollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const diceFinalizeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const diceMessageTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const revealedCardsTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const processedEventDeduperRef = useRef(createEventDeduper());
 
   const applyLocalState = useCallback((newState: SyncState) => {
@@ -130,6 +134,13 @@ export const useGameBoardLogic = () => {
     }
   }, []);
 
+  const clearRevealedCardsTimer = useCallback(() => {
+    if (revealedCardsTimeoutRef.current) {
+      clearTimeout(revealedCardsTimeoutRef.current);
+      revealedCardsTimeoutRef.current = null;
+    }
+  }, []);
+
   const playSharedUiEffect = useCallback((effect: SharedUiEffect) => {
     if (effect.type === 'COIN_FLIP_RESULT') {
       showTimedCoinMessage(formatSharedUiMessage(effect, role, isSoloMode), 3000);
@@ -138,6 +149,32 @@ export const useGameBoardLogic = () => {
 
     if (effect.type === 'STARTER_DECIDED') {
       showTimedCoinMessage(formatSharedUiMessage(effect, role, isSoloMode), 4000);
+      return;
+    }
+
+    if (effect.type === 'REVEAL_TOP_DECK_CARDS') {
+      clearRevealedCardsTimer();
+      setRevealedCardsOverlay({
+        title: `${getSharedActorLabel(effect.actor, role, isSoloMode)} revealed from Look Top`,
+        cards: effect.cards,
+      });
+      revealedCardsTimeoutRef.current = setTimeout(() => {
+        setRevealedCardsOverlay(null);
+        revealedCardsTimeoutRef.current = null;
+      }, 5000);
+      return;
+    }
+
+    if (effect.type === 'REVEAL_SEARCHED_CARD_TO_HAND') {
+      clearRevealedCardsTimer();
+      setRevealedCardsOverlay({
+        title: `${getSharedActorLabel(effect.actor, role, isSoloMode)} revealed from Search`,
+        cards: effect.cards,
+      });
+      revealedCardsTimeoutRef.current = setTimeout(() => {
+        setRevealedCardsOverlay(null);
+        revealedCardsTimeoutRef.current = null;
+      }, 5000);
       return;
     }
 
@@ -171,7 +208,7 @@ export const useGameBoardLogic = () => {
       }, 800);
       diceFinalizeTimeoutRef.current = null;
     }, 900);
-  }, [clearCoinMessageTimer, clearDiceTimers, isSoloMode, role, showTimedCoinMessage]);
+  }, [clearCoinMessageTimer, clearDiceTimers, clearRevealedCardsTimer, isSoloMode, role, showTimedCoinMessage]);
 
   const maybeApplySnapshot = useCallback((incomingState: SyncState, source: PlayerRole) => {
     const currentRevision = gameStateRef.current.revision;
@@ -219,6 +256,27 @@ export const useGameBoardLogic = () => {
     if (nextState === currentState) return;
     applyLocalState(nextState);
     sendSnapshot(nextState, role);
+
+    if (event.type === 'RESOLVE_TOP_DECK') {
+      const revealEffect = buildTopDeckRevealEffect(currentState.cards, event.actor, event.results);
+      if (revealEffect) {
+        playSharedUiEffect(revealEffect);
+        sendSharedUiEffect(revealEffect);
+      }
+    }
+
+    if (event.type === 'EXTRACT_CARD' && event.revealToOpponent && event.destination?.startsWith('hand-')) {
+      const revealEffect = buildSingleCardRevealEffect(
+        currentState.cards,
+        event.actor,
+        event.cardId,
+        'REVEAL_SEARCHED_CARD_TO_HAND'
+      );
+      if (revealEffect) {
+        playSharedUiEffect(revealEffect);
+        sendSharedUiEffect(revealEffect);
+      }
+    }
 
     if (event.type === 'SET_INITIAL_TURN_ORDER') {
       const effect: SharedUiEffect = {
@@ -333,8 +391,9 @@ export const useGameBoardLogic = () => {
     return () => {
       clearCoinMessageTimer();
       clearDiceTimers();
+      clearRevealedCardsTimer();
     };
-  }, [clearCoinMessageTimer, clearDiceTimers]);
+  }, [clearCoinMessageTimer, clearDiceTimers, clearRevealedCardsTimer]);
 
   useEffect(() => {
     if (gameState.gameStatus !== 'playing') return;
@@ -430,8 +489,13 @@ export const useGameBoardLogic = () => {
     setTopDeckCards([]);
   };
 
-  const handleExtractCard = (cardId: string, customDestination?: string, targetRole?: PlayerRole) => {
-    dispatchGameEvent({ type: 'EXTRACT_CARD', actor: targetRole, cardId, destination: customDestination });
+  const handleExtractCard = (
+    cardId: string,
+    customDestination?: string,
+    targetRole?: PlayerRole,
+    revealToOpponent = false
+  ) => {
+    dispatchGameEvent({ type: 'EXTRACT_CARD', actor: targetRole, cardId, destination: customDestination, revealToOpponent });
     setSearchZone(null);
   };
 
@@ -530,7 +594,7 @@ export const useGameBoardLogic = () => {
 
   return {
     room, mode, isSoloMode, isHost, role, status, gameState, searchZone, setSearchZone,
-    showResetConfirm, setShowResetConfirm, coinMessage, turnMessage,
+    showResetConfirm, setShowResetConfirm, coinMessage, turnMessage, revealedCardsOverlay,
     isRollingDice, diceValue, mulliganOrder, isMulliganModalOpen, setIsMulliganModalOpen,
     handleStatChange, setPhase, endTurn, handleUndoTurn, handleSetInitialTurnOrder,
     handlePureCoinFlip, handleRollDice, handleStartGame, handleToggleReady,

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -11,7 +11,7 @@ import type { PlayerRole } from '../types/game';
 const GameBoard: React.FC = () => {
   const {
     room, isSoloMode, isHost, role, status, gameState, searchZone, setSearchZone,
-    showResetConfirm, setShowResetConfirm, coinMessage, turnMessage,
+    showResetConfirm, setShowResetConfirm, coinMessage, turnMessage, revealedCardsOverlay,
     isRollingDice, diceValue, mulliganOrder, isMulliganModalOpen, setIsMulliganModalOpen,
     handleStatChange, setPhase, endTurn, handleUndoTurn, handleSetInitialTurnOrder,
     handlePureCoinFlip, handleRollDice, handleStartGame, handleToggleReady,
@@ -852,7 +852,7 @@ const GameBoard: React.FC = () => {
             : getCards(searchZone.id)
           ).slice()
         ) : []}
-        onExtractCard={(cardId, destination) => handleExtractCard(cardId, destination, searchTargetRole)}
+        onExtractCard={(cardId, destination, revealToOpponent) => handleExtractCard(cardId, destination, searchTargetRole, revealToOpponent)}
         onToggleFlip={(cardId) => handleFlipCard(cardId, searchTargetRole)}
         viewerRole={searchTargetRole}
         targetRole={searchTargetRole}
@@ -914,6 +914,41 @@ const GameBoard: React.FC = () => {
           letterSpacing: '8px'
         }}>
           {turnMessage}
+        </div>
+      )}
+
+      {revealedCardsOverlay && (
+        <div style={{
+          position: 'fixed',
+          top: '18%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          background: 'rgba(3, 7, 18, 0.96)',
+          border: '2px solid #14b8a6',
+          borderRadius: '16px',
+          padding: '1.25rem 1.5rem',
+          zIndex: 2100,
+          boxShadow: '0 0 30px rgba(20,184,166,0.25)',
+          minWidth: '320px',
+          maxWidth: '90vw'
+        }}>
+          <div style={{ color: '#99f6e4', fontWeight: 'bold', fontSize: '1rem', marginBottom: '0.9rem', textAlign: 'center' }}>
+            {revealedCardsOverlay.title}
+          </div>
+          <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>
+            {revealedCardsOverlay.cards.map((card) => (
+              <div key={`${card.cardId}-${card.name}`} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.35rem', maxWidth: '120px' }}>
+                <img
+                  src={card.image}
+                  alt={card.name}
+                  style={{ width: '90px', height: '126px', objectFit: 'cover', borderRadius: '8px', boxShadow: '0 4px 14px rgba(0,0,0,0.45)' }}
+                />
+                <div style={{ color: 'white', fontSize: '0.7rem', textAlign: 'center', lineHeight: 1.3 }}>
+                  {card.name}
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
       )}
 

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -2,6 +2,12 @@ import type { CardInstance } from '../components/Card';
 import type { PlayerRole, SyncState } from './game';
 import type { TopDeckResult } from '../utils/cardLogic';
 
+export interface PublicCardView {
+  cardId: string;
+  name: string;
+  image: string;
+}
+
 export type GameSyncEvent =
   | { id: string; type: 'FLIP_SHARED_COIN'; actor: PlayerRole }
   | { id: string; type: 'ROLL_SHARED_DIE'; actor: PlayerRole }
@@ -21,7 +27,7 @@ export type GameSyncEvent =
   | { id: string; type: 'SEND_TO_CEMETERY'; actor: PlayerRole; cardId: string }
   | { id: string; type: 'RETURN_EVOLVE'; actor: PlayerRole; cardId: string }
   | { id: string; type: 'PLAY_TO_FIELD'; actor: PlayerRole; cardId: string }
-  | { id: string; type: 'EXTRACT_CARD'; actor: PlayerRole; cardId: string; destination?: string }
+  | { id: string; type: 'EXTRACT_CARD'; actor: PlayerRole; cardId: string; destination?: string; revealToOpponent?: boolean }
   | { id: string; type: 'SHUFFLE_DECK'; actor: PlayerRole }
   | { id: string; type: 'MODIFY_PLAYER_STAT'; actor: PlayerRole; playerKey: PlayerRole; stat: 'hp' | 'pp' | 'maxPp' | 'ep' | 'sep' | 'combo'; delta: number }
   | { id: string; type: 'DRAW_INITIAL_HAND'; actor: PlayerRole }
@@ -35,7 +41,9 @@ export type GameSyncEvent =
 export type SharedUiEffect =
   | { type: 'COIN_FLIP_RESULT'; actor: PlayerRole; result: 'HEADS (表)' | 'TAILS (裏)' }
   | { type: 'DICE_ROLL_RESULT'; actor: PlayerRole; value: number }
-  | { type: 'STARTER_DECIDED'; actor: PlayerRole; starter: PlayerRole; manual: boolean };
+  | { type: 'STARTER_DECIDED'; actor: PlayerRole; starter: PlayerRole; manual: boolean }
+  | { type: 'REVEAL_TOP_DECK_CARDS'; actor: PlayerRole; cards: PublicCardView[] }
+  | { type: 'REVEAL_SEARCHED_CARD_TO_HAND'; actor: PlayerRole; cards: PublicCardView[] };
 
 export type SyncMessage =
   | { type: 'EVENT'; event: GameSyncEvent }

--- a/src/utils/cardLogic.test.ts
+++ b/src/utils/cardLogic.test.ts
@@ -492,6 +492,22 @@ describe('CardLogic utils', () => {
       expect(handCards[1].id).toBe('top1'); // Should be at the end (right)
     });
 
+    it('should move revealed-hand cards into the hidden hand zone', () => {
+      const existingHand = createMockCard('existing', 'hand-host');
+      const deckCard = createMockCard('top1', 'mainDeck-host');
+      const cards = [existingHand, deckCard];
+
+      const results: CardLogic.TopDeckResult[] = [
+        { cardId: 'top1', action: 'revealedHand' }
+      ];
+
+      const result = CardLogic.resolveTopDeckResults(cards, 'host', results);
+
+      const handCards = result.filter(c => c.zone === 'hand-host');
+      expect(handCards).toHaveLength(2);
+      expect(handCards[1].id).toBe('top1');
+    });
+
     it('should route evolve cards to evolveDeck even if action is top/bottom', () => {
       const evolveCard = { ...createMockCard('e1', 'field-host'), isEvolveCard: true };
       const results: CardLogic.TopDeckResult[] = [

--- a/src/utils/cardLogic.ts
+++ b/src/utils/cardLogic.ts
@@ -576,7 +576,7 @@ export const executeMulligan = (
  */
 export interface TopDeckResult {
   cardId: string;
-  action: 'hand' | 'field' | 'ex' | 'cemetery' | 'top' | 'bottom';
+  action: 'hand' | 'revealedHand' | 'field' | 'ex' | 'cemetery' | 'top' | 'bottom';
   order?: number;
 }
 
@@ -593,6 +593,7 @@ export const resolveTopDeckResults = (
     let zone = '';
     switch (res.action) {
       case 'hand': zone = `hand-${role}`; break;
+      case 'revealedHand': zone = `hand-${role}`; break;
       case 'field': zone = `field-${role}`; break;
       case 'ex': zone = `ex-${role}`; break;
       case 'cemetery': zone = `cemetery-${role}`; break;

--- a/src/utils/cardReveal.test.ts
+++ b/src/utils/cardReveal.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import type { CardInstance } from '../components/Card';
+import { buildSingleCardRevealEffect } from './cardReveal';
+
+const createCard = (id: string): CardInstance => ({
+  id,
+  cardId: id,
+  name: `Card ${id}`,
+  image: `/${id}.png`,
+  zone: 'mainDeck-host',
+  owner: 'host',
+  isTapped: false,
+  isFlipped: true,
+  counters: { atk: 0, hp: 0 },
+});
+
+describe('cardReveal', () => {
+  it('returns null when the card cannot be found', () => {
+    expect(buildSingleCardRevealEffect([], 'host', 'missing', 'REVEAL_SEARCHED_CARD_TO_HAND')).toBeNull();
+  });
+
+  it('builds a reveal effect for a searched card', () => {
+    expect(buildSingleCardRevealEffect(
+      [createCard('c1')],
+      'host',
+      'c1',
+      'REVEAL_SEARCHED_CARD_TO_HAND'
+    )).toEqual({
+      type: 'REVEAL_SEARCHED_CARD_TO_HAND',
+      actor: 'host',
+      cards: [{ cardId: 'c1', name: 'Card c1', image: '/c1.png' }],
+    });
+  });
+});

--- a/src/utils/cardReveal.ts
+++ b/src/utils/cardReveal.ts
@@ -1,0 +1,25 @@
+import type { CardInstance } from '../components/Card';
+import type { PlayerRole } from '../types/game';
+import type { PublicCardView, SharedUiEffect } from '../types/sync';
+
+const toPublicCardView = (card: CardInstance): PublicCardView => ({
+  cardId: card.cardId,
+  name: card.name,
+  image: card.image,
+});
+
+export const buildSingleCardRevealEffect = (
+  cards: CardInstance[],
+  actor: PlayerRole,
+  cardId: string,
+  type: 'REVEAL_TOP_DECK_CARDS' | 'REVEAL_SEARCHED_CARD_TO_HAND'
+): SharedUiEffect | null => {
+  const card = cards.find((currentCard) => currentCard.id === cardId);
+  if (!card) return null;
+
+  return {
+    type,
+    actor,
+    cards: [toPublicCardView(card)],
+  };
+};

--- a/src/utils/sharedRandom.ts
+++ b/src/utils/sharedRandom.ts
@@ -40,6 +40,16 @@ export const formatSharedUiMessage = (
     return `${actorLabel} rolled: ${effect.value}`;
   }
 
+  if (effect.type === 'REVEAL_TOP_DECK_CARDS') {
+    const actorLabel = getSharedActorLabel(effect.actor, viewerRole, isSoloMode);
+    return `${actorLabel} revealed from Look Top`;
+  }
+
+  if (effect.type === 'REVEAL_SEARCHED_CARD_TO_HAND') {
+    const actorLabel = getSharedActorLabel(effect.actor, viewerRole, isSoloMode);
+    return `${actorLabel} revealed from Search`;
+  }
+
   const starterLabel = getSharedActorLabel(effect.starter, viewerRole, isSoloMode);
   const baseMessage = `${starterLabel} will go first!`;
   return effect.manual ? `Manually set: ${baseMessage}` : baseMessage;

--- a/src/utils/topDeckReveal.test.ts
+++ b/src/utils/topDeckReveal.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { CardInstance } from '../components/Card';
+import { buildTopDeckRevealEffect } from './topDeckReveal';
+import type { TopDeckResult } from './cardLogic';
+
+const createCard = (id: string): CardInstance => ({
+  id,
+  cardId: id,
+  name: `Card ${id}`,
+  image: `/${id}.png`,
+  zone: 'mainDeck-host',
+  owner: 'host',
+  isTapped: false,
+  isFlipped: true,
+  counters: { atk: 0, hp: 0 },
+});
+
+describe('topDeckReveal', () => {
+  it('returns null when no top-deck card is marked as revealed hand', () => {
+    const results: TopDeckResult[] = [{ cardId: 'c1', action: 'hand' }];
+    expect(buildTopDeckRevealEffect([createCard('c1')], 'host', results)).toBeNull();
+  });
+
+  it('builds a shared UI effect for cards revealed into hand', () => {
+    const cards = [createCard('c1'), createCard('c2')];
+    const results: TopDeckResult[] = [
+      { cardId: 'c1', action: 'revealedHand' },
+      { cardId: 'c2', action: 'hand' },
+    ];
+
+    expect(buildTopDeckRevealEffect(cards, 'host', results)).toEqual({
+      type: 'REVEAL_TOP_DECK_CARDS',
+      actor: 'host',
+      cards: [{ cardId: 'c1', name: 'Card c1', image: '/c1.png' }],
+    });
+  });
+});

--- a/src/utils/topDeckReveal.ts
+++ b/src/utils/topDeckReveal.ts
@@ -1,0 +1,30 @@
+import type { CardInstance } from '../components/Card';
+import type { PlayerRole } from '../types/game';
+import type { SharedUiEffect } from '../types/sync';
+import type { TopDeckResult } from './cardLogic';
+
+export const buildTopDeckRevealEffect = (
+  cards: CardInstance[],
+  actor: PlayerRole,
+  results: TopDeckResult[]
+): SharedUiEffect | null => {
+  const revealedCards = results
+    .filter((result) => result.action === 'revealedHand')
+    .map((result) => cards.find((card) => card.id === result.cardId))
+    .filter((card): card is CardInstance => Boolean(card))
+    .map((card) => ({
+      cardId: card.cardId,
+      name: card.name,
+      image: card.image,
+    }));
+
+  if (revealedCards.length === 0) {
+    return null;
+  }
+
+  return {
+    type: 'REVEAL_TOP_DECK_CARDS',
+    actor,
+    cards: revealedCards,
+  };
+};


### PR DESCRIPTION
n 枚ルック、山札サーチに、相手に公開してから手札に追加の選択肢を追加。
公開したカードは一時的に表示される