### PR TITLE
検索モーダルに、カード種別の集計情報を追加

### DIFF
--- a/src/components/CardSearchModal.test.tsx
+++ b/src/components/CardSearchModal.test.tsx
@@ -78,6 +78,60 @@ describe('CardSearchModal', () => {
     expect(screen.getByText('Add to EX Area')).toBeInTheDocument();
   });
 
+  it('shows card type counts only when searching the cemetery or main deck', () => {
+    const cards = [
+      createCard({ id: 'follower-1', zone: 'cemetery-host', baseCardType: 'follower' }),
+      createCard({ id: 'follower-2', zone: 'cemetery-host', baseCardType: 'follower' }),
+      createCard({ id: 'spell-1', zone: 'cemetery-host', baseCardType: 'spell' }),
+      createCard({ id: 'amulet-1', zone: 'cemetery-host', baseCardType: 'amulet' }),
+    ];
+    const { rerender } = render(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Cemetery"
+        zoneId="cemetery-host"
+        cards={cards}
+        onExtractCard={vi.fn()}
+        viewerRole="host"
+        allowHandExtraction={true}
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Cemetery (4)' })).toBeInTheDocument();
+    expect(screen.getByTestId('search-card-type-counts')).toHaveTextContent('Follower: 2 / Spell: 1 / Amulet: 1');
+
+    rerender(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Main Deck"
+        zoneId="mainDeck-host"
+        cards={cards}
+        onExtractCard={vi.fn()}
+        viewerRole="host"
+        allowHandExtraction={true}
+      />
+    );
+
+    expect(screen.getByTestId('search-card-type-counts')).toHaveTextContent('Follower: 2 / Spell: 1 / Amulet: 1');
+
+    rerender(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Evolve Deck"
+        zoneId="evolveDeck-host"
+        cards={cards}
+        onExtractCard={vi.fn()}
+        viewerRole="host"
+        allowHandExtraction={true}
+      />
+    );
+
+    expect(screen.queryByTestId('search-card-type-counts')).not.toBeInTheDocument();
+  });
+
   it('only allows face-down field set when searching the main deck during preparation', () => {
     render(
       <CardSearchModal

--- a/src/components/CardSearchModal.tsx
+++ b/src/components/CardSearchModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { CardInstance } from './Card';
 import type { PlayerRole } from '../types/game';
 import { formatAbilityText, type CardDetailLookup } from '../utils/cardDetails';
+import { normalizeBaseCardType, type RuntimeBaseCardType } from '../utils/cardType';
 import CardArtwork from './CardArtwork';
 import { useTranslation } from 'react-i18next';
 
@@ -19,6 +20,8 @@ interface CardSearchModalProps {
   allowHandExtraction?: boolean;
   readOnly?: boolean;
 }
+
+type SearchTypeCounts = Record<RuntimeBaseCardType, number>;
 
 const CardSearchModal: React.FC<CardSearchModalProps> = ({
   isOpen,
@@ -96,7 +99,26 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
   const isMainDeckSearch = sourceZonePrefix === 'mainDeck';
   const isPreparingMainDeckSearch = !allowHandExtraction && isMainDeckSearch;
   const isEvolveDeck = sourceZonePrefix === 'evolveDeck';
+  const shouldShowTypeCounts = sourceZonePrefix === 'cemetery' || sourceZonePrefix === 'mainDeck';
   const isPublicRecoveryZone = sourceZonePrefix === 'cemetery' || sourceZonePrefix === 'banish';
+  const searchTypeCounts = shouldShowTypeCounts
+    ? cards.reduce<SearchTypeCounts>((counts, card) => {
+      const cardDetail = cardDetailLookup[card.cardId];
+      const baseCardType = card.baseCardType
+        ?? normalizeBaseCardType(card.cardKindNormalized)
+        ?? normalizeBaseCardType(cardDetail?.cardKindNormalized)
+        ?? normalizeBaseCardType(cardDetail?.type);
+
+      if (baseCardType) {
+        counts[baseCardType] += 1;
+      }
+
+      return counts;
+    }, { follower: 0, spell: 0, amulet: 0 })
+    : null;
+  const searchTypeCountLabel = shouldShowTypeCounts
+    ? t('gameBoard.modals.search.typeCounts', searchTypeCounts ?? undefined)
+    : null;
   const actionRole = targetRole ?? viewerRole;
   const selectedCard = selectedCardId ? cards.find(card => card.id === selectedCardId) ?? null : null;
   const selectedCardDetail = selectedCard ? cardDetailLookup[selectedCard.cardId] : null;
@@ -139,8 +161,18 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
         position: 'relative'
       }}
     >
-        <div style={{ padding: '1.5rem', borderBottom: '1px solid var(--border-color)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <h2 className="Garamond" style={{ margin: 0 }}>{title} ({cards.length})</h2>
+        <div style={{ padding: '1.5rem', borderBottom: '1px solid var(--border-color)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '1rem' }}>
+          <div>
+            <h2 className="Garamond" style={{ margin: 0 }}>{title} ({cards.length})</h2>
+            {searchTypeCountLabel && (
+              <div
+                data-testid="search-card-type-counts"
+                style={{ marginTop: '0.35rem', color: 'var(--text-muted)', fontSize: '0.85rem', lineHeight: 1.4 }}
+              >
+                {searchTypeCountLabel}
+              </div>
+            )}
+          </div>
           <button
             onClick={onClose}
             style={{

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -621,6 +621,7 @@
         "setUsed": "Set USED",
         "setUnused": "Set UNUSED",
         "empty": "This zone is empty.",
+        "typeCounts": "Follower: {{follower}} / Spell: {{spell}} / Amulet: {{amulet}}",
         "stats": "Stats",
         "noDetailText": "No detailed text was found for this card."
       },

--- a/src/i18n/ja/translation.json
+++ b/src/i18n/ja/translation.json
@@ -574,6 +574,7 @@
         "setUsed": "使用済にする",
         "setUnused": "未使用にする",
         "empty": "このゾーンは空です",
+        "typeCounts": "フォロワー: {{follower}} / スペル: {{spell}} / アミュレット: {{amulet}}",
         "stats": "スタッツ",
         "noDetailText": "このカードの詳細テキストは見つかりませんでした。"
       },


### PR DESCRIPTION
墓地とデッキの検索で、カード種別ごとの内訳を見れるようにした