### PR TITLE
analytics に game のモードの出しわけを追加

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -190,7 +190,7 @@ describe('App', () => {
     expect(analyticsMock.props[0]?.beforeSend?.({
       url: 'https://example.com/game?host=true&room=ROOM123',
     })).toEqual({
-      url: 'https://example.com/game',
+      url: 'https://example.com/game/p2p-host',
     });
   });
 });

--- a/src/utils/vercelAnalytics.test.ts
+++ b/src/utils/vercelAnalytics.test.ts
@@ -22,14 +22,20 @@ describe('vercelAnalytics', () => {
     })).toBe(false);
   });
 
-  it('redacts game room query parameters from analytics URLs', () => {
+  it.each([
+    ['solo mode', 'https://example.com/game?mode=solo&room=ROOM123', 'https://example.com/game/solo'],
+    ['P2P host', 'https://example.com/game?host=true&room=ROOM123', 'https://example.com/game/p2p-host'],
+    ['P2P guest', 'https://example.com/game?host=false&room=ROOM123', 'https://example.com/game/p2p-guest'],
+    ['spectator', 'https://example.com/game?spectator=true&room=ROOM123', 'https://example.com/game/spectator'],
+    ['unknown game mode', 'https://example.com/game?room=ROOM123', 'https://example.com/game'],
+  ])('redacts game room query parameters while preserving the safe %s bucket', (_, inputUrl, expectedUrl) => {
     const event = redactVercelAnalyticsEvent({
-      url: 'https://example.com/game?host=true&room=ROOM123',
+      url: inputUrl,
       referrer: 'https://example.com/',
     });
 
     expect(event).toEqual({
-      url: 'https://example.com/game',
+      url: expectedUrl,
       referrer: 'https://example.com/',
     });
   });

--- a/src/utils/vercelAnalytics.ts
+++ b/src/utils/vercelAnalytics.ts
@@ -11,6 +11,15 @@ export const shouldEnableVercelAnalytics = (env: VercelAnalyticsEnv) => {
   return env.PROD === true && env.VITE_ENABLE_VERCEL_ANALYTICS === 'true';
 };
 
+const getSafeGameAnalyticsPath = (url: URL) => {
+  if (url.searchParams.get('mode') === 'solo') return '/game/solo';
+  if (url.searchParams.get('spectator') === 'true') return '/game/spectator';
+  if (url.searchParams.get('host') === 'true') return '/game/p2p-host';
+  if (url.searchParams.get('host') === 'false') return '/game/p2p-guest';
+
+  return '/game';
+};
+
 export const redactVercelAnalyticsEvent = <TEvent extends VercelAnalyticsEvent>(
   event: TEvent,
 ) => {
@@ -18,6 +27,7 @@ export const redactVercelAnalyticsEvent = <TEvent extends VercelAnalyticsEvent>(
     const url = new URL(event.url);
 
     if (url.pathname === '/game') {
+      url.pathname = getSafeGameAnalyticsPath(url);
       url.search = '';
       url.hash = '';
     }


### PR DESCRIPTION
## 概要

Vercel Web Analytics を導入します。

既存動作への影響を避けるため、Analytics は以下の条件を満たす場合のみ有効化されます。

- production build であること
- `VITE_ENABLE_VERCEL_ANALYTICS=true` が設定されていること

そのため、今回のリリースをそのまま Vercel にデプロイしても、環境変数を設定しない限り Analytics は有効化されません。

## 変更内容

- `@vercel/analytics` を依存に追加
- App ルートに Vercel Analytics を条件付きで追加
- Analytics 有効化条件を追加
  - `import.meta.env.PROD === true`
  - `VITE_ENABLE_VERCEL_ANALYTICS === 'true'`
- `/game` ページの Analytics URL redaction を追加
  - ルームコードやクエリ文字列は送信しない
  - 利用モードだけを安全な URL bucket に分類する

## `/game` の Analytics 分類

Analytics 送信時のみ、以下のように URL を変換します。

```text
/game?mode=solo&room=...       -> /game/solo
/game?host=true&room=...       -> /game/p2p-host
/game?host=false&room=...      -> /game/p2p-guest
/game?spectator=true&room=...  -> /game/spectator
/game?room=...                 -> /game
