### PR TITLE
検索にソートを追加

### DIFF
--- a/src/components/CardSearchModal.test.tsx
+++ b/src/components/CardSearchModal.test.tsx
@@ -16,6 +16,11 @@ const createCard = (overrides: Partial<CardInstance> = {}): CardInstance => ({
   ...overrides,
 });
 
+const getRenderedCardOrder = (): string[] => {
+  const cardGrid = screen.getByTestId('search-card-grid');
+  return Array.from(cardGrid.querySelectorAll('img[alt]')).map((image) => image.getAttribute('alt') ?? '');
+};
+
 describe('CardSearchModal', () => {
   it('does not show hand or EX extraction buttons for evolve cards', () => {
     render(
@@ -130,6 +135,139 @@ describe('CardSearchModal', () => {
     );
 
     expect(screen.queryByTestId('search-card-type-counts')).not.toBeInTheDocument();
+  });
+
+  it('shows sort controls only for cemetery and banish searches', () => {
+    const { rerender } = render(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Cemetery"
+        zoneId="cemetery-host"
+        cards={[createCard({ zone: 'cemetery-host' })]}
+        onExtractCard={vi.fn()}
+        viewerRole="host"
+      />
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Sort cards' })).toBeInTheDocument();
+
+    rerender(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Banish"
+        zoneId="banish-host"
+        cards={[createCard({ zone: 'banish-host' })]}
+        onExtractCard={vi.fn()}
+        viewerRole="host"
+      />
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Sort cards' })).toBeInTheDocument();
+
+    rerender(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Main Deck"
+        zoneId="mainDeck-host"
+        cards={[createCard({ zone: 'mainDeck-host' })]}
+        onExtractCard={vi.fn()}
+        viewerRole="host"
+      />
+    );
+
+    expect(screen.queryByRole('combobox', { name: 'Sort cards' })).not.toBeInTheDocument();
+  });
+
+  it('sorts cemetery cards by added order, cost, and card type for display only', () => {
+    const cards = [
+      createCard({ id: 'card-1', cardId: 'BP01-003', name: 'Amulet 3', zone: 'cemetery-host', baseCardType: 'amulet' }),
+      createCard({ id: 'card-2', cardId: 'BP01-001', name: 'Spell 1', zone: 'cemetery-host', baseCardType: 'spell' }),
+      createCard({ id: 'card-3', cardId: 'BP01-002', name: 'Follower 2', zone: 'cemetery-host', baseCardType: 'follower' }),
+    ];
+
+    render(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Cemetery"
+        zoneId="cemetery-host"
+        cards={cards}
+        cardDetailLookup={{
+          'BP01-001': { id: 'BP01-001', name: 'Spell 1', image: '/spell.png', className: '', title: '', type: 'スペル', subtype: '', cost: '1', atk: null, hp: null, abilityText: '' },
+          'BP01-002': { id: 'BP01-002', name: 'Follower 2', image: '/follower.png', className: '', title: '', type: 'フォロワー', subtype: '', cost: '2', atk: 2, hp: 2, abilityText: '' },
+          'BP01-003': { id: 'BP01-003', name: 'Amulet 3', image: '/amulet.png', className: '', title: '', type: 'アミュレット', subtype: '', cost: '3', atk: null, hp: null, abilityText: '' },
+        }}
+        onExtractCard={vi.fn()}
+        viewerRole="host"
+      />
+    );
+
+    expect(getRenderedCardOrder()).toEqual(['Amulet 3', 'Spell 1', 'Follower 2']);
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Sort cards' }), { target: { value: 'cost' } });
+    expect(getRenderedCardOrder()).toEqual(['Spell 1', 'Follower 2', 'Amulet 3']);
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Sort cards' }), { target: { value: 'type' } });
+    expect(getRenderedCardOrder()).toEqual(['Follower 2', 'Spell 1', 'Amulet 3']);
+  });
+
+  it('groups same-name cards when sorting by cost', () => {
+    render(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Cemetery"
+        zoneId="cemetery-host"
+        cards={[
+          createCard({ id: 'card-1', cardId: 'BP01-001', name: 'Alpha', zone: 'cemetery-host', baseCardType: 'spell' }),
+          createCard({ id: 'card-2', cardId: 'BP01-002', name: 'Beta', zone: 'cemetery-host', baseCardType: 'follower' }),
+          createCard({ id: 'card-3', cardId: 'BP01-003', name: 'Alpha', zone: 'cemetery-host', baseCardType: 'amulet' }),
+          createCard({ id: 'card-4', cardId: 'BP01-004', name: 'Beta', zone: 'cemetery-host', baseCardType: 'spell' }),
+        ]}
+        cardDetailLookup={{
+          'BP01-001': { id: 'BP01-001', name: 'Alpha', image: '/alpha1.png', className: '', title: '', type: 'スペル', subtype: '', cost: '2', atk: null, hp: null, abilityText: '' },
+          'BP01-002': { id: 'BP01-002', name: 'Beta', image: '/beta1.png', className: '', title: '', type: 'フォロワー', subtype: '', cost: '2', atk: 2, hp: 2, abilityText: '' },
+          'BP01-003': { id: 'BP01-003', name: 'Alpha', image: '/alpha2.png', className: '', title: '', type: 'アミュレット', subtype: '', cost: '2', atk: null, hp: null, abilityText: '' },
+          'BP01-004': { id: 'BP01-004', name: 'Beta', image: '/beta2.png', className: '', title: '', type: 'スペル', subtype: '', cost: '2', atk: null, hp: null, abilityText: '' },
+        }}
+        onExtractCard={vi.fn()}
+        viewerRole="host"
+      />
+    );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Sort cards' }), { target: { value: 'cost' } });
+    expect(getRenderedCardOrder()).toEqual(['Alpha', 'Alpha', 'Beta', 'Beta']);
+  });
+
+  it('groups same-name cards when sorting by card type', () => {
+    render(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Cemetery"
+        zoneId="cemetery-host"
+        cards={[
+          createCard({ id: 'card-1', cardId: 'BP01-001', name: 'Sword', zone: 'cemetery-host', baseCardType: 'follower' }),
+          createCard({ id: 'card-2', cardId: 'BP01-002', name: 'Arrow', zone: 'cemetery-host', baseCardType: 'follower' }),
+          createCard({ id: 'card-3', cardId: 'BP01-003', name: 'Sword', zone: 'cemetery-host', baseCardType: 'follower' }),
+          createCard({ id: 'card-4', cardId: 'BP01-004', name: 'Arrow', zone: 'cemetery-host', baseCardType: 'follower' }),
+        ]}
+        cardDetailLookup={{
+          'BP01-001': { id: 'BP01-001', name: 'Sword', image: '/sword1.png', className: '', title: '', type: 'フォロワー', subtype: '', cost: '4', atk: 4, hp: 4, abilityText: '' },
+          'BP01-002': { id: 'BP01-002', name: 'Arrow', image: '/arrow1.png', className: '', title: '', type: 'フォロワー', subtype: '', cost: '1', atk: 1, hp: 1, abilityText: '' },
+          'BP01-003': { id: 'BP01-003', name: 'Sword', image: '/sword2.png', className: '', title: '', type: 'フォロワー', subtype: '', cost: '2', atk: 2, hp: 2, abilityText: '' },
+          'BP01-004': { id: 'BP01-004', name: 'Arrow', image: '/arrow2.png', className: '', title: '', type: 'フォロワー', subtype: '', cost: '3', atk: 3, hp: 3, abilityText: '' },
+        }}
+        onExtractCard={vi.fn()}
+        viewerRole="host"
+      />
+    );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Sort cards' }), { target: { value: 'type' } });
+    expect(getRenderedCardOrder()).toEqual(['Arrow', 'Arrow', 'Sword', 'Sword']);
   });
 
   it('only allows face-down field set when searching the main deck during preparation', () => {
@@ -521,6 +659,78 @@ describe('CardSearchModal', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Send to bottom of deck' }));
 
     expect(onSendCardsToBottom).toHaveBeenCalledWith(['card-1', 'card-2']);
+  });
+
+  it('keeps bulk selection and batch actions working after changing sort mode', () => {
+    const onSendCardsToBottom = vi.fn();
+
+    render(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Cemetery"
+        zoneId="cemetery-host"
+        cards={[
+          createCard({ id: 'card-1', cardId: 'BP01-003', name: 'Amulet 3', zone: 'cemetery-host', baseCardType: 'amulet' }),
+          createCard({ id: 'card-2', cardId: 'BP01-001', name: 'Spell 1', zone: 'cemetery-host', baseCardType: 'spell' }),
+          createCard({ id: 'card-3', cardId: 'BP01-002', name: 'Follower 2', zone: 'cemetery-host', baseCardType: 'follower' }),
+        ]}
+        cardDetailLookup={{
+          'BP01-001': { id: 'BP01-001', name: 'Spell 1', image: '/spell.png', className: '', title: '', type: 'スペル', subtype: '', cost: '1', atk: null, hp: null, abilityText: '' },
+          'BP01-002': { id: 'BP01-002', name: 'Follower 2', image: '/follower.png', className: '', title: '', type: 'フォロワー', subtype: '', cost: '2', atk: 2, hp: 2, abilityText: '' },
+          'BP01-003': { id: 'BP01-003', name: 'Amulet 3', image: '/amulet.png', className: '', title: '', type: 'アミュレット', subtype: '', cost: '3', atk: null, hp: null, abilityText: '' },
+        }}
+        onExtractCard={vi.fn()}
+        onSendCardsToBottom={onSendCardsToBottom}
+        viewerRole="host"
+      />
+    );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Sort cards' }), { target: { value: 'cost' } });
+    fireEvent.click(screen.getByText('Select Multiple'));
+    fireEvent.click(screen.getByAltText('Spell 1'));
+    fireEvent.click(screen.getByAltText('Follower 2'));
+    fireEvent.click(screen.getByRole('button', { name: 'Send to bottom of deck' }));
+
+    expect(onSendCardsToBottom).toHaveBeenCalledWith(['card-2', 'card-3']);
+  });
+
+  it('keeps selected cards and batch actions working when sort mode changes during bulk selection', () => {
+    const onSendCardsToBottom = vi.fn();
+
+    render(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Cemetery"
+        zoneId="cemetery-host"
+        cards={[
+          createCard({ id: 'card-1', cardId: 'BP01-003', name: 'Amulet 3', zone: 'cemetery-host', baseCardType: 'amulet' }),
+          createCard({ id: 'card-2', cardId: 'BP01-001', name: 'Spell 1', zone: 'cemetery-host', baseCardType: 'spell' }),
+          createCard({ id: 'card-3', cardId: 'BP01-002', name: 'Follower 2', zone: 'cemetery-host', baseCardType: 'follower' }),
+        ]}
+        cardDetailLookup={{
+          'BP01-001': { id: 'BP01-001', name: 'Spell 1', image: '/spell.png', className: '', title: '', type: 'スペル', subtype: '', cost: '1', atk: null, hp: null, abilityText: '' },
+          'BP01-002': { id: 'BP01-002', name: 'Follower 2', image: '/follower.png', className: '', title: '', type: 'フォロワー', subtype: '', cost: '2', atk: 2, hp: 2, abilityText: '' },
+          'BP01-003': { id: 'BP01-003', name: 'Amulet 3', image: '/amulet.png', className: '', title: '', type: 'アミュレット', subtype: '', cost: '3', atk: null, hp: null, abilityText: '' },
+        }}
+        onExtractCard={vi.fn()}
+        onSendCardsToBottom={onSendCardsToBottom}
+        viewerRole="host"
+      />
+    );
+
+    fireEvent.click(screen.getByText('Select Multiple'));
+    fireEvent.click(screen.getByAltText('Amulet 3'));
+    fireEvent.click(screen.getByAltText('Follower 2'));
+
+    expect(screen.getAllByText('2 selected')).toHaveLength(2);
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Sort cards' }), { target: { value: 'cost' } });
+    expect(screen.getAllByText('2 selected')).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send to bottom of deck' }));
+    expect(onSendCardsToBottom).toHaveBeenCalledWith(['card-1', 'card-3']);
   });
 
   it('sends a main-deck card to cemetery immediately', () => {

--- a/src/components/CardSearchModal.tsx
+++ b/src/components/CardSearchModal.tsx
@@ -29,6 +29,32 @@ interface CardSearchModalProps {
 }
 
 type SearchTypeCounts = Record<RuntimeBaseCardType, number>;
+type SearchSortMode = 'added' | 'cost' | 'type';
+type SearchTypeOrder = RuntimeBaseCardType | 'unknown';
+
+const parseSortCost = (cost?: string): number => {
+  if (!cost) return Number.MAX_SAFE_INTEGER;
+  const parsed = Number.parseInt(cost, 10);
+  return Number.isNaN(parsed) ? Number.MAX_SAFE_INTEGER : parsed;
+};
+
+const getSortTypeOrder = (baseCardType: RuntimeBaseCardType | null): SearchTypeOrder => {
+  if (baseCardType === 'follower' || baseCardType === 'spell' || baseCardType === 'amulet') {
+    return baseCardType;
+  }
+  return 'unknown';
+};
+
+const searchTypeRank: Record<SearchTypeOrder, number> = {
+  follower: 0,
+  spell: 1,
+  amulet: 2,
+  unknown: 3,
+};
+
+const compareCardName = (left: CardInstance, right: CardInstance): number => (
+  left.name.localeCompare(right.name, undefined, { sensitivity: 'base' })
+);
 
 const CardSearchModal: React.FC<CardSearchModalProps> = ({
   isOpen,
@@ -55,6 +81,7 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
   const [selectedCardId, setSelectedCardId] = React.useState<string | null>(null);
   const [isBulkSelecting, setIsBulkSelecting] = React.useState(false);
   const [bulkSelectedCardIds, setBulkSelectedCardIds] = React.useState<string[]>([]);
+  const [sortMode, setSortMode] = React.useState<SearchSortMode>('added');
   const [reserveDetailSpace, setReserveDetailSpace] = React.useState(false);
   const modalPanelRef = React.useRef<HTMLDivElement | null>(null);
   const detailPopoverRef = React.useRef<HTMLDivElement | null>(null);
@@ -65,6 +92,7 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
       setSelectedCardId(null);
       setIsBulkSelecting(false);
       setBulkSelectedCardIds([]);
+      setSortMode('added');
       return;
     }
 
@@ -115,8 +143,6 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
     return () => window.removeEventListener('resize', measureScrollRoom);
   }, [cards.length, isOpen, selectedCardId]);
 
-  if (!isOpen) return null;
-
   // Search behavior must key off the structural zone id, not the localized
   // modal title, otherwise i18n changes can alter which actions are allowed.
   const sourceZonePrefix = zoneId?.split('-')[0] ?? null;
@@ -125,7 +151,44 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
   const isEvolveDeck = sourceZonePrefix === 'evolveDeck';
   const shouldShowTypeCounts = sourceZonePrefix === 'cemetery' || sourceZonePrefix === 'mainDeck';
   const isPublicRecoveryZone = sourceZonePrefix === 'cemetery' || sourceZonePrefix === 'banish';
+  const canSortCards = sourceZonePrefix === 'cemetery' || sourceZonePrefix === 'banish';
   const supportsBulkSelection = !readOnly && (sourceZonePrefix === 'mainDeck' || sourceZonePrefix === 'cemetery' || sourceZonePrefix === 'banish');
+  const visibleCards = React.useMemo(() => {
+    if (!canSortCards || sortMode === 'added') return cards;
+
+    const indexedCards = cards.map((card, index) => ({ card, index }));
+    const getBaseType = (card: CardInstance) => {
+      const cardDetail = cardDetailLookup[card.cardId];
+      return card.baseCardType
+        ?? normalizeBaseCardType(card.cardKindNormalized)
+        ?? normalizeBaseCardType(cardDetail?.cardKindNormalized)
+        ?? normalizeBaseCardType(cardDetail?.type);
+    };
+
+    indexedCards.sort((left, right) => {
+      if (sortMode === 'cost') {
+        const leftCost = parseSortCost(cardDetailLookup[left.card.cardId]?.cost);
+        const rightCost = parseSortCost(cardDetailLookup[right.card.cardId]?.cost);
+        if (leftCost !== rightCost) return leftCost - rightCost;
+
+        const comparedName = compareCardName(left.card, right.card);
+        if (comparedName !== 0) return comparedName;
+      }
+
+      if (sortMode === 'type') {
+        const leftType = getSortTypeOrder(getBaseType(left.card));
+        const rightType = getSortTypeOrder(getBaseType(right.card));
+        if (leftType !== rightType) return searchTypeRank[leftType] - searchTypeRank[rightType];
+
+        const comparedName = compareCardName(left.card, right.card);
+        if (comparedName !== 0) return comparedName;
+      }
+
+      return left.index - right.index;
+    });
+
+    return indexedCards.map((entry) => entry.card);
+  }, [canSortCards, cardDetailLookup, cards, sortMode]);
   const searchTypeCounts = shouldShowTypeCounts
     ? cards.reduce<SearchTypeCounts>((counts, card) => {
       const cardDetail = cardDetailLookup[card.cardId];
@@ -205,6 +268,8 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
   const canBulkSendToBottom = selectedBulkCardCount > 0 && bulkSelectedCards.every(canSendCardToBottom);
   const canBulkSendToCemetery = selectedBulkCardCount > 0 && bulkSelectedCards.every(canSendCardToCemetery);
   const canBulkBanish = selectedBulkCardCount > 0 && bulkSelectedCards.every(canBanishCard);
+
+  if (!isOpen) return null;
 
   const handleBulkExtract = (destination?: string, revealToOpponent = false) => {
     if (bulkSelectedCardIds.length === 0) return;
@@ -321,7 +386,7 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
                       {selectedCountLabel}
                     </span>
                     <button
-                      onClick={() => setBulkSelectedCardIds(cards.map(card => card.id))}
+                      onClick={() => setBulkSelectedCardIds(visibleCards.map(card => card.id))}
                       style={{
                         background: 'rgba(255,255,255,0.05)',
                         border: '1px solid var(--border-color)',
@@ -375,6 +440,28 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
                 </button>
               </>
             )}
+            {canSortCards && (
+              <label style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4rem', color: 'var(--text-muted)', fontSize: '0.8rem' }}>
+                <span>{t('gameBoard.modals.search.sortLabel')}</span>
+                <select
+                  aria-label={t('gameBoard.modals.search.sortAria')}
+                  value={sortMode}
+                  onChange={(event) => setSortMode(event.target.value as SearchSortMode)}
+                  style={{
+                    background: 'rgba(255,255,255,0.05)',
+                    border: '1px solid var(--border-color)',
+                    color: 'white',
+                    padding: '0.45rem 0.5rem',
+                    borderRadius: '4px',
+                    cursor: 'pointer'
+                  }}
+                >
+                  <option value="added">{t('gameBoard.modals.search.sortOptions.added')}</option>
+                  <option value="cost">{t('gameBoard.modals.search.sortOptions.cost')}</option>
+                  <option value="type">{t('gameBoard.modals.search.sortOptions.type')}</option>
+                </select>
+              </label>
+            )}
             <button
               onClick={onClose}
               style={{
@@ -404,7 +491,7 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
             paddingBottom: selectedCard && reserveDetailSpace ? '11rem' : '1.5rem'
           }}
         >
-          {cards.map(c => {
+          {visibleCards.map(c => {
             const isUsed = isEvolveDeck && !c.isFlipped;
             const canAddToHand = canAddCardToHand(c);
             const canRevealToHand = canRevealCardToHand(c);

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -638,6 +638,13 @@
         "selectAll": "Select All",
         "clearSelection": "Clear",
         "bulkSelectedCount": "{{count}} selected",
+        "sortLabel": "Sort",
+        "sortAria": "Sort cards",
+        "sortOptions": {
+          "added": "Added Order",
+          "cost": "Cost",
+          "type": "Card Type"
+        },
         "addToHand": "Add to Hand",
         "revealAndAddToHand": "Reveal & Add to Hand",
         "addToEx": "Add to EX Area",

--- a/src/i18n/ja/translation.json
+++ b/src/i18n/ja/translation.json
@@ -584,6 +584,13 @@
         "selectAll": "すべて選択",
         "clearSelection": "解除",
         "bulkSelectedCount": "{{count}}枚選択中",
+        "sortLabel": "並び替え",
+        "sortAria": "カードを並び替え",
+        "sortOptions": {
+          "added": "追加順",
+          "cost": "コスト順",
+          "type": "カード種類順"
+        },
         "addToHand": "手札に加える",
         "revealAndAddToHand": "公開して手札に加える",
         "addToEx": "EXエリアに置く",


### PR DESCRIPTION
## 概要

墓地 / 消滅領域の `search` モーダルに、表示専用のソート機能を追加しました。  
実データ配列は変更せず、モーダル上の表示順のみ切り替わります。

## 変更内容

- `CardSearchModal` にソートモードを追加
- 対象ゾーンを `cemetery` / `banish` に限定
- ソート種別を追加
- `追加順`（デフォルト / 既存挙動）
- `コスト順`
- `カード種類順`（フォロワー → スペル → アミュレット）
- `コスト順` / `カード種類順` 時に同名カードがまとまるよう、比較キーに `name` を追加
- 同値時は元 index で安定化し、表示ブレを防止
- 複数選択中のソート変更でも選択が壊れないことを担保
- `Select All` を表示中順ベースに調整
- i18n文言を `en/ja` に追加（sort label / aria / options）

## 影響範囲

- `src/components/CardSearchModal.tsx`
- `src/components/CardSearchModal.test.tsx`
- `src/i18n/en/translation.json`
- `src/i18n/ja/translation.json`

## 仕様メモ

- デフォルト表示は既存と同じ `追加順`
- ソートは表示のみで、ゲーム状態のカード配列順には影響しない
- 操作は従来通り `cardId` 基準のため、移動・複数選択の整合性を維持

## テスト

- `npx vitest run src/components/CardSearchModal.test.tsx`
- `npm run lint`
- `npx tsc --noEmit -p tsconfig.app.json`
- `npx vitest run`
- `npm run build`
- `npm run test:e2e`

## 確認したこと

- 墓地/消滅のみソートUIが表示される
- 追加順・コスト順・カード種類順で期待通りに表示切替される
- コスト順/カード種類順で同名カードがまとまる
- 複数選択後にソート変更しても batch 操作が正しい `cardId` で実行される
