### PR TITLE
細かいバグ修正

### DIFF
--- a/src/utils/cardLogic.test.ts
+++ b/src/utils/cardLogic.test.ts
@@ -322,6 +322,26 @@ describe('CardLogic utils', () => {
       expect(CardLogic.resolveMoveDestination(card, 'hand-host')).toBe('evolveDeck-host');
     });
 
+    it('should return non-advance evolve cards to evolve deck when sent to ex', () => {
+      const card = {
+        ...createMockCard('e1', 'field-host'),
+        isEvolveCard: true,
+        cardKindNormalized: 'evolve_follower',
+      };
+
+      expect(CardLogic.resolveMoveDestination(card, 'ex-host')).toBe('evolveDeck-host');
+    });
+
+    it('should allow advance cards to stay in ex', () => {
+      const card = {
+        ...createMockCard('adv-1', 'field-host'),
+        isEvolveCard: true,
+        cardKindNormalized: 'advance_follower',
+      };
+
+      expect(CardLogic.resolveMoveDestination(card, 'ex-host')).toBe('ex-host');
+    });
+
     it('should keep leader cards in the leader zone regardless of the requested destination', () => {
       const leader = { ...createMockCard('leader-1', 'leader-host'), isLeaderCard: true };
 
@@ -373,6 +393,23 @@ describe('CardLogic utils', () => {
       const moved = result.find(c => c.id === 'e1');
       expect(moved?.zone).toBe('evolveDeck-host');
       expect(moved?.isFlipped).toBe(false);
+    });
+
+    it('should leave invalid non-evolve attachments on the field when an evolve root is dropped onto cemetery', () => {
+      const evolveRoot = { ...createMockCard('e1', 'field-host'), isEvolveCard: true };
+      const invalidTop = { ...createMockCard('main-top', 'field-host'), attachedTo: 'e1' };
+      const cemetery = createMockCard('cem', 'cemetery-host');
+
+      const result = CardLogic.applyDrop([evolveRoot, invalidTop, cemetery], 'e1', 'cem');
+
+      expect(result.find(c => c.id === 'e1')).toMatchObject({
+        zone: 'evolveDeck-host',
+        attachedTo: undefined,
+      });
+      expect(result.find(c => c.id === 'main-top')).toMatchObject({
+        zone: 'field-host',
+        attachedTo: undefined,
+      });
     });
 
     it('should turn cards face-up when moving from a deck to the field by drag and drop', () => {
@@ -432,6 +469,66 @@ describe('CardLogic utils', () => {
       expect(result.find(c => c.id === 'field-1')?.isTapped).toBe(false);
       expect(result.find(c => c.id === 'field-1')?.counters).toEqual({ atk: 0, hp: 0 });
       expect(result.find(c => c.id === 'field-1')?.genericCounter).toBe(0);
+    });
+
+    it('should detach the whole stack when a field stack is dragged to the ex area', () => {
+      const base = createMockCard('base', 'field-host');
+      const top = { ...createMockCard('top', 'field-host'), attachedTo: 'base' };
+      const nested = { ...createMockCard('nested', 'field-host'), attachedTo: 'top' };
+      const exCard = createMockCard('ex-1', 'ex-host');
+
+      const result = CardLogic.applyDrop([base, top, nested, exCard], 'base', 'ex-1');
+
+      expect(result.find(c => c.id === 'base')).toMatchObject({
+        zone: 'ex-host',
+        attachedTo: undefined,
+      });
+      expect(result.find(c => c.id === 'top')).toMatchObject({
+        zone: 'ex-host',
+        attachedTo: undefined,
+      });
+      expect(result.find(c => c.id === 'nested')).toMatchObject({
+        zone: 'ex-host',
+        attachedTo: undefined,
+      });
+    });
+
+    it('should return non-advance evolve cards to evolve deck when a stack is moved to the ex area', () => {
+      const base = createMockCard('base', 'field-host');
+      const evolve = {
+        ...createMockCard('evo', 'field-host'),
+        attachedTo: 'base',
+        isEvolveCard: true,
+        cardKindNormalized: 'evolve_follower',
+      };
+      const exCard = createMockCard('ex-1', 'ex-host');
+
+      const result = CardLogic.applyDrop([base, evolve, exCard], 'base', 'ex-1');
+
+      expect(result.find(c => c.id === 'base')).toMatchObject({
+        zone: 'ex-host',
+        attachedTo: undefined,
+      });
+      expect(result.find(c => c.id === 'evo')).toMatchObject({
+        zone: 'evolveDeck-host',
+        attachedTo: undefined,
+      });
+    });
+
+    it('should still allow advance cards to move to the ex area', () => {
+      const advance = {
+        ...createMockCard('advance', 'field-host'),
+        isEvolveCard: true,
+        cardKindNormalized: 'advance_follower',
+      };
+      const exCard = createMockCard('ex-1', 'ex-host');
+
+      const result = CardLogic.applyDrop([advance, exCard], 'advance', 'ex-1');
+
+      expect(result.find(c => c.id === 'advance')).toMatchObject({
+        zone: 'ex-host',
+        attachedTo: undefined,
+      });
     });
 
     it('should preserve counters when an ex card is dragged to the field', () => {
@@ -733,6 +830,23 @@ describe('CardLogic utils', () => {
       });
     });
 
+    it('should send opposing non-token descendants to their owner private zones when sending a token to cemetery', () => {
+      const token = { ...createMockCard('token-root', 'field-host', 'host'), cardId: 'token' };
+      const opposingFollower = {
+        ...createMockCard('opposing-follower', 'field-host', 'guest'),
+        attachedTo: 'token-root',
+      };
+
+      const result = CardLogic.sendCardToCemetery([token, opposingFollower], 'token-root');
+
+      expect(result.find(c => c.id === 'token-root')).toBeUndefined();
+      expect(result.find(c => c.id === 'opposing-follower')).toMatchObject({
+        zone: 'cemetery-guest',
+        attachedTo: undefined,
+        linkedTo: undefined,
+      });
+    });
+
     it('should return attached evolve cards to evolve deck when sending the base card to cemetery', () => {
       const oldCemetery = createMockCard('old-cemetery', 'cemetery-host');
       const oldUsedEvo = { ...createMockCard('old-evo', 'evolveDeck-host'), isEvolveCard: true, isFlipped: false };
@@ -746,6 +860,31 @@ describe('CardLogic utils', () => {
       expect(result.find(c => c.id === 'evo')?.attachedTo).toBeUndefined();
       expect(result[0].id).toBe('base');
       expect(result[1].id).toBe('evo');
+    });
+
+    it('should leave invalid non-evolve attachments on the field when sending an evolve root to cemetery', () => {
+      const evolveRoot = { ...createMockCard('evo-root', 'field-host'), isEvolveCard: true };
+      const invalidTop = {
+        ...createMockCard('main-top', 'field-host'),
+        attachedTo: 'evo-root',
+        counters: { atk: 2, hp: -1 },
+        genericCounter: 1,
+        isTapped: true,
+      };
+
+      const result = CardLogic.sendCardToCemetery([evolveRoot, invalidTop], 'evo-root');
+
+      expect(result.find(c => c.id === 'evo-root')).toMatchObject({
+        zone: 'evolveDeck-host',
+        attachedTo: undefined,
+      });
+      expect(result.find(c => c.id === 'main-top')).toMatchObject({
+        zone: 'field-host',
+        attachedTo: undefined,
+        counters: { atk: 2, hp: -1 },
+        genericCounter: 1,
+        isTapped: true,
+      });
     });
 
     it('should place newly sent cemetery cards on top of the cemetery stack', () => {
@@ -862,6 +1001,52 @@ describe('CardLogic utils', () => {
         isTapped: true,
       });
       expect(result.find(card => card.id === 'base')?.isTapped).toBe(true);
+    });
+
+    it('should detach attachments when extracting a stack into the ex area', () => {
+      const base = createMockCard('base', 'field-host');
+      const top = { ...createMockCard('top', 'field-host'), attachedTo: 'base' };
+
+      const result = CardLogic.extractCard([base, top], 'base', 'host', 'ex-host');
+
+      expect(result.find(card => card.id === 'base')).toMatchObject({
+        zone: 'ex-host',
+        attachedTo: undefined,
+      });
+      expect(result.find(card => card.id === 'top')).toMatchObject({
+        zone: 'ex-host',
+        attachedTo: undefined,
+      });
+    });
+
+    it('should return non-advance evolve cards to evolve deck when extracting them to ex', () => {
+      const card = {
+        ...createMockCard('evo', 'field-host'),
+        isEvolveCard: true,
+        cardKindNormalized: 'evolve_spell',
+      };
+
+      const result = CardLogic.extractCard([card], 'evo', 'host', 'ex-host');
+
+      expect(result.find(found => found.id === 'evo')).toMatchObject({
+        zone: 'evolveDeck-host',
+        attachedTo: undefined,
+      });
+    });
+
+    it('should still allow advance cards to be extracted to ex', () => {
+      const card = {
+        ...createMockCard('advance', 'field-host'),
+        isEvolveCard: true,
+        cardKindNormalized: 'advance_spell',
+      };
+
+      const result = CardLogic.extractCard([card], 'advance', 'host', 'ex-host');
+
+      expect(result.find(found => found.id === 'advance')).toMatchObject({
+        zone: 'ex-host',
+        attachedTo: undefined,
+      });
     });
   });
 
@@ -995,6 +1180,57 @@ describe('CardLogic utils', () => {
 
       expect(result.find(c => c.id === 'field-hidden')?.isFlipped).toBe(true);
       expect(result.find(c => c.id === 'deck-hidden')?.isFlipped).toBe(true);
+    });
+
+    it('should preserve valid attached and linked relations on the field', () => {
+      const base = createMockCard('base', 'field-host');
+      const attached = { ...createMockCard('attached', 'field-host'), attachedTo: 'base' };
+      const linked = { ...createMockCard('linked', 'field-host'), linkedTo: 'base' };
+
+      const result = CardLogic.applyStateWithGuards([base, attached, linked]);
+
+      expect(result.find(c => c.id === 'attached')?.attachedTo).toBe('base');
+      expect(result.find(c => c.id === 'linked')?.linkedTo).toBe('base');
+    });
+
+    it('should clear relations that remain outside the field', () => {
+      const exParent = createMockCard('ex-parent', 'ex-host');
+      const exAttached = { ...createMockCard('ex-attached', 'ex-host'), attachedTo: 'ex-parent' };
+      const cemeteryParent = createMockCard('cem-parent', 'cemetery-host');
+      const cemeteryLinked = { ...createMockCard('cem-linked', 'cemetery-host'), linkedTo: 'cem-parent' };
+
+      const result = CardLogic.applyStateWithGuards([exParent, exAttached, cemeteryParent, cemeteryLinked]);
+
+      expect(result.find(c => c.id === 'ex-attached')?.attachedTo).toBeUndefined();
+      expect(result.find(c => c.id === 'cem-linked')?.linkedTo).toBeUndefined();
+    });
+
+    it('should clear missing and cyclic parent references', () => {
+      const orphan = { ...createMockCard('orphan', 'field-host'), attachedTo: 'missing-parent' };
+      const cycleA = { ...createMockCard('cycle-a', 'field-host'), attachedTo: 'cycle-b' };
+      const cycleB = { ...createMockCard('cycle-b', 'field-host'), attachedTo: 'cycle-a' };
+
+      const result = CardLogic.applyStateWithGuards([orphan, cycleA, cycleB]);
+
+      expect(result.find(c => c.id === 'orphan')?.attachedTo).toBeUndefined();
+      expect(result.find(c => c.id === 'cycle-a')?.attachedTo).toBeUndefined();
+      expect(result.find(c => c.id === 'cycle-b')?.attachedTo).toBeUndefined();
+    });
+
+    it('should prefer attachedTo when both relation fields are present', () => {
+      const base = createMockCard('base', 'field-host');
+      const card = {
+        ...createMockCard('dual', 'field-host'),
+        attachedTo: 'base',
+        linkedTo: 'base',
+      };
+
+      const result = CardLogic.applyStateWithGuards([base, card]);
+
+      expect(result.find(c => c.id === 'dual')).toMatchObject({
+        attachedTo: 'base',
+        linkedTo: undefined,
+      });
     });
   });
 

--- a/src/utils/cardLogic.ts
+++ b/src/utils/cardLogic.ts
@@ -1,6 +1,6 @@
 import type { CardInstance } from '../components/Card';
 import type { SyncState } from '../types/game';
-import { isMainDeckSpellCard } from './cardType';
+import { isMainDeckSpellCard, isPureEvolveCard } from './cardType';
 
 /**
  * Pure logic for card state transitions.
@@ -114,12 +114,113 @@ const collectLinkedChildIds = (
   );
 };
 
+const detachInvalidEvolveRootSubtrees = (
+  cards: CardInstance[],
+  rootCardId: string,
+  destinationZone?: string
+): CardInstance[] => {
+  if (!destinationZone) return cards;
+
+  const rootCard = cards.find(card => card.id === rootCardId);
+  if (!rootCard?.isEvolveCard) return cards;
+
+  const destinationPrefix = getZonePrefix(destinationZone);
+  if (destinationPrefix === 'field' || destinationPrefix === 'ex') return cards;
+
+  const releasedRootIds = new Set(
+    cards
+      .filter(card => card.attachedTo === rootCardId && !card.isEvolveCard && !isTokenCard(card))
+      .map(card => card.id)
+  );
+
+  if (releasedRootIds.size === 0) return cards;
+
+  return cards.map(card => (
+    releasedRootIds.has(card.id)
+      ? { ...card, attachedTo: undefined }
+      : card
+  ));
+};
+
 const getZonePrefix = (zone: string): string => zone.split('-')[0];
+const PRIVATE_ZONE_PREFIXES = new Set(['mainDeck', 'evolveDeck', 'hand', 'cemetery', 'banish']);
+const ATTACHMENT_BLOCKED_ZONE_PREFIXES = new Set([...PRIVATE_ZONE_PREFIXES, 'ex']);
 const isLeaderZone = (zone: string): boolean => zone.startsWith('leader-');
 const isLeaderCard = (card: CardInstance | undefined): boolean =>
   Boolean(card?.isLeaderCard) || isLeaderZone(card?.zone ?? '');
 const isTokenCard = (card: CardInstance | undefined): boolean =>
   Boolean(card?.isTokenCard) || card?.cardId === 'token';
+const isFieldZone = (zone: string): boolean => getZonePrefix(zone) === 'field';
+
+const getPreferredParentId = (card: Pick<CardInstance, 'attachedTo' | 'linkedTo'>): string | undefined =>
+  card.attachedTo ?? card.linkedTo;
+
+const hasBrokenAncestorChain = (
+  cardsById: Map<string, CardInstance>,
+  cardId: string,
+  parentId: string
+): boolean => {
+  const visited = new Set<string>([cardId]);
+  let currentId: string | undefined = parentId;
+
+  while (currentId) {
+    if (visited.has(currentId)) return true;
+    visited.add(currentId);
+
+    const currentCard = cardsById.get(currentId);
+    if (!currentCard) return false;
+
+    currentId = getPreferredParentId(currentCard);
+  }
+
+  return false;
+};
+
+const sanitizeCardRelations = (cards: CardInstance[]): CardInstance[] => {
+  const cardsById = new Map(cards.map(card => [card.id, card] as const));
+
+  return cards.map(card => {
+    let nextCard = card;
+
+    if (nextCard.attachedTo && nextCard.linkedTo) {
+      nextCard = { ...nextCard, linkedTo: undefined };
+    }
+
+    if (nextCard.attachedTo) {
+      const parentCard = cardsById.get(nextCard.attachedTo);
+      const isInvalidAttachment =
+        !parentCard ||
+        parentCard.id === nextCard.id ||
+        isLeaderCard(parentCard) ||
+        isLeaderCard(nextCard) ||
+        !isFieldZone(nextCard.zone) ||
+        parentCard.zone !== nextCard.zone ||
+        hasBrokenAncestorChain(cardsById, nextCard.id, nextCard.attachedTo);
+
+      if (isInvalidAttachment) {
+        nextCard = { ...nextCard, attachedTo: undefined };
+      }
+    }
+
+    if (nextCard.linkedTo) {
+      const parentCard = cardsById.get(nextCard.linkedTo);
+      const isInvalidLink =
+        !parentCard ||
+        parentCard.id === nextCard.id ||
+        isLeaderCard(parentCard) ||
+        isLeaderCard(nextCard) ||
+        !isFieldZone(nextCard.zone) ||
+        parentCard.zone !== nextCard.zone ||
+        hasBrokenAncestorChain(cardsById, nextCard.id, nextCard.linkedTo);
+
+      if (isInvalidLink) {
+        nextCard = { ...nextCard, linkedTo: undefined };
+      }
+    }
+
+    return nextCard;
+  });
+};
 
 const findRootCard = (cards: CardInstance[], card: CardInstance): CardInstance => {
   let rootCard = card;
@@ -184,16 +285,17 @@ export const moveCardToEnd = (
   cardId: string,
   options: MoveCardOptions
 ): CardInstance[] => {
-  const targetCard = cards.find(c => c.id === cardId);
+  const workingCards = detachInvalidEvolveRootSubtrees(cards, cardId, options.zone);
+  const targetCard = workingCards.find(c => c.id === cardId);
   if (!targetCard) return cards;
   if (isLeaderCard(targetCard)) return cards;
 
-  const descendantIds = collectDescendantIds(cards, cardId);
+  const descendantIds = collectDescendantIds(workingCards, cardId);
   const movedStackIds = new Set<string>([cardId, ...descendantIds]);
-  const linkedChildIds = collectLinkedChildIds(cards, movedStackIds);
-  const otherCards = cards.filter(c => c.id !== cardId && !descendantIds.has(c.id) && !linkedChildIds.has(c.id));
-  const attachments = cards.filter(c => descendantIds.has(c.id));
-  const linkedCards = cards.filter(c => linkedChildIds.has(c.id));
+  const linkedChildIds = collectLinkedChildIds(workingCards, movedStackIds);
+  const otherCards = workingCards.filter(c => c.id !== cardId && !descendantIds.has(c.id) && !linkedChildIds.has(c.id));
+  const attachments = workingCards.filter(c => descendantIds.has(c.id));
+  const linkedCards = workingCards.filter(c => linkedChildIds.has(c.id));
 
   const movedAttachments = attachments.map(a => {
     const attachmentZone = options.zone ? resolveMoveDestination(a, options.zone) : a.zone;
@@ -261,16 +363,17 @@ export const moveCardToFront = (
   cardId: string,
   options: MoveCardOptions
 ): CardInstance[] => {
-  const targetCard = cards.find(c => c.id === cardId);
+  const workingCards = detachInvalidEvolveRootSubtrees(cards, cardId, options.zone);
+  const targetCard = workingCards.find(c => c.id === cardId);
   if (!targetCard) return cards;
   if (isLeaderCard(targetCard)) return cards;
 
-  const descendantIds = collectDescendantIds(cards, cardId);
+  const descendantIds = collectDescendantIds(workingCards, cardId);
   const movedStackIds = new Set<string>([cardId, ...descendantIds]);
-  const linkedChildIds = collectLinkedChildIds(cards, movedStackIds);
-  const otherCards = cards.filter(c => c.id !== cardId && !descendantIds.has(c.id) && !linkedChildIds.has(c.id));
-  const attachments = cards.filter(c => descendantIds.has(c.id));
-  const linkedCards = cards.filter(c => linkedChildIds.has(c.id));
+  const linkedChildIds = collectLinkedChildIds(workingCards, movedStackIds);
+  const otherCards = workingCards.filter(c => c.id !== cardId && !descendantIds.has(c.id) && !linkedChildIds.has(c.id));
+  const attachments = workingCards.filter(c => descendantIds.has(c.id));
+  const linkedCards = workingCards.filter(c => linkedChildIds.has(c.id));
 
   const movedAttachments = attachments.map(a => {
     const attachmentZone = options.zone ? resolveMoveDestination(a, options.zone) : a.zone;
@@ -411,11 +514,20 @@ export const resolveMoveDestination = (
     return getDeckZone(card);
   }
 
-  if (card.isEvolveCard && ['hand', 'cemetery', 'banish'].includes(requestedPrefix)) {
+  if (isPureEvolveCard(card) && ['hand', 'cemetery', 'banish', 'ex'].includes(requestedPrefix)) {
     return getDeckZone(card);
   }
 
   return requestedZone;
+};
+
+const resolveOwnedRequestedZone = (
+  card: CardInstance,
+  requestedZone: string
+): string => {
+  const requestedPrefix = getZonePrefix(requestedZone);
+  if (!PRIVATE_ZONE_PREFIXES.has(requestedPrefix)) return requestedZone;
+  return `${requestedPrefix}-${card.owner}`;
 };
 
 export const resolveDrop = (
@@ -465,6 +577,7 @@ export const resolveDrop = (
   baseZonePrefix = getZonePrefix(targetZone);
 
   const isEnteringSafeZone = ['mainDeck', 'evolveDeck', 'hand', 'cemetery', 'banish'].includes(baseZonePrefix);
+  const shouldDetachAttachments = ATTACHMENT_BLOCKED_ZONE_PREFIXES.has(baseZonePrefix);
   const isReturningToDeck = baseZonePrefix === 'mainDeck' || baseZonePrefix === 'evolveDeck';
   const isEnteringHand = baseZonePrefix === 'hand';
   const isEnteringEx = baseZonePrefix === 'ex';
@@ -489,7 +602,7 @@ export const resolveDrop = (
       isTapped: isEnteringSafeZone || isEnteringEx ? false : activeCard.isTapped,
       counters: isEnteringHand ? { atk: 0, hp: 0 } : getCountersForMove(activeCard, targetZone),
       genericCounter: getGenericCounterForMove(activeCard, targetZone),
-      preserveAttachment: !isEnteringSafeZone,
+      preserveAttachment: !shouldDetachAttachments,
     },
   };
 };
@@ -613,7 +726,8 @@ const dissolveTokenStackIntoZone = (
   const movedNonTokenCards = cards
     .filter(card => stackIds.has(card.id) && !isTokenCard(card))
     .map(card => {
-      const destinationZone = resolveMoveDestination(card, requestedZone);
+      const ownedRequestedZone = resolveOwnedRequestedZone(card, requestedZone);
+      const destinationZone = resolveMoveDestination(card, ownedRequestedZone);
       return {
         ...card,
         zone: destinationZone,
@@ -628,7 +742,8 @@ const dissolveTokenStackIntoZone = (
   const movedLinkedCards = cards
     .filter(card => linkedChildIds.has(card.id) && !isTokenCard(card))
     .map(card => {
-      const destinationZone = resolveMoveDestination(card, requestedZone);
+      const ownedRequestedZone = resolveOwnedRequestedZone(card, requestedZone);
+      const destinationZone = resolveMoveDestination(card, ownedRequestedZone);
       return {
         ...card,
         zone: destinationZone,
@@ -775,7 +890,7 @@ export const extractCard = (
 
   const destinationPrefix = getZonePrefix(destinationZone);
   const isEnteringHand = destinationPrefix === 'hand';
-  const isEnteringSafeZone = ['mainDeck', 'evolveDeck', 'hand', 'cemetery', 'banish'].includes(destinationPrefix);
+  const shouldDetachAttachments = ATTACHMENT_BLOCKED_ZONE_PREFIXES.has(destinationPrefix);
 
   return moveCardToEnd(cards, cardId, {
     zone: destinationZone,
@@ -783,7 +898,7 @@ export const extractCard = (
     counters: isEnteringHand ? { atk: 0, hp: 0 } : getCountersForMove(targetCard, destinationZone),
     genericCounter: getGenericCounterForMove(targetCard, destinationZone),
     attachedTo: undefined,
-    preserveAttachment: !isEnteringSafeZone,
+    preserveAttachment: !shouldDetachAttachments,
   });
 };
 
@@ -990,7 +1105,7 @@ export const resolveTopDeckResults = (
  * Final guard to ensure state integrity.
  */
 export const applyStateWithGuards = (newState: CardInstance[]): CardInstance[] => {
-  const ids = new Set();
+  const ids = new Set<string>();
   const uniqueCards: CardInstance[] = [];
   
   for (const card of newState) {
@@ -1001,8 +1116,8 @@ export const applyStateWithGuards = (newState: CardInstance[]): CardInstance[] =
     ids.add(card.id);
     uniqueCards.push(card);
   }
-  
-  return uniqueCards;
+
+  return sanitizeCardRelations(uniqueCards);
 };
 
 export const normalizeCardsForGameState = (

--- a/src/utils/cardType.test.ts
+++ b/src/utils/cardType.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isMainDeckSpellCard, normalizeBaseCardType } from './cardType';
+import { isAdvanceKind, isMainDeckSpellCard, isPureEvolveCard, normalizeBaseCardType } from './cardType';
 
 describe('cardType', () => {
   it('normalizes known card kinds and Japanese fallback labels', () => {
@@ -20,5 +20,13 @@ describe('cardType', () => {
     expect(isMainDeckSpellCard({ baseCardType: 'spell' })).toBe(true);
     expect(isMainDeckSpellCard({ baseCardType: 'spell', isEvolveCard: true })).toBe(false);
     expect(isMainDeckSpellCard({ baseCardType: 'follower' })).toBe(false);
+  });
+
+  it('distinguishes advance cards from non-advance evolve cards', () => {
+    expect(isAdvanceKind('advance_follower')).toBe(true);
+    expect(isAdvanceKind('evolve_follower')).toBe(false);
+    expect(isPureEvolveCard({ isEvolveCard: true, cardKindNormalized: 'evolve_follower' })).toBe(true);
+    expect(isPureEvolveCard({ isEvolveCard: true, cardKindNormalized: 'advance_follower' })).toBe(false);
+    expect(isPureEvolveCard({ isEvolveCard: true })).toBe(true);
   });
 });

--- a/src/utils/cardType.ts
+++ b/src/utils/cardType.ts
@@ -15,7 +15,14 @@ export const normalizeBaseCardType = (value?: string | null): RuntimeBaseCardTyp
   return null;
 };
 
+export const isAdvanceKind = (cardKindNormalized?: string | null): boolean => (
+  Boolean(cardKindNormalized?.startsWith('advance_'))
+);
+
+export const isPureEvolveCard = (
+  card: { isEvolveCard?: boolean; cardKindNormalized?: string | null } | null | undefined
+): boolean => Boolean(card?.isEvolveCard && !isAdvanceKind(card.cardKindNormalized));
+
 export const isMainDeckSpellCard = (
   card: { isEvolveCard?: boolean; baseCardType?: RuntimeBaseCardType | null } | null | undefined
 ): boolean => Boolean(card && !card.isEvolveCard && card.baseCardType === 'spell');
-


### PR DESCRIPTION
細かい以下のバグを修正

- エボルヴカードの上に通常カードを重ねた異常な stack を墓地に送ると、メインデッキ側のカードが root の動きに引っ張られて表むきでメインデッキに入ってしまう挙動を修正。　stack を分解するのみにした
-  EX エリアにエボルヴデッキのカードが入るのを修正
- その他、バグの混入対策に、エリア移動の時に カードのつながりを明示的に切る基本るーるを追加 
-  - - - - - - - - - - - - - - - - - - - - - 