### PR TITLE
vercel analytics を有効

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@vercel/analytics": "^2.0.1",
         "i18next": "^25.8.20",
         "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^0.577.0",
@@ -1555,6 +1556,48 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@vercel/analytics": "^2.0.1",
     "i18next": "^25.8.20",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.577.0",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,23 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import App from './App';
+
+const analyticsMock = vi.hoisted(() => ({
+  props: [] as Array<{
+    beforeSend?: (event: { url: string }) => { url: string } | null;
+    debug?: boolean;
+  }>,
+}));
+
+vi.mock('@vercel/analytics/react', () => ({
+  Analytics: (props: {
+    beforeSend?: (event: { url: string }) => { url: string } | null;
+    debug?: boolean;
+  }) => {
+    analyticsMock.props.push(props);
+    return <div data-testid="vercel-analytics" />;
+  },
+}));
 
 vi.mock('./pages/Home', () => ({
   default: () => <div>Mock Home Page</div>,
@@ -39,6 +56,11 @@ vi.mock('./pages/GameBoard', () => ({
 }));
 
 describe('App', () => {
+  beforeEach(() => {
+    analyticsMock.props = [];
+    vi.unstubAllEnvs();
+  });
+
   it('renders the navigation shell and home route', () => {
     window.history.pushState({}, '', '/');
     render(<App />);
@@ -145,5 +167,30 @@ describe('App', () => {
     expect(screen.getByRole('listbox')).toBeInTheDocument();
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('does not render Vercel Analytics unless explicitly enabled for production', () => {
+    vi.stubEnv('PROD', true);
+    window.history.pushState({}, '', '/');
+    render(<App />);
+
+    expect(screen.queryByTestId('vercel-analytics')).not.toBeInTheDocument();
+    expect(analyticsMock.props).toHaveLength(0);
+  });
+
+  it('renders Vercel Analytics in enabled production builds with game URL redaction', () => {
+    vi.stubEnv('PROD', true);
+    vi.stubEnv('VITE_ENABLE_VERCEL_ANALYTICS', 'true');
+    window.history.pushState({}, '', '/');
+    render(<App />);
+
+    expect(screen.getByTestId('vercel-analytics')).toBeInTheDocument();
+    expect(analyticsMock.props).toHaveLength(1);
+    expect(analyticsMock.props[0]?.debug).toBe(false);
+    expect(analyticsMock.props[0]?.beforeSend?.({
+      url: 'https://example.com/game?host=true&room=ROOM123',
+    })).toEqual({
+      url: 'https://example.com/game',
+    });
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
+import { Analytics } from '@vercel/analytics/react';
 import { BrowserRouter, Routes, Route, Link, useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Home from './pages/Home';
 import DeckBuilder from './pages/DeckBuilder';
 import GameBoard from './pages/GameBoard';
 import { generateRoomCode } from './utils/roomCode';
+import {
+  redactVercelAnalyticsEvent,
+  shouldEnableVercelAnalytics,
+} from './utils/vercelAnalytics';
 
 const navLinkStyle: React.CSSProperties = {
   color: 'var(--text-main)',
@@ -342,6 +347,10 @@ function App() {
           <Route path="/game" element={<GameBoard />} />
         </Routes>
       </main>
+
+      {shouldEnableVercelAnalytics(import.meta.env) && (
+        <Analytics beforeSend={redactVercelAnalyticsEvent} debug={false} />
+      )}
     </BrowserRouter>
   );
 }

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,7 +1,9 @@
 declare const __APP_VERSION__: string
 
 interface ImportMetaEnv {
+  readonly PROD: boolean
   readonly VITE_CARD_ART_MODE?: 'official' | 'dummy'
+  readonly VITE_ENABLE_VERCEL_ANALYTICS?: string
 }
 
 interface ImportMeta {

--- a/src/utils/vercelAnalytics.test.ts
+++ b/src/utils/vercelAnalytics.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  redactVercelAnalyticsEvent,
+  shouldEnableVercelAnalytics,
+} from './vercelAnalytics';
+
+describe('vercelAnalytics', () => {
+  it('enables analytics only for production builds with the explicit Vercel flag', () => {
+    expect(shouldEnableVercelAnalytics({
+      PROD: true,
+      VITE_ENABLE_VERCEL_ANALYTICS: 'true',
+    })).toBe(true);
+
+    expect(shouldEnableVercelAnalytics({
+      PROD: false,
+      VITE_ENABLE_VERCEL_ANALYTICS: 'true',
+    })).toBe(false);
+
+    expect(shouldEnableVercelAnalytics({
+      PROD: true,
+      VITE_ENABLE_VERCEL_ANALYTICS: undefined,
+    })).toBe(false);
+  });
+
+  it('redacts game room query parameters from analytics URLs', () => {
+    const event = redactVercelAnalyticsEvent({
+      url: 'https://example.com/game?host=true&room=ROOM123',
+      referrer: 'https://example.com/',
+    });
+
+    expect(event).toEqual({
+      url: 'https://example.com/game',
+      referrer: 'https://example.com/',
+    });
+  });
+
+  it('keeps non-game analytics URLs intact', () => {
+    const event = redactVercelAnalyticsEvent({
+      url: 'https://example.com/deck-builder?search=dragon',
+    });
+
+    expect(event.url).toBe('https://example.com/deck-builder?search=dragon');
+  });
+});

--- a/src/utils/vercelAnalytics.ts
+++ b/src/utils/vercelAnalytics.ts
@@ -1,0 +1,32 @@
+type VercelAnalyticsEnv = {
+  PROD?: boolean;
+  VITE_ENABLE_VERCEL_ANALYTICS?: string;
+};
+
+type VercelAnalyticsEvent = {
+  url: string;
+};
+
+export const shouldEnableVercelAnalytics = (env: VercelAnalyticsEnv) => {
+  return env.PROD === true && env.VITE_ENABLE_VERCEL_ANALYTICS === 'true';
+};
+
+export const redactVercelAnalyticsEvent = <TEvent extends VercelAnalyticsEvent>(
+  event: TEvent,
+) => {
+  try {
+    const url = new URL(event.url);
+
+    if (url.pathname === '/game') {
+      url.search = '';
+      url.hash = '';
+    }
+
+    return {
+      ...event,
+      url: url.toString(),
+    };
+  } catch {
+    return event;
+  }
+};


### PR DESCRIPTION
## 概要

Vercel Web Analytics を導入します。

ただし既存動作への影響を避けるため、Analytics は以下の条件を満たす場合のみ有効化されます。

- production build であること
- `VITE_ENABLE_VERCEL_ANALYTICS=true` が設定されていること

そのため、今回のリリースをそのまま Vercel にデプロイしても、環境変数を設定しない限り Analytics は有効化されません。

## 変更内容

- `@vercel/analytics` を依存に追加
- App ルートに Vercel Analytics を条件付きで追加
- `/game` ページの Analytics URL 送信前 redaction を追加
  - `/game?host=true&room=...`
  - `/game?host=false&room=...`
  - `/game?spectator=true&room=...`
  - これらは Analytics 送信時に `/game` として扱う
- Analytics 有効化条件と URL redaction のテストを追加
- `ImportMetaEnv` に `PROD` / `VITE_ENABLE_VERCEL_ANALYTICS` の型を追加

## 既存動作への影響

通常のローカル開発、既存の production build、他ホスティングへのデプロイでは、`VITE_ENABLE_VERCEL_ANALYTICS=true` を設定しない限り Analytics は描画されません。

有効化された場合も、Analytics コンポーネントは UI を持たず、ゲームロジック、P2P 接続、ルーティング操作、デッキビルダーの挙動には関与しません。

## 有効化方法

Vercel で Analytics を使う場合は、Vercel Dashboard 側で以下を設定します。

1. Project の Web Analytics を Enable
2. Production 環境変数に `VITE_ENABLE_VERCEL_ANALYTICS=true` を追加
3. 再デプロイ

## テスト

- [x] `npx vitest run src/utils/vercelAnalytics.test.ts src/App.test.tsx`
- [x] `npm run lint`
- [x] `npx tsc --noEmit -p tsconfig.app.json`
- [x] `npx vitest run`
- [x] `npm run build`
- [x] `git diff --check`

## 補足

`npm install` 時に `npm audit` の警告が表示されていますが、今回追加した `@vercel/analytics` 自体ではなく、既存の開発ツール系依存である `vite` / `picomatch` / `brace-expansion` に関する警告です。

この修正は次回リリースで別途対応予定です。
