### PR TITLE
自動進化を ドライブポイント / にんじんに対応

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -18,6 +18,7 @@ export interface CardInstance {
   counters: { atk: number; hp: number };
   genericCounter?: number;
   attachedTo?: string; // ID of the base card this evolve card is stacked on
+  linkedTo?: string; // ID of the parent card this special linked card visually sits under
   isEvolveCard?: boolean; // Rule flag to prevent Evolve cards mixing into Main deck
   isLeaderCard?: boolean;
   isTokenCard?: boolean;

--- a/src/components/Zone.test.tsx
+++ b/src/components/Zone.test.tsx
@@ -161,4 +161,43 @@ describe('Zone', () => {
     expect(cards[0]).toHaveAttribute('data-base-stats', '2/3');
     expect(cards[1]).toHaveAttribute('data-display-counters', '1/-1');
   });
+
+  it('does not count linked cards as top-level field cards', () => {
+    render(
+      <Zone
+        id="field-host"
+        label="Field"
+        cards={[
+          createCard('parent'),
+          createCard('linked-special', { linkedTo: 'parent', isEvolveCard: true }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Field')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+
+    const renderedCards = screen.getAllByTestId('mock-card');
+    expect(renderedCards.map(card => card.getAttribute('data-card-id'))).toEqual(['parent', 'linked-special']);
+  });
+
+  it('renders linked cards below existing attachments on the same parent', () => {
+    render(
+      <Zone
+        id="field-host"
+        label="Field"
+        cards={[
+          createCard('parent'),
+          createCard('evolve', { attachedTo: 'parent', isEvolveCard: true }),
+          createCard('linked-special', { linkedTo: 'parent', isEvolveCard: true }),
+        ]}
+      />
+    );
+
+    const linkedCard = screen.getAllByTestId('mock-card').find(card => card.getAttribute('data-card-id') === 'linked-special');
+    expect(linkedCard?.parentElement).toHaveStyle({
+      top: '40px',
+      left: '30px',
+    });
+  });
 });

--- a/src/components/Zone.tsx
+++ b/src/components/Zone.tsx
@@ -34,6 +34,11 @@ interface Props {
 
 const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLookup, onInspectCard, onAttack, onTap, onModifyCounter, onModifyGenericCounter, onSendToBottom, onBanish, onReturnEvolve, onCemetery, onPlayToField, hideCards, layout = 'horizontal', isProtected, lockCards, disableQuickActionsForCard, getHighlightTone, viewerRole, containerStyle, isDebug }) => {
   const { isOver, setNodeRef } = useDroppable({ id });
+  const attachmentTopOffset = 20;
+  const attachmentLeftOffset = 15;
+  const linkedCardTopOffset = 20;
+  const linkedCardLeftOffset = 15;
+  const linkedCardPaddingBottom = 24;
 
   const isStack = layout === 'stack';
   const isFieldZone = id.startsWith('field-');
@@ -44,7 +49,43 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
   const validAttachedIds = new Set(
     cards.filter(c => c.attachedTo && cards.some(parent => parent.id === c.attachedTo)).map(c => c.id)
   );
-  const topLevelCards = cards.filter(c => !validAttachedIds.has(c.id));
+  const validLinkedIds = new Set(
+    cards.filter(c => c.linkedTo && cards.some(parent => parent.id === c.linkedTo)).map(c => c.id)
+  );
+  const topLevelCards = cards.filter(c => !validAttachedIds.has(c.id) && !validLinkedIds.has(c.id));
+
+  const renderLinkedCards = React.useCallback((linkedCards: CardInstance[], attachmentCount: number) => {
+    if (linkedCards.length === 0) return null;
+
+    const baseTopOffset = linkedCardTopOffset + (attachmentCount * attachmentTopOffset);
+    const baseLeftOffset = linkedCardLeftOffset + (attachmentCount * attachmentLeftOffset);
+
+    return linkedCards.map((linkedCard, index) => (
+      <div
+        key={linkedCard.id}
+        style={{
+          position: 'absolute',
+          top: baseTopOffset + (index * linkedCardTopOffset),
+          left: baseLeftOffset + (index * linkedCardLeftOffset),
+          zIndex: 0,
+        }}
+      >
+        <Card
+          card={linkedCard}
+          baseStats={cardStatLookup?.[linkedCard.cardId]}
+          detail={cardDetailLookup?.[linkedCard.cardId]}
+          highlightTone={getHighlightTone?.(linkedCard)}
+          onInspect={onInspectCard}
+          onReturnEvolve={onReturnEvolve}
+          isHidden={hideCards}
+          isLocked={lockCards || (isProtected && viewerRole !== 'all' && linkedCard.owner !== viewerRole)}
+          quickActionsDisabled={disableQuickActionsForCard?.(linkedCard)}
+          disableCombatAndCounterControls={true}
+          debugIndex={isDebug ? index : undefined}
+        />
+      </div>
+    ));
+  }, [attachmentLeftOffset, attachmentTopOffset, cardDetailLookup, cardStatLookup, disableQuickActionsForCard, getHighlightTone, hideCards, isDebug, isProtected, linkedCardLeftOffset, linkedCardTopOffset, lockCards, onInspectCard, onReturnEvolve, viewerRole]);
 
   return (
     <div
@@ -140,8 +181,20 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                 const displayIndex = cards.length - index;
                 const stackOffset = Math.min(index, 5) * 2;
                 const attachments = cards.filter(c => c.attachedTo === card.id);
+                const linkedCards = cards.filter(c => c.linkedTo === card.id);
                 return (
-                  <div key={card.id} style={{ position: 'absolute', top: stackOffset, left: stackOffset, zIndex: displayIndex }}>
+                  <div
+                    key={card.id}
+                    style={{
+                      position: 'absolute',
+                      top: stackOffset,
+                      left: stackOffset,
+                      zIndex: displayIndex,
+                      paddingBottom: linkedCards.length > 0
+                        ? linkedCardPaddingBottom + (attachments.length * attachmentTopOffset) + ((linkedCards.length - 1) * linkedCardTopOffset)
+                        : undefined,
+                    }}
+                  >
                     <Card
                       card={card}
                       baseStats={cardStatLookup?.[card.cardId]}
@@ -164,8 +217,9 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                       disableCombatAndCounterControls={hasCardOnTop(card.id)}
                       debugIndex={isDebug ? index : undefined}
                     />
+                    {renderLinkedCards(linkedCards, attachments.length)}
                     {attachments.map((attachedCard, i) => (
-                      <div key={attachedCard.id} style={{ position: 'absolute', top: (i + 1) * 20, left: (i + 1) * 15, zIndex: index + 10 + i }}>
+                      <div key={attachedCard.id} style={{ position: 'absolute', top: (i + 1) * attachmentTopOffset, left: (i + 1) * attachmentLeftOffset, zIndex: index + 10 + i }}>
                         <Card
                           card={attachedCard}
                           baseStats={cardStatLookup?.[attachedCard.cardId]}
@@ -202,8 +256,17 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
 
         return topLevelCards.map((card) => {
           const attachments = cards.filter(c => c.attachedTo === card.id);
+          const linkedCards = cards.filter(c => c.linkedTo === card.id);
           return (
-            <div key={card.id} style={{ position: 'relative' }}>
+            <div
+              key={card.id}
+              style={{
+                position: 'relative',
+                paddingBottom: linkedCards.length > 0
+                  ? linkedCardPaddingBottom + (attachments.length * attachmentTopOffset) + ((linkedCards.length - 1) * linkedCardTopOffset)
+                  : undefined,
+              }}
+            >
               <Card
                 card={card}
                 baseStats={cardStatLookup?.[card.cardId]}
@@ -226,8 +289,9 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                 disableCombatAndCounterControls={hasCardOnTop(card.id)}
                 debugIndex={isDebug ? topLevelCards.indexOf(card) : undefined}
               />
+              {renderLinkedCards(linkedCards, attachments.length)}
               {attachments.map((attachedCard, i) => (
-                <div key={attachedCard.id} style={{ position: 'absolute', top: (i + 1) * 20, left: (i + 1) * 15, zIndex: 10 + i }}>
+                <div key={attachedCard.id} style={{ position: 'absolute', top: (i + 1) * attachmentTopOffset, left: (i + 1) * attachmentLeftOffset, zIndex: 10 + i }}>
                   <Card
                     card={attachedCard}
                     baseStats={cardStatLookup?.[attachedCard.cardId]}

--- a/src/data/fieldLinkRules.test.ts
+++ b/src/data/fieldLinkRules.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getFieldLinkGroupId } from './fieldLinkRules';
+
+describe('fieldLinkRules', () => {
+  it('matches drive point cards to the vanguard link group', () => {
+    expect(getFieldLinkGroupId({
+      name: 'ドライブポイント',
+      title: 'カードファイト!! ヴァンガード',
+      card_kind_normalized: 'evolve_spell',
+      deck_section: 'evolve',
+    })).toBe('vanguard-drive-point');
+  });
+
+  it('matches carrot-like cards to the umamusume link group', () => {
+    expect(getFieldLinkGroupId({
+      name: '開催大成功！',
+      title: 'ウマ娘 プリティーダービー',
+      card_kind_normalized: 'evolve_spell',
+      deck_section: 'evolve',
+    })).toBe('umamusume-carrot-like');
+  });
+});

--- a/src/data/fieldLinkRules.ts
+++ b/src/data/fieldLinkRules.ts
@@ -1,0 +1,91 @@
+import type { DeckBuilderCardData } from '../models/deckBuilderCard';
+
+export interface FieldLinkRuleMember {
+  name: string;
+  title: string;
+  cardKindNormalized: string;
+  deckSection: string;
+}
+
+export interface FieldLinkRuleGroup {
+  id: string;
+  members: FieldLinkRuleMember[];
+}
+
+export const FIELD_LINK_RULE_GROUPS: FieldLinkRuleGroup[] = [
+  {
+    id: 'vanguard-drive-point',
+    members: [
+      {
+        name: 'ドライブポイント',
+        title: 'カードファイト!! ヴァンガード',
+        cardKindNormalized: 'evolve_spell',
+        deckSection: 'evolve',
+      },
+    ],
+  },
+  {
+    id: 'umamusume-carrot-like',
+    members: [
+      {
+        name: 'にんじん',
+        title: 'ウマ娘 プリティーダービー',
+        cardKindNormalized: 'evolve_spell',
+        deckSection: 'evolve',
+      },
+      {
+        name: '開催大成功！',
+        title: 'ウマ娘 プリティーダービー',
+        cardKindNormalized: 'evolve_spell',
+        deckSection: 'evolve',
+      },
+      {
+        name: '聖なる夜に重なるキセキ',
+        title: 'ウマ娘 プリティーダービー',
+        cardKindNormalized: 'evolve_spell',
+        deckSection: 'evolve',
+      },
+      {
+        name: '1日の終わりに',
+        title: 'ウマ娘 プリティーダービー',
+        cardKindNormalized: 'evolve_spell',
+        deckSection: 'evolve',
+      },
+      {
+        name: '開幕ッ！大農耕時代ッ！',
+        title: 'ウマ娘 プリティーダービー',
+        cardKindNormalized: 'evolve_spell',
+        deckSection: 'evolve',
+      },
+      {
+        name: '合宿ッ！農家体験ッ！',
+        title: 'ウマ娘 プリティーダービー',
+        cardKindNormalized: 'evolve_spell',
+        deckSection: 'evolve',
+      },
+    ],
+  },
+];
+
+export const cardMatchesFieldLinkMember = (
+  card: Pick<DeckBuilderCardData, 'name' | 'title' | 'card_kind_normalized' | 'deck_section'> | null | undefined,
+  member: FieldLinkRuleMember
+): boolean => (
+  Boolean(card)
+  && card?.name === member.name
+  && (card?.title ?? '') === member.title
+  && (card?.card_kind_normalized ?? '') === member.cardKindNormalized
+  && (card?.deck_section ?? '') === member.deckSection
+);
+
+export const getFieldLinkGroupId = (
+  card: Pick<DeckBuilderCardData, 'name' | 'title' | 'card_kind_normalized' | 'deck_section'> | null | undefined
+): string | null => {
+  if (!card) return null;
+
+  const matchingGroup = FIELD_LINK_RULE_GROUPS.find(group => (
+    group.members.some(member => cardMatchesFieldLinkMember(card, member))
+  ));
+
+  return matchingGroup?.id ?? null;
+};

--- a/src/hooks/useGameBoardLogic.test.tsx
+++ b/src/hooks/useGameBoardLogic.test.tsx
@@ -263,6 +263,11 @@ function HookHarness() {
       <div data-testid="evolve-search-tapped">{String(gameState.cards.find(card => card.id === 'evolve-search-card')?.isTapped ?? 'missing')}</div>
       <div data-testid="drag-evolve-attached-to">{gameState.cards.find(card => card.id === 'drag-evolve-card')?.attachedTo ?? 'none'}</div>
       <div data-testid="drag-evolve-tapped">{String(gameState.cards.find(card => card.id === 'drag-evolve-card')?.isTapped ?? 'missing')}</div>
+      <div data-testid="link-search-linked-to">{gameState.cards.find(card => card.id === 'link-search-card')?.linkedTo ?? 'none'}</div>
+      <div data-testid="link-search-zone">{gameState.cards.find(card => card.id === 'link-search-card')?.zone ?? 'none'}</div>
+      <div data-testid="drag-linked-linked-to">{gameState.cards.find(card => card.id === 'drag-linked-card')?.linkedTo ?? 'none'}</div>
+      <div data-testid="drag-linked-zone">{gameState.cards.find(card => card.id === 'drag-linked-card')?.zone ?? 'none'}</div>
+      <div data-testid="drag-linked-tapped">{String(gameState.cards.find(card => card.id === 'drag-linked-card')?.isTapped ?? 'missing')}</div>
       {savedSessionCandidate && (
         <>
           <button onClick={resumeSavedSession}>Resume Saved Session</button>
@@ -283,7 +288,10 @@ function HookHarness() {
       <button onClick={() => handleBanish('banish-card')}>Banish Field Card</button>
       <button onClick={() => handlePlayToField('hand-card', 'host')}>Play Hand Card to Field</button>
       <button onClick={() => handleExtractCard('evolve-search-card', 'field-host', 'host')}>Extract Evolve to Field</button>
+      <button onClick={() => handleExtractCard('link-search-card', 'field-host', 'host')}>Extract Linked to Field</button>
       <button onClick={() => handleDragEnd({ active: { id: 'drag-evolve-card' }, over: { id: 'field-host' } } as any)}>Drag Evolve to Field</button>
+      <button onClick={() => handleDragEnd({ active: { id: 'drag-linked-card' }, over: { id: 'link-base-card' } } as any)}>Drag Linked Card to Base</button>
+      <button onClick={() => handleDragEnd({ active: { id: 'drag-linked-card' }, over: { id: 'field-host' } } as any)}>Drag Linked Card to Field</button>
       <button onClick={() => handleDragEnd({ active: { id: 'attach-base-1' }, over: { id: 'attach-base-2' } } as any)}>Attach Base 1 Under Base 2</button>
       <button onClick={() => confirmEvolveAutoAttachSelection('attach-base-1')}>Confirm Auto Attach Base 1</button>
       <button onClick={() => confirmEvolveAutoAttachSelection('attach-base-2')}>Confirm Auto Attach Base 2</button>
@@ -2099,6 +2107,244 @@ describe('useGameBoardLogic action handlers', () => {
     expect(screen.getByTestId('host-field-count')).toHaveTextContent('2');
     expect(screen.getByTestId('drag-evolve-attached-to')).toHaveTextContent('attach-base-1');
     expect(screen.getByTestId('drag-evolve-tapped')).toHaveTextContent('true');
+  });
+
+  it('keeps the existing placement behavior for special link cards when no target is on the field', async () => {
+    installMockCatalogFetch([
+      createCatalogCard({ id: 'BASE-001', name: 'Base Vanguard Unit' }),
+      createCatalogCard({
+        id: 'DRIVE-001',
+        name: 'ドライブポイント',
+        title: 'カードファイト!! ヴァンガード',
+        deck_section: 'evolve',
+        card_kind_normalized: 'evolve_spell',
+      }),
+    ]);
+
+    renderResumedHostHarness({
+      cards: [{
+        id: 'link-search-card',
+        cardId: 'DRIVE-001',
+        name: 'ドライブポイント',
+        image: '/drive-point.png',
+        zone: 'evolveDeck-host',
+        owner: 'host',
+        isTapped: false,
+        isFlipped: false,
+        counters: { atk: 0, hp: 0 },
+        isEvolveCard: true,
+      }],
+      gameStatus: 'playing',
+      turnCount: 2,
+      phase: 'Main',
+      revision: 7,
+    });
+
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole('button', { name: 'Extract Linked to Field' }));
+
+    expect(screen.getByTestId('host-evolve-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('host-field-count')).toHaveTextContent('1');
+    expect(screen.getByTestId('link-search-linked-to')).toHaveTextContent('none');
+    expect(screen.getByTestId('link-search-zone')).toHaveTextContent('field-host');
+  });
+
+  it('auto-links a special card from search when a single related field card is present', async () => {
+    installMockCatalogFetch([
+      createCatalogCard({
+        id: 'BASE-001',
+        name: 'Base Vanguard Unit',
+        related_cards: [{ id: 'DRIVE-001', name: 'ドライブポイント' }],
+      }),
+      createCatalogCard({
+        id: 'DRIVE-001',
+        name: 'ドライブポイント',
+        title: 'カードファイト!! ヴァンガード',
+        deck_section: 'evolve',
+        card_kind_normalized: 'evolve_spell',
+      }),
+    ]);
+
+    renderResumedHostHarness({
+      cards: [
+        {
+          id: 'link-search-card',
+          cardId: 'DRIVE-001',
+          name: 'ドライブポイント',
+          image: '/drive-point.png',
+          zone: 'evolveDeck-host',
+          owner: 'host',
+          isTapped: false,
+          isFlipped: false,
+          counters: { atk: 0, hp: 0 },
+          isEvolveCard: true,
+        },
+        {
+          id: 'link-base-1',
+          cardId: 'BASE-001',
+          name: 'Base Vanguard Unit',
+          image: '/base-vanguard-unit.png',
+          zone: 'field-host',
+          owner: 'host',
+          isTapped: true,
+          isFlipped: false,
+          counters: { atk: 0, hp: 0 },
+        },
+      ],
+      gameStatus: 'playing',
+      turnCount: 2,
+      phase: 'Main',
+      revision: 7,
+    });
+
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole('button', { name: 'Extract Linked to Field' }));
+
+    expect(screen.getByTestId('host-evolve-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('host-field-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('link-search-linked-to')).toHaveTextContent('link-base-1');
+    expect(screen.getByTestId('link-search-zone')).toHaveTextContent('field-host');
+  });
+
+  it('offers selection for special link cards and links the chosen target', async () => {
+    installMockCatalogFetch([
+      createCatalogCard({
+        id: 'BASE-001',
+        name: 'Base Vanguard Unit',
+        related_cards: [{ id: 'DRIVE-001', name: 'ドライブポイント' }],
+      }),
+      createCatalogCard({
+        id: 'BASE-002',
+        name: 'Base Vanguard Unit 2',
+        related_cards: [{ id: 'DRIVE-001', name: 'ドライブポイント' }],
+      }),
+      createCatalogCard({
+        id: 'DRIVE-001',
+        name: 'ドライブポイント',
+        title: 'カードファイト!! ヴァンガード',
+        deck_section: 'evolve',
+        card_kind_normalized: 'evolve_spell',
+      }),
+    ]);
+
+    renderResumedHostHarness({
+      cards: [
+        {
+          id: 'drag-linked-card',
+          cardId: 'DRIVE-001',
+          name: 'ドライブポイント',
+          image: '/drive-point.png',
+          zone: 'evolveDeck-host',
+          owner: 'host',
+          isTapped: false,
+          isFlipped: false,
+          counters: { atk: 0, hp: 0 },
+          isEvolveCard: true,
+        },
+        {
+          id: 'attach-base-1',
+          cardId: 'BASE-001',
+          name: 'Base Vanguard Unit',
+          image: '/base-vanguard-unit.png',
+          zone: 'field-host',
+          owner: 'host',
+          isTapped: false,
+          isFlipped: false,
+          counters: { atk: 0, hp: 0 },
+        },
+        {
+          id: 'attach-base-2',
+          cardId: 'BASE-002',
+          name: 'Base Vanguard Unit 2',
+          image: '/base-vanguard-unit-2.png',
+          zone: 'field-host',
+          owner: 'host',
+          isTapped: false,
+          isFlipped: false,
+          counters: { atk: 0, hp: 0 },
+        },
+      ],
+      gameStatus: 'playing',
+      turnCount: 2,
+      phase: 'Main',
+      revision: 7,
+    });
+
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole('button', { name: 'Drag Linked Card to Field' }));
+
+    expect(screen.getByTestId('auto-attach-selection-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('auto-attach-selection-source')).toHaveTextContent('drag-linked-card');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Auto Attach Base 2' }));
+
+    expect(screen.getByTestId('auto-attach-selection-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('drag-linked-linked-to')).toHaveTextContent('attach-base-2');
+    expect(screen.getByTestId('drag-linked-zone')).toHaveTextContent('field-host');
+  });
+
+  it('links a special card by manual drag and clears the link when moved back to the field', async () => {
+    installMockCatalogFetch([
+      createCatalogCard({
+        id: 'VG-DRIVE-001',
+        name: 'ドライブポイント',
+        title: 'カードファイト!! ヴァンガード',
+        deck_section: 'evolve',
+        card_kind_normalized: 'evolve_spell',
+      }),
+      createCatalogCard({
+        id: 'BASE-001',
+        name: 'Base Follower',
+      }),
+    ]);
+
+    renderResumedHostHarness({
+      cards: [
+        {
+          id: 'drag-linked-card',
+          cardId: 'VG-DRIVE-001',
+          name: 'ドライブポイント',
+          image: '/drive-point.png',
+          zone: 'evolveDeck-host',
+          owner: 'host',
+          isTapped: false,
+          isFlipped: false,
+          counters: { atk: 0, hp: 0 },
+          isEvolveCard: true,
+        },
+        {
+          id: 'link-base-card',
+          cardId: 'BASE-001',
+          name: 'Base Follower',
+          image: '/base-follower.png',
+          zone: 'field-host',
+          owner: 'host',
+          isTapped: true,
+          isFlipped: false,
+          counters: { atk: 0, hp: 0 },
+        },
+      ],
+      gameStatus: 'playing',
+      turnCount: 2,
+      phase: 'Main',
+      revision: 7,
+    });
+
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole('button', { name: 'Drag Linked Card to Base' }));
+
+    expect(screen.getByTestId('drag-linked-linked-to')).toHaveTextContent('link-base-card');
+    expect(screen.getByTestId('drag-linked-zone')).toHaveTextContent('field-host');
+    expect(screen.getByTestId('drag-linked-tapped')).toHaveTextContent('true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Drag Linked Card to Field' }));
+
+    expect(screen.getByTestId('drag-linked-linked-to')).toHaveTextContent('none');
+    expect(screen.getByTestId('drag-linked-zone')).toHaveTextContent('field-host');
   });
 
   it('moves a field card to banish', () => {

--- a/src/hooks/useGameBoardLogic.ts
+++ b/src/hooks/useGameBoardLogic.ts
@@ -22,6 +22,8 @@ import { buildAttackDeclaredEffect, formatAttackEffect } from '../utils/attackUi
 import { buildCardPlayedEffect, formatCardPlayedEffect } from '../utils/cardPlayUi';
 import { normalizeBaseCardType } from '../utils/cardType';
 import { buildEvolveAutoAttachResolver, type EvolveAutoAttachResolver } from '../utils/evolveAutoAttach';
+import { buildFieldLinkAutoAttachResolver, type FieldLinkAutoAttachResolver } from '../utils/fieldLinkAutoAttach';
+import { getFieldLinkGroupId } from '../data/fieldLinkRules';
 
 type DispatchableGameSyncEvent =
   | { type: 'FLIP_SHARED_COIN'; actor?: PlayerRole }
@@ -32,6 +34,7 @@ type DispatchableGameSyncEvent =
   | { type: 'START_GAME'; actor?: PlayerRole }
   | { type: 'RESET_GAME'; actor?: PlayerRole }
   | { type: 'MOVE_CARD'; actor?: PlayerRole; cardId: string; overId: string }
+  | { type: 'LINK_CARD_TO_FIELD'; actor?: PlayerRole; cardId: string; parentCardId: string }
   | { type: 'MODIFY_COUNTER'; actor?: PlayerRole; cardId: string; stat: 'atk' | 'hp'; delta: number }
   | { type: 'MODIFY_GENERIC_COUNTER'; actor?: PlayerRole; cardId: string; delta: number }
   | { type: 'DRAW_CARD'; actor?: PlayerRole }
@@ -235,6 +238,8 @@ export const useGameBoardLogic = () => {
   const gameStateRef = useRef<SyncState>(initialState);
   const cardDetailLookupRef = useRef<CardDetailLookup>({});
   const evolveAutoAttachResolverRef = useRef<EvolveAutoAttachResolver | null>(null);
+  const fieldLinkAutoAttachResolverRef = useRef<FieldLinkAutoAttachResolver | null>(null);
+  const fieldLinkCardIdsRef = useRef<Set<string>>(new Set());
   const savedSessionCandidateRef = useRef<SavedHostSession | null>(null);
   const awaitingInitialSnapshotRef = useRef(false);
   const activeConnectionTokenRef = useRef<string | null>(null);
@@ -423,11 +428,20 @@ export const useGameBoardLogic = () => {
   }, []);
 
   const resolveEvolveAutoAttachSelection = useCallback((cardId: string, boardCards = gameStateRef.current.cards) => {
-    const resolver = evolveAutoAttachResolverRef.current;
-    if (!resolver) return null;
-
     const sourceCard = boardCards.find(card => card.id === cardId);
-    if (!sourceCard || !resolver.isEligibleSource(sourceCard)) return null;
+    if (!sourceCard) return null;
+
+    const fieldLinkResolver = fieldLinkAutoAttachResolverRef.current;
+    if (fieldLinkResolver?.isEligibleSource(sourceCard)) {
+      return {
+        sourceCard,
+        candidateCards: fieldLinkResolver.resolveCandidates(sourceCard, boardCards),
+        placement: 'linked' as const,
+      };
+    }
+
+    const resolver = evolveAutoAttachResolverRef.current;
+    if (!resolver || !resolver.isEligibleSource(sourceCard)) return null;
 
     const candidateCards = resolver.resolveCandidates(sourceCard, boardCards)
       .map(candidate => candidate.card);
@@ -435,6 +449,7 @@ export const useGameBoardLogic = () => {
     return {
       sourceCard,
       candidateCards,
+      placement: 'stack' as const,
     };
   }, []);
 
@@ -1061,8 +1076,19 @@ export const useGameBoardLogic = () => {
   const executeEvolveAutoAttach = useCallback((
     sourceCardId: string,
     actor: PlayerRole,
-    attachToCardId: string
+    attachToCardId: string,
+    placement: 'stack' | 'linked'
   ) => {
+    if (placement === 'linked') {
+      dispatchGameEvent({
+        type: 'LINK_CARD_TO_FIELD',
+        actor,
+        cardId: sourceCardId,
+        parentCardId: attachToCardId,
+      });
+      return;
+    }
+
     dispatchGameEvent({
       type: 'EXTRACT_CARD',
       actor,
@@ -1093,7 +1119,8 @@ export const useGameBoardLogic = () => {
     executeEvolveAutoAttach(
       pendingEvolveAutoAttachSelection.sourceCardId,
       pendingEvolveAutoAttachSelection.actor,
-      attachToCardId
+      attachToCardId,
+      resolvedSelection.placement
     );
   }, [executeEvolveAutoAttach, pendingEvolveAutoAttachSelection, resolveEvolveAutoAttachSelection]);
 
@@ -1463,11 +1490,19 @@ export const useGameBoardLogic = () => {
         setCardDetailLookup(detailLookup);
         cardDetailLookupRef.current = detailLookup;
         evolveAutoAttachResolverRef.current = buildEvolveAutoAttachResolver(data);
+        fieldLinkAutoAttachResolverRef.current = buildFieldLinkAutoAttachResolver(data);
+        fieldLinkCardIdsRef.current = new Set(
+          data
+            .filter((card: any) => Boolean(getFieldLinkGroupId(card)))
+            .map((card: any) => card.id)
+        );
       })
       .catch(err => console.error('Could not load card stats', err));
     return () => {
       isActive = false;
       evolveAutoAttachResolverRef.current = null;
+      fieldLinkAutoAttachResolverRef.current = null;
+      fieldLinkCardIdsRef.current = new Set();
     };
   }, []);
 
@@ -1494,6 +1529,7 @@ export const useGameBoardLogic = () => {
       actor: pendingEvolveAutoAttachSelection.actor,
       sourceCard,
       candidateCards,
+      placement: resolvedSelection.placement,
     };
   }, [gameState.cards, pendingEvolveAutoAttachSelection, resolveEvolveAutoAttachSelection]);
 
@@ -1656,14 +1692,12 @@ export const useGameBoardLogic = () => {
       if (sourceCard?.zone === `evolveDeck-${actor}`) {
         const resolvedSelection = resolveEvolveAutoAttachSelection(cardId);
         if (resolvedSelection?.candidateCards.length === 1) {
-          dispatchGameEvent({
-            type: 'EXTRACT_CARD',
-            actor,
+          executeEvolveAutoAttach(
             cardId,
-            destination: customDestination,
-            revealToOpponent,
-            attachToCardId: resolvedSelection.candidateCards[0].id,
-          });
+            actor,
+            resolvedSelection.candidateCards[0].id,
+            resolvedSelection.placement
+          );
           setSearchZone(null);
           return;
         }
@@ -1864,6 +1898,25 @@ export const useGameBoardLogic = () => {
     const overId = over.id as string;
 
     const sourceCard = gameStateRef.current.cards.find(card => card.id === cardId);
+    const overCard = gameStateRef.current.cards.find(card => card.id === overId);
+
+    if (
+      sourceCard &&
+      overCard &&
+      cardId !== overId &&
+      fieldLinkCardIdsRef.current.has(sourceCard.cardId) &&
+      overCard.zone === `field-${sourceCard.owner}` &&
+      overCard.owner === sourceCard.owner
+    ) {
+      dispatchGameEvent({
+        type: 'LINK_CARD_TO_FIELD',
+        actor: sourceCard.owner,
+        cardId,
+        parentCardId: overId,
+      });
+      return;
+    }
+
     if (
       sourceCard &&
       sourceCard.zone === `evolveDeck-${sourceCard.owner}` &&
@@ -1871,13 +1924,12 @@ export const useGameBoardLogic = () => {
     ) {
       const resolvedSelection = resolveEvolveAutoAttachSelection(cardId);
       if (resolvedSelection?.candidateCards.length === 1) {
-        dispatchGameEvent({
-          type: 'EXTRACT_CARD',
-          actor: sourceCard.owner,
+        executeEvolveAutoAttach(
           cardId,
-          destination: overId,
-          attachToCardId: resolvedSelection.candidateCards[0].id,
-        });
+          sourceCard.owner,
+          resolvedSelection.candidateCards[0].id,
+          resolvedSelection.placement
+        );
         return;
       }
 

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -597,10 +597,10 @@
         "confirm": "Generate"
       },
       "evolveAutoAttach": {
-        "title": "Choose Stack Target",
-        "description": "Choose which card to stack {{card}} onto.",
+        "title": "Choose Target Card",
+        "description": "Choose which card should receive {{card}}.",
         "playingCard": "Card Being Played",
-        "selectTarget": "Multiple matching cards are on the field. Select the card to stack onto."
+        "selectTarget": "Multiple matching cards are on the field. Select the target card."
       },
       "topN": {
         "title": "How many cards to look at?",

--- a/src/i18n/ja/translation.json
+++ b/src/i18n/ja/translation.json
@@ -550,10 +550,10 @@
         "confirm": "生成"
       },
       "evolveAutoAttach": {
-        "title": "重ね先を選択",
-        "description": "{{card}} を重ねる対象を選んでください。",
+        "title": "対象カードを選択",
+        "description": "{{card}} を配置する対象を選んでください。",
         "playingCard": "場に出すカード",
-        "selectTarget": "対象が複数見つかりました。重ねるカードを選択してください。"
+        "selectTarget": "対象が複数見つかりました。配置先のカードを選択してください。"
       },
       "topN": {
         "title": "上から何枚見ますか？",

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -25,6 +25,7 @@ export type GameSyncEvent =
   | { id: string; type: 'START_GAME'; actor: PlayerRole }
   | { id: string; type: 'RESET_GAME'; actor: PlayerRole }
   | { id: string; type: 'MOVE_CARD'; actor: PlayerRole; cardId: string; overId: string }
+  | { id: string; type: 'LINK_CARD_TO_FIELD'; actor: PlayerRole; cardId: string; parentCardId: string }
   | { id: string; type: 'MODIFY_COUNTER'; actor: PlayerRole; cardId: string; stat: 'atk' | 'hp'; delta: number }
   | { id: string; type: 'MODIFY_GENERIC_COUNTER'; actor: PlayerRole; cardId: string; delta: number }
   | { id: string; type: 'DRAW_CARD'; actor: PlayerRole }

--- a/src/utils/cardLogic.test.ts
+++ b/src/utils/cardLogic.test.ts
@@ -79,6 +79,20 @@ describe('CardLogic utils', () => {
       expect(result.every(c => c.zone === 'cemetery-host')).toBe(true);
       expect(result.every(c => c.attachedTo === undefined)).toBe(true);
     });
+
+    it('should carry linked cards with the parent card and clear their link outside the field', () => {
+      const parent = createMockCard('parent', 'field-host');
+      const linked = { ...createMockCard('linked', 'field-host'), linkedTo: 'parent', isEvolveCard: true };
+      const other = createMockCard('other', 'field-host');
+      const cards = [parent, linked, other];
+
+      const result = CardLogic.moveCardToEnd(cards, 'parent', { zone: 'cemetery-host' });
+
+      expect(result.map(c => c.id)).toEqual(['other', 'parent', 'linked']);
+      expect(result[1].zone).toBe('cemetery-host');
+      expect(result[2].zone).toBe('evolveDeck-host');
+      expect(result[2].linkedTo).toBeUndefined();
+    });
   });
 
   describe('moveCardToFront', () => {
@@ -123,6 +137,44 @@ describe('CardLogic utils', () => {
       });
 
       expect(result.every(c => c.attachedTo === undefined)).toBe(true);
+    });
+
+    it('should keep linked cards with the parent card when moving within the field', () => {
+      const parent = createMockCard('parent', 'field-host');
+      const linked = { ...createMockCard('linked', 'field-host'), linkedTo: 'parent', isEvolveCard: true };
+      const cards = [parent, linked];
+
+      const result = CardLogic.moveCardToFront(cards, 'parent', { zone: 'field-host' });
+      const movedLinked = result.find(c => c.id === 'linked');
+
+      expect(result.map(c => c.id)).toEqual(['parent', 'linked']);
+      expect(movedLinked?.zone).toBe('field-host');
+      expect(movedLinked?.linkedTo).toBe('parent');
+    });
+  });
+
+  describe('linkCardToField', () => {
+    it('moves a special card onto the field and links it to the target root card', () => {
+      const source = {
+        ...createMockCard('special', 'evolveDeck-host'),
+        cardId: 'BPV-001',
+        isEvolveCard: true,
+      };
+      const parent = {
+        ...createMockCard('parent', 'field-host'),
+        isTapped: true,
+      };
+
+      const result = CardLogic.linkCardToField([source, parent], 'special', 'parent');
+      const linked = result.find(card => card.id === 'special');
+
+      expect(linked).toMatchObject({
+        zone: 'field-host',
+        linkedTo: 'parent',
+        attachedTo: undefined,
+        isTapped: true,
+        isFlipped: false,
+      });
     });
   });
 
@@ -275,6 +327,20 @@ describe('CardLogic utils', () => {
 
       expect(CardLogic.resolveMoveDestination(leader, 'field-host')).toBe('leader-host');
       expect(CardLogic.resolveMoveDestination(leader, 'hand-host')).toBe('leader-host');
+    });
+  });
+
+  describe('tap sync with linked cards', () => {
+    it('toggles tap on linked cards together with the stack root', () => {
+      const parent = createMockCard('parent', 'field-host');
+      const evolve = { ...createMockCard('evolve', 'field-host'), attachedTo: 'parent', isEvolveCard: true };
+      const linked = { ...createMockCard('linked', 'field-host'), linkedTo: 'parent', isEvolveCard: true };
+
+      const result = CardLogic.toggleTapStack([parent, evolve, linked], 'parent');
+
+      expect(result.find(c => c.id === 'parent')?.isTapped).toBe(true);
+      expect(result.find(c => c.id === 'evolve')?.isTapped).toBe(true);
+      expect(result.find(c => c.id === 'linked')?.isTapped).toBe(true);
     });
   });
 
@@ -433,6 +499,22 @@ describe('CardLogic utils', () => {
       expect(result.find(c => c.id === 'base')?.zone).toBe('cemetery-host');
       expect(result.find(c => c.id === 'evo')?.zone).toBe('evolveDeck-host');
       expect(result.find(c => c.id === 'evo')?.attachedTo).toBeUndefined();
+    });
+
+    it('clears linkedTo when a linked card is dragged back onto the field zone', () => {
+      const linked = {
+        ...createMockCard('linked', 'field-host'),
+        linkedTo: 'parent',
+        isEvolveCard: true,
+      };
+      const parent = createMockCard('parent', 'field-host');
+
+      const result = CardLogic.applyDrop([linked, parent], 'linked', 'field-host');
+
+      expect(result.find(c => c.id === 'linked')).toMatchObject({
+        zone: 'field-host',
+        linkedTo: undefined,
+      });
     });
 
     it('should prevent moving leader cards or dropping onto leader zones', () => {

--- a/src/utils/cardLogic.ts
+++ b/src/utils/cardLogic.ts
@@ -101,6 +101,19 @@ const collectDescendantIds = (
   return descendantIds;
 };
 
+const collectLinkedChildIds = (
+  cards: CardInstance[],
+  parentIds: Iterable<string>
+): Set<string> => {
+  const parentIdSet = parentIds instanceof Set ? parentIds : new Set(parentIds);
+
+  return new Set(
+    cards
+      .filter(card => card.linkedTo && parentIdSet.has(card.linkedTo))
+      .map(card => card.id)
+  );
+};
+
 const getZonePrefix = (zone: string): string => zone.split('-')[0];
 const isLeaderZone = (zone: string): boolean => zone.startsWith('leader-');
 const isLeaderCard = (card: CardInstance | undefined): boolean =>
@@ -112,9 +125,11 @@ const findRootCard = (cards: CardInstance[], card: CardInstance): CardInstance =
   let rootCard = card;
   const visited = new Set<string>();
 
-  while (rootCard.attachedTo && !visited.has(rootCard.attachedTo)) {
+  while (true) {
+    const parentId = rootCard.attachedTo ?? rootCard.linkedTo;
+    if (!parentId || visited.has(parentId)) break;
     visited.add(rootCard.id);
-    const parentCard = cards.find(c => c.id === rootCard.attachedTo);
+    const parentCard = cards.find(c => c.id === parentId);
     if (!parentCard) break;
     rootCard = parentCard;
   }
@@ -151,9 +166,10 @@ const syncStackTapState = (
 ): CardInstance[] => {
   const stackIds = collectStackIds(cards, rootId);
   if (stackIds.size === 0) return cards;
+  const linkedIds = collectLinkedChildIds(cards, stackIds);
 
   return cards.map(card => (
-    stackIds.has(card.id)
+    stackIds.has(card.id) || linkedIds.has(card.id)
       ? { ...card, isTapped }
       : card
   ));
@@ -173,8 +189,11 @@ export const moveCardToEnd = (
   if (isLeaderCard(targetCard)) return cards;
 
   const descendantIds = collectDescendantIds(cards, cardId);
-  const otherCards = cards.filter(c => c.id !== cardId && !descendantIds.has(c.id));
+  const movedStackIds = new Set<string>([cardId, ...descendantIds]);
+  const linkedChildIds = collectLinkedChildIds(cards, movedStackIds);
+  const otherCards = cards.filter(c => c.id !== cardId && !descendantIds.has(c.id) && !linkedChildIds.has(c.id));
   const attachments = cards.filter(c => descendantIds.has(c.id));
+  const linkedCards = cards.filter(c => linkedChildIds.has(c.id));
 
   const movedAttachments = attachments.map(a => {
     const attachmentZone = options.zone ? resolveMoveDestination(a, options.zone) : a.zone;
@@ -191,6 +210,7 @@ export const moveCardToEnd = (
           : a.isFlipped
       ),
       attachedTo: options.preserveAttachment === false ? undefined : (options.attachedTo ?? a.attachedTo),
+      linkedTo: options.zone ? undefined : a.linkedTo,
     };
   });
 
@@ -206,9 +226,30 @@ export const moveCardToEnd = (
         ? getFaceStateForZone(movedZone, targetCard.isFlipped)
         : targetCard.isFlipped
     ),
+    linkedTo: options.zone ? undefined : targetCard.linkedTo,
   };
 
-  return [...otherCards, ...movedAttachments, movedCard];
+  const movedLinkedCards = linkedCards.map(linkedCard => {
+    const linkedZone = options.zone ? resolveMoveDestination(linkedCard, options.zone) : linkedCard.zone;
+    const linkedZonePrefix = getZonePrefix(linkedZone);
+    return {
+      ...linkedCard,
+      ...options,
+      zone: linkedZone,
+      counters: options.zone ? getCountersForMove(linkedCard, linkedZone) : (options.counters ?? linkedCard.counters),
+      genericCounter: options.zone ? getGenericCounterForMove(linkedCard, linkedZone) : (options.genericCounter ?? linkedCard.genericCounter),
+      isTapped: options.isTapped ?? linkedCard.isTapped,
+      isFlipped: options.isFlipped ?? (
+        options.zone
+          ? getFaceStateForZone(linkedZone, linkedCard.isFlipped)
+          : linkedCard.isFlipped
+      ),
+      attachedTo: undefined,
+      linkedTo: linkedZonePrefix === 'field' ? linkedCard.linkedTo : undefined,
+    };
+  });
+
+  return [...otherCards, ...movedAttachments, movedCard, ...movedLinkedCards];
 };
 
 /**
@@ -225,8 +266,11 @@ export const moveCardToFront = (
   if (isLeaderCard(targetCard)) return cards;
 
   const descendantIds = collectDescendantIds(cards, cardId);
-  const otherCards = cards.filter(c => c.id !== cardId && !descendantIds.has(c.id));
+  const movedStackIds = new Set<string>([cardId, ...descendantIds]);
+  const linkedChildIds = collectLinkedChildIds(cards, movedStackIds);
+  const otherCards = cards.filter(c => c.id !== cardId && !descendantIds.has(c.id) && !linkedChildIds.has(c.id));
   const attachments = cards.filter(c => descendantIds.has(c.id));
+  const linkedCards = cards.filter(c => linkedChildIds.has(c.id));
 
   const movedAttachments = attachments.map(a => {
     const attachmentZone = options.zone ? resolveMoveDestination(a, options.zone) : a.zone;
@@ -243,6 +287,7 @@ export const moveCardToFront = (
           : a.isFlipped
       ),
       attachedTo: options.preserveAttachment === false ? undefined : (options.attachedTo ?? a.attachedTo),
+      linkedTo: options.zone ? undefined : a.linkedTo,
     };
   });
 
@@ -258,9 +303,30 @@ export const moveCardToFront = (
         ? getFaceStateForZone(movedZone, targetCard.isFlipped)
         : targetCard.isFlipped
     ),
+    linkedTo: options.zone ? undefined : targetCard.linkedTo,
   };
 
-  return [movedCard, ...movedAttachments, ...otherCards];
+  const movedLinkedCards = linkedCards.map(linkedCard => {
+    const linkedZone = options.zone ? resolveMoveDestination(linkedCard, options.zone) : linkedCard.zone;
+    const linkedZonePrefix = getZonePrefix(linkedZone);
+    return {
+      ...linkedCard,
+      ...options,
+      zone: linkedZone,
+      counters: options.zone ? getCountersForMove(linkedCard, linkedZone) : (options.counters ?? linkedCard.counters),
+      genericCounter: options.zone ? getGenericCounterForMove(linkedCard, linkedZone) : (options.genericCounter ?? linkedCard.genericCounter),
+      isTapped: options.isTapped ?? linkedCard.isTapped,
+      isFlipped: options.isFlipped ?? (
+        options.zone
+          ? getFaceStateForZone(linkedZone, linkedCard.isFlipped)
+          : linkedCard.isFlipped
+      ),
+      attachedTo: undefined,
+      linkedTo: linkedZonePrefix === 'field' ? linkedCard.linkedTo : undefined,
+    };
+  });
+
+  return [movedCard, ...movedAttachments, ...movedLinkedCards, ...otherCards];
 };
 
 /**
@@ -493,9 +559,14 @@ export const toggleTapStack = (
   if (isLeaderCard(targetCard)) return cards;
 
   const stackIds = collectStackIds(cards, cardId);
+  const linkedIds = collectLinkedChildIds(cards, stackIds);
   const newIsTapped = !targetCard.isTapped;
 
-  return cards.map(c => stackIds.has(c.id) ? { ...c, isTapped: newIsTapped } : c);
+  return cards.map(c => (
+    stackIds.has(c.id) || linkedIds.has(c.id)
+      ? { ...c, isTapped: newIsTapped }
+      : c
+  ));
 };
 
 export const tapStack = (
@@ -507,10 +578,15 @@ export const tapStack = (
   if (isLeaderCard(targetCard)) return cards;
 
   const stackIds = collectStackIds(cards, cardId);
-  const shouldChange = cards.some(c => stackIds.has(c.id) && !c.isTapped);
+  const linkedIds = collectLinkedChildIds(cards, stackIds);
+  const shouldChange = cards.some(c => (stackIds.has(c.id) || linkedIds.has(c.id)) && !c.isTapped);
   if (!shouldChange) return cards;
 
-  return cards.map(c => stackIds.has(c.id) ? { ...c, isTapped: true } : c);
+  return cards.map(c => (
+    stackIds.has(c.id) || linkedIds.has(c.id)
+      ? { ...c, isTapped: true }
+      : c
+  ));
 };
 
 export const toggleFlip = (
@@ -532,7 +608,8 @@ const dissolveTokenStackIntoZone = (
 ): CardInstance[] => {
   const descendantIds = collectDescendantIds(cards, cardId);
   const stackIds = new Set<string>([cardId, ...descendantIds]);
-  const otherCards = cards.filter(card => !stackIds.has(card.id));
+  const linkedChildIds = collectLinkedChildIds(cards, stackIds);
+  const otherCards = cards.filter(card => !stackIds.has(card.id) && !linkedChildIds.has(card.id));
   const movedNonTokenCards = cards
     .filter(card => stackIds.has(card.id) && !isTokenCard(card))
     .map(card => {
@@ -543,14 +620,30 @@ const dissolveTokenStackIntoZone = (
         isFlipped: getFaceStateForZone(destinationZone, card.isFlipped),
         isTapped: false,
         attachedTo: undefined,
+        linkedTo: undefined,
+        counters: getCountersForMove(card, destinationZone),
+        genericCounter: getGenericCounterForMove(card, destinationZone),
+      };
+    });
+  const movedLinkedCards = cards
+    .filter(card => linkedChildIds.has(card.id) && !isTokenCard(card))
+    .map(card => {
+      const destinationZone = resolveMoveDestination(card, requestedZone);
+      return {
+        ...card,
+        zone: destinationZone,
+        isFlipped: getFaceStateForZone(destinationZone, card.isFlipped),
+        isTapped: false,
+        attachedTo: undefined,
+        linkedTo: undefined,
         counters: getCountersForMove(card, destinationZone),
         genericCounter: getGenericCounterForMove(card, destinationZone),
       };
     });
 
   return shouldPlaceAtFront
-    ? [...movedNonTokenCards, ...otherCards]
-    : [...otherCards, ...movedNonTokenCards];
+    ? [...movedNonTokenCards, ...movedLinkedCards, ...otherCards]
+    : [...otherCards, ...movedNonTokenCards, ...movedLinkedCards];
 };
 
 export const sendCardToBottom = (
@@ -723,6 +816,41 @@ export const extractCardToFieldAttachment = (
   });
 };
 
+export const linkCardToField = (
+  cards: CardInstance[],
+  cardId: string,
+  parentCardId: string
+): CardInstance[] => {
+  const targetCard = cards.find(c => c.id === cardId);
+  if (!targetCard) return cards;
+  if (isLeaderCard(targetCard)) return cards;
+
+  const parentCard = cards.find(c => c.id === parentCardId);
+  if (!parentCard) return cards;
+  if (isLeaderCard(parentCard)) return cards;
+
+  const rootCard = findRootCard(cards, parentCard);
+  const destinationZone = `field-${targetCard.owner}`;
+  if (rootCard.zone !== destinationZone) return cards;
+  if (rootCard.owner !== targetCard.owner) return cards;
+
+  const movedCards = moveCardToEnd(cards, cardId, {
+    zone: destinationZone,
+    isFlipped: false,
+    isTapped: rootCard.isTapped,
+    counters: getCountersForMove(targetCard, destinationZone),
+    genericCounter: getGenericCounterForMove(targetCard, destinationZone),
+    attachedTo: undefined,
+    preserveAttachment: false,
+  });
+
+  return movedCards.map(card => (
+    card.id === cardId
+      ? { ...card, attachedTo: undefined, linkedTo: rootCard.id }
+      : card
+  ));
+};
+
 export const modifyPlayerStatValue = (
   currentValue: number,
   maxPp: number,
@@ -747,7 +875,7 @@ export const drawInitialHand = (
   const myDeck = cards.filter(c => c.zone === `mainDeck-${role}`);
   if (myDeck.length < 4) return cards;
 
-  const drawnCards = myDeck.slice(0, 4).map(c => ({ ...c, zone: `hand-${role}`, isFlipped: false }));
+  const drawnCards = myDeck.slice(0, 4).map(c => ({ ...c, zone: `hand-${role}`, isFlipped: false, linkedTo: undefined }));
   const drawnIds = new Set(drawnCards.map(c => c.id));
   const otherCards = cards.filter(c => !drawnIds.has(c.id));
   return [...otherCards, ...drawnCards];
@@ -788,11 +916,11 @@ export const executeMulligan = (
   // 1. Prepare returned cards (Ordered by selection)
   const returnedCards = selectedIds.map(id => {
     const card = cards.find(c => c.id === id)!;
-    return { ...card, zone: getDeckZone(card), isFlipped: true, isTapped: false, attachedTo: undefined };
+    return { ...card, zone: getDeckZone(card), isFlipped: true, isTapped: false, attachedTo: undefined, linkedTo: undefined };
   });
 
   // 2. Draw 4 new ones
-  const newHandCards = restOfDeck.slice(0, 4).map(c => ({ ...c, zone: `hand-${role}`, isFlipped: false }));
+  const newHandCards = restOfDeck.slice(0, 4).map(c => ({ ...c, zone: `hand-${role}`, isFlipped: false, linkedTo: undefined }));
   
   // 3. Remaining
   const remainingDeckCards = restOfDeck.slice(4);
@@ -834,7 +962,7 @@ export const resolveTopDeckResults = (
         zone = getDeckZone(card); 
         break;
     }
-    return { ...card, zone, isFlipped: (res.action === 'top' || res.action === 'bottom') };
+    return { ...card, zone, isFlipped: (res.action === 'top' || res.action === 'bottom'), linkedTo: undefined };
   });
 
   const topCards = results.filter(r => r.action === 'top').sort((a, b) => (a.order || 0) - (b.order || 0)).map(r => processedCards.find(pc => pc.id === r.cardId)!);

--- a/src/utils/fieldLinkAutoAttach.test.ts
+++ b/src/utils/fieldLinkAutoAttach.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import type { CardInstance } from '../components/Card';
+import type { DeckBuilderCardData } from '../models/deckBuilderCard';
+import { buildFieldLinkAutoAttachResolver } from './fieldLinkAutoAttach';
+
+const createCatalogCard = (overrides: Partial<DeckBuilderCardData>): DeckBuilderCardData => ({
+  id: 'CARD-001',
+  name: 'Test Card',
+  image: '/card.png',
+  card_kind_normalized: 'follower',
+  deck_section: 'main',
+  ...overrides,
+});
+
+const createRuntimeCard = (overrides: Partial<CardInstance>): CardInstance => ({
+  id: 'runtime-1',
+  cardId: 'CARD-001',
+  name: 'Runtime Card',
+  image: '/runtime.png',
+  zone: 'field-host',
+  owner: 'host',
+  isTapped: false,
+  isFlipped: false,
+  counters: { atk: 0, hp: 0 },
+  genericCounter: 0,
+  ...overrides,
+});
+
+describe('buildFieldLinkAutoAttachResolver', () => {
+  it('resolves drive point targets by reverse related_cards lookup', () => {
+    const resolver = buildFieldLinkAutoAttachResolver([
+      createCatalogCard({
+        id: 'BASE-001',
+        name: 'Base Vanguard Unit',
+        related_cards: [{ id: 'DRIVE-001', name: 'ドライブポイント' }],
+      }),
+      createCatalogCard({
+        id: 'DRIVE-001',
+        name: 'ドライブポイント',
+        title: 'カードファイト!! ヴァンガード',
+        deck_section: 'evolve',
+        card_kind_normalized: 'evolve_spell',
+      }),
+    ]);
+
+    const candidates = resolver.resolveCandidates(
+      createRuntimeCard({
+        id: 'drive-runtime',
+        cardId: 'DRIVE-001',
+        name: 'ドライブポイント',
+        zone: 'evolveDeck-host',
+        owner: 'host',
+        isEvolveCard: true,
+      }),
+      [
+        createRuntimeCard({ id: 'field-base', cardId: 'BASE-001', name: 'Base Vanguard Unit' }),
+      ]
+    );
+
+    expect(candidates.map(card => card.id)).toEqual(['field-base']);
+  });
+
+  it('accepts carrot-like reprints through the shared link group', () => {
+    const resolver = buildFieldLinkAutoAttachResolver([
+      createCatalogCard({
+        id: 'BASE-001',
+        name: 'Uma Target',
+        title: 'ウマ娘 プリティーダービー',
+        related_cards: [{ id: 'CARROT-001', name: 'にんじん' }],
+      }),
+      createCatalogCard({
+        id: 'CARROT-001',
+        name: 'にんじん',
+        title: 'ウマ娘 プリティーダービー',
+        deck_section: 'evolve',
+        card_kind_normalized: 'evolve_spell',
+      }),
+      createCatalogCard({
+        id: 'CARROT-SP',
+        name: '開催大成功！',
+        title: 'ウマ娘 プリティーダービー',
+        deck_section: 'evolve',
+        card_kind_normalized: 'evolve_spell',
+      }),
+    ]);
+
+    const candidates = resolver.resolveCandidates(
+      createRuntimeCard({
+        id: 'carrot-runtime',
+        cardId: 'CARROT-SP',
+        name: '開催大成功！',
+        zone: 'evolveDeck-host',
+        owner: 'host',
+        isEvolveCard: true,
+      }),
+      [
+        createRuntimeCard({
+          id: 'field-base',
+          cardId: 'BASE-001',
+          name: 'Uma Target',
+        }),
+      ]
+    );
+
+    expect(candidates.map(card => card.id)).toEqual(['field-base']);
+  });
+
+  it('keeps evolved units eligible because linked cards sit under the whole unit', () => {
+    const resolver = buildFieldLinkAutoAttachResolver([
+      createCatalogCard({
+        id: 'BASE-001',
+        name: 'Base Vanguard Unit',
+        related_cards: [{ id: 'DRIVE-001', name: 'ドライブポイント' }],
+      }),
+      createCatalogCard({
+        id: 'EVO-001',
+        name: 'Base Vanguard Unit',
+        deck_section: 'evolve',
+        card_kind_normalized: 'evolve_follower',
+        related_cards: [{ id: 'BASE-001', name: 'Base Vanguard Unit' }],
+      }),
+      createCatalogCard({
+        id: 'DRIVE-001',
+        name: 'ドライブポイント',
+        title: 'カードファイト!! ヴァンガード',
+        deck_section: 'evolve',
+        card_kind_normalized: 'evolve_spell',
+      }),
+    ]);
+
+    const candidates = resolver.resolveCandidates(
+      createRuntimeCard({
+        id: 'drive-runtime',
+        cardId: 'DRIVE-001',
+        name: 'ドライブポイント',
+        zone: 'evolveDeck-host',
+        owner: 'host',
+        isEvolveCard: true,
+      }),
+      [
+        createRuntimeCard({ id: 'field-base', cardId: 'BASE-001', name: 'Base Vanguard Unit' }),
+        createRuntimeCard({
+          id: 'field-evolved',
+          cardId: 'EVO-001',
+          name: 'Base Vanguard Unit',
+          zone: 'field-host',
+          owner: 'host',
+          isEvolveCard: true,
+          attachedTo: 'field-base',
+        }),
+      ]
+    );
+
+    expect(candidates.map(card => card.id)).toEqual(['field-base']);
+  });
+
+  it('ignores unrelated or invalid field targets', () => {
+    const resolver = buildFieldLinkAutoAttachResolver([
+      createCatalogCard({
+        id: 'BASE-001',
+        name: 'Base Vanguard Unit',
+      }),
+      createCatalogCard({
+        id: 'DRIVE-001',
+        name: 'ドライブポイント',
+        title: 'カードファイト!! ヴァンガード',
+        deck_section: 'evolve',
+        card_kind_normalized: 'evolve_spell',
+      }),
+    ]);
+
+    const candidates = resolver.resolveCandidates(
+      createRuntimeCard({
+        id: 'drive-runtime',
+        cardId: 'DRIVE-001',
+        name: 'ドライブポイント',
+        zone: 'evolveDeck-host',
+        owner: 'host',
+        isEvolveCard: true,
+      }),
+      [
+        createRuntimeCard({ id: 'field-base', cardId: 'BASE-001', name: 'Base Vanguard Unit' }),
+        createRuntimeCard({ id: 'field-token', cardId: 'BASE-001', name: 'Token Copy', isTokenCard: true }),
+      ]
+    );
+
+    expect(candidates).toEqual([]);
+  });
+});

--- a/src/utils/fieldLinkAutoAttach.ts
+++ b/src/utils/fieldLinkAutoAttach.ts
@@ -1,0 +1,84 @@
+import type { CardInstance } from '../components/Card';
+import type { DeckBuilderCardData } from '../models/deckBuilderCard';
+import { getFieldLinkGroupId } from '../data/fieldLinkRules';
+
+const isAdvanceKind = (cardKindNormalized?: string): boolean => (
+  Boolean(cardKindNormalized?.startsWith('advance_'))
+);
+
+const getRootFieldCards = (boardCards: CardInstance[], owner: CardInstance['owner']): CardInstance[] => {
+  const fieldCards = boardCards.filter(card => card.zone === `field-${owner}`);
+  const fieldCardIds = new Set(fieldCards.map(card => card.id));
+
+  return fieldCards.filter(card => !card.attachedTo || !fieldCardIds.has(card.attachedTo));
+};
+
+const isValidFieldLinkTarget = (
+  card: CardInstance,
+  cardsById: Record<string, DeckBuilderCardData>
+): boolean => {
+  if (card.isLeaderCard || card.isEvolveCard || card.isTokenCard) return false;
+
+  const catalogCard = cardsById[card.cardId];
+  if (!catalogCard || catalogCard.deck_section !== 'main') return false;
+
+  return !isAdvanceKind(catalogCard.card_kind_normalized);
+};
+
+export interface FieldLinkAutoAttachResolver {
+  isEligibleSource: (card: CardInstance) => boolean;
+  resolveCandidates: (card: CardInstance, boardCards: CardInstance[]) => CardInstance[];
+}
+
+export const buildFieldLinkAutoAttachResolver = (
+  cards: DeckBuilderCardData[]
+): FieldLinkAutoAttachResolver => {
+  const cardsById = cards.reduce<Record<string, DeckBuilderCardData>>((lookup, card) => {
+    lookup[card.id] = card;
+    return lookup;
+  }, {});
+
+  const fieldLinkGroupIdByCardId = cards.reduce<Record<string, string>>((lookup, card) => {
+    const groupId = getFieldLinkGroupId(card);
+    if (groupId) {
+      lookup[card.id] = groupId;
+    }
+    return lookup;
+  }, {});
+
+  const relatedFieldLinkGroupsByCardId = cards.reduce<Record<string, Set<string>>>((lookup, card) => {
+    const relatedGroupIds = new Set(
+      (card.related_cards ?? [])
+        .map(related => fieldLinkGroupIdByCardId[related.id])
+        .filter((groupId): groupId is string => Boolean(groupId))
+    );
+
+    lookup[card.id] = relatedGroupIds;
+    return lookup;
+  }, {});
+
+  const isEligibleSource = (card: CardInstance): boolean => {
+    const catalogCard = cardsById[card.cardId];
+    if (!catalogCard || catalogCard.deck_section !== 'evolve') return false;
+    return Boolean(fieldLinkGroupIdByCardId[catalogCard.id]);
+  };
+
+  const resolveCandidates = (card: CardInstance, boardCards: CardInstance[]): CardInstance[] => {
+    if (!isEligibleSource(card)) return [];
+
+    const sourceCatalogCard = cardsById[card.cardId];
+    if (!sourceCatalogCard) return [];
+
+    const sourceGroupId = fieldLinkGroupIdByCardId[sourceCatalogCard.id];
+    if (!sourceGroupId) return [];
+
+    return getRootFieldCards(boardCards, card.owner)
+      .filter(fieldCard => isValidFieldLinkTarget(fieldCard, cardsById))
+      .filter(fieldCard => relatedFieldLinkGroupsByCardId[fieldCard.cardId]?.has(sourceGroupId));
+  };
+
+  return {
+    isEligibleSource,
+    resolveCandidates,
+  };
+};

--- a/src/utils/gameSyncReducer.test.ts
+++ b/src/utils/gameSyncReducer.test.ts
@@ -1299,6 +1299,54 @@ describe('gameSyncReducer', () => {
     expect(dragged).toBe(state);
   });
 
+  it('links a special card to a field card without using the normal stack model', () => {
+    const state = createState({
+      revision: 8,
+      gameStatus: 'playing',
+      cards: [
+        {
+          id: 'special-card',
+          cardId: 'BPV-001',
+          name: 'ドライブポイント',
+          image: '',
+          zone: 'evolveDeck-host',
+          owner: 'host',
+          isTapped: false,
+          isFlipped: false,
+          counters: { atk: 0, hp: 0 },
+          isEvolveCard: true,
+        },
+        {
+          id: 'field-card',
+          cardId: 'BP01-099',
+          name: 'Field Card',
+          image: '',
+          zone: 'field-host',
+          owner: 'host',
+          isTapped: true,
+          isFlipped: false,
+          counters: { atk: 0, hp: 0 },
+        },
+      ],
+    });
+
+    const result = applyGameSyncEvent(state, {
+      id: 'evt-link-card-to-field',
+      type: 'LINK_CARD_TO_FIELD',
+      actor: 'host',
+      cardId: 'special-card',
+      parentCardId: 'field-card',
+    });
+
+    expect(result.cards.find(card => card.id === 'special-card')).toMatchObject({
+      zone: 'field-host',
+      linkedTo: 'field-card',
+      attachedTo: undefined,
+      isTapped: true,
+    });
+    expect(result.lastUndoableCardMoveActor).toBe('host');
+  });
+
   it('applies stat, initial hand, mulligan, top deck resolve, and import events', () => {
     const baseState = createState({
       revision: 0,

--- a/src/utils/gameSyncReducer.ts
+++ b/src/utils/gameSyncReducer.ts
@@ -208,6 +208,7 @@ export const applyGameSyncEvent = (
           isFlipped: c.isLeaderCard ? false : true,
           isTapped: false,
           attachedTo: undefined,
+          linkedTo: undefined,
           counters: { atk: 0, hp: 0 },
           genericCounter: 0,
         }));
@@ -228,6 +229,15 @@ export const applyGameSyncEvent = (
       if (isPreparingMainDeckDragBlocked(state, event.cardId)) return state;
       if (isPreparingEvolveDeckMoveBlocked(state, event.cardId)) return state;
       const nextCards = CardLogic.applyDrop(state.cards, event.cardId, event.overId);
+      if (nextCards === state.cards) return state;
+      return withCardMoveCheckpoint(state, event.actor, nextCards);
+    }
+
+    case 'LINK_CARD_TO_FIELD': {
+      if (isPreparingHandMovementBlocked(state, event.cardId)) return state;
+      if (isPreparingMainDeckDragBlocked(state, event.cardId)) return state;
+      if (isPreparingEvolveDeckMoveBlocked(state, event.cardId)) return state;
+      const nextCards = CardLogic.linkCardToField(state.cards, event.cardId, event.parentCardId);
       if (nextCards === state.cards) return state;
       return withCardMoveCheckpoint(state, event.actor, nextCards);
     }


### PR DESCRIPTION
#50 
自動進化の対象をドライブポイント / にんじんにも対応

実装メモ：
にんじんに関しては、同一能力カードが複数名称あるため、にんじんグループとして定義。
ドライブポイントも１名称だが同様にグループ化

これらは、出走持ちやドライブ獲得持ちからの片側からの関連カード情報しかないため、自動ロジックはそちらを参照するように特例仕様としている。

また、これらのカードはテーブルトップではカードの下に重ねて運用するものである。
現状の見た目的な動作では一応実現可能ではあるが、実装上の root card が持つ役割と若干齟齬のある運用になってしまうため、下に重ねる特例のカードに対する状態を新たに定義した。
