### PR TITLE
クレスト対応

### DIFF
--- a/card_metadata.py
+++ b/card_metadata.py
@@ -13,6 +13,7 @@ CARD_KIND_BY_TYPE = {
     "スペル・トークン": "token_spell",
     "アミュレット・トークン": "token_amulet",
     "イクイップメント・トークン": "token_equipment",
+    "クレスト・トークン": "token_crest",
     "フォロワー・アドバンス": "advance_follower",
     "スペル・アドバンス": "advance_spell",
     "アミュレット・アドバンス": "advance_amulet",
@@ -35,6 +36,7 @@ DECK_SECTION_BY_CARD_KIND = {
     "token_spell": "token",
     "token_amulet": "token",
     "token_equipment": "token",
+    "token_crest": "token",
     "ep": "neither",
     "sep": "neither",
 }

--- a/card_metadata_test.py
+++ b/card_metadata_test.py
@@ -92,6 +92,14 @@ class CardMetadataTest(unittest.TestCase):
             is_deck_build_legal=True,
         )
         self.assertDerived(
+            "クレスト・トークン",
+            card_kind_normalized="token_crest",
+            deck_section="token",
+            is_token=True,
+            is_evolve_card=False,
+            is_deck_build_legal=True,
+        )
+        self.assertDerived(
             "SEP",
             card_kind_normalized="sep",
             deck_section="neither",

--- a/src/components/CardArtwork.test.tsx
+++ b/src/components/CardArtwork.test.tsx
@@ -115,6 +115,27 @@ describe('CardArtwork', () => {
     expect(screen.getByText('EQUIPMENT')).toBeInTheDocument();
   });
 
+  it('shows crest tokens as TOKEN without equipment styling', () => {
+    render(
+      <CardArtwork
+        image="/test.png"
+        alt="Crest Token"
+        isTokenCard={true}
+        detail={{
+          name: 'Crest Token',
+          cost: '-',
+          atk: null,
+          hp: null,
+          type: 'クレスト・トークン',
+          cardKindNormalized: 'token_crest',
+        }}
+      />
+    );
+
+    expect(screen.getAllByText('TOKEN')).toHaveLength(2);
+    expect(screen.queryByText('EQUIPMENT')).not.toBeInTheDocument();
+  });
+
   it('renders the dummy card back when requested', () => {
     render(
       <CardArtwork

--- a/src/components/CardSearchModal.test.tsx
+++ b/src/components/CardSearchModal.test.tsx
@@ -89,6 +89,7 @@ describe('CardSearchModal', () => {
       createCard({ id: 'follower-2', zone: 'cemetery-host', baseCardType: 'follower' }),
       createCard({ id: 'spell-1', zone: 'cemetery-host', baseCardType: 'spell' }),
       createCard({ id: 'amulet-1', zone: 'cemetery-host', baseCardType: 'amulet' }),
+      createCard({ id: 'crest-1', zone: 'cemetery-host', cardKindNormalized: 'token_crest', isTokenCard: true }),
     ];
     const { rerender } = render(
       <CardSearchModal
@@ -103,7 +104,7 @@ describe('CardSearchModal', () => {
       />
     );
 
-    expect(screen.getByRole('heading', { name: 'Cemetery (4)' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Cemetery (5)' })).toBeInTheDocument();
     expect(screen.getByTestId('search-card-type-counts')).toHaveTextContent('Follower: 2 / Spell: 1 / Amulet: 1');
 
     rerender(

--- a/src/models/cardClassification.test.ts
+++ b/src/models/cardClassification.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getBaseCardType } from './cardClassification';
+import { CARD_KIND_NORMALIZED_VALUES, getBaseCardType } from './cardClassification';
 
 describe('cardClassification helpers', () => {
   it('maps current normalized kinds to their base card type', () => {
@@ -8,6 +8,11 @@ describe('cardClassification helpers', () => {
     expect(getBaseCardType('advance_spell')).toBe('spell');
     expect(getBaseCardType('token_amulet')).toBe('amulet');
     expect(getBaseCardType('token_equipment')).toBe('amulet');
+  });
+
+  it('recognizes crest as a token-only kind without a base card type', () => {
+    expect(CARD_KIND_NORMALIZED_VALUES).toContain('token_crest');
+    expect(getBaseCardType('token_crest')).toBeNull();
   });
 
   it('handles future amulet variants without changing the deckbuilder filter', () => {

--- a/src/models/cardClassification.ts
+++ b/src/models/cardClassification.ts
@@ -10,6 +10,7 @@ export const CARD_KIND_NORMALIZED_VALUES = [
   'token_spell',
   'token_amulet',
   'token_equipment',
+  'token_crest',
   'advance_follower',
   'advance_spell',
   'advance_amulet',

--- a/src/utils/cardType.test.ts
+++ b/src/utils/cardType.test.ts
@@ -12,6 +12,7 @@ describe('cardType', () => {
     expect(normalizeBaseCardType()).toBeNull();
     expect(normalizeBaseCardType(null)).toBeNull();
     expect(normalizeBaseCardType('leader')).toBeNull();
+    expect(normalizeBaseCardType('token_crest')).toBeNull();
   });
 
   it('detects only non-evolve spell cards as main-deck spells', () => {

--- a/src/utils/deckBuilderCatalog.test.ts
+++ b/src/utils/deckBuilderCatalog.test.ts
@@ -76,6 +76,21 @@ const mockCards: DeckBuilderCardData[] = [
     deck_section: 'token',
     is_token: true,
   },
+  {
+    id: 'TK01-020',
+    name: 'Crest Token',
+    image: '/crest.png',
+    cost: '-',
+    class: '-',
+    title: 'Hero Tale',
+    type: 'クレスト・トークン',
+    subtype: '-',
+    rarity: 'PR',
+    product_name: 'Token Pack',
+    card_kind_normalized: 'token_crest',
+    deck_section: 'token',
+    is_token: true,
+  },
 ];
 
 describe('deckBuilderCatalog', () => {
@@ -103,6 +118,48 @@ describe('deckBuilderCatalog', () => {
     expect(view.totalPages).toBe(1);
   });
 
+  it('shows crest tokens in the token section without treating them as an amulet filter match', () => {
+    const tokenSectionView = buildDeckBuilderCatalogView(mockCards, {
+      ...createDefaultDeckRuleConfig(),
+      format: 'other',
+    }, {
+      search: 'crest',
+      costFilter: 'All',
+      expansionFilter: 'All',
+      classFilter: 'All',
+      cardTypeFilter: 'All',
+      rarityFilter: 'All',
+      productNameFilter: 'All',
+      selectedSubtypeTags: [],
+      deckSectionFilter: 'token',
+      hideSameNameVariants: false,
+      page: 0,
+      pageSize: 50,
+    });
+
+    expect(tokenSectionView.filteredCards.map(card => card.id)).toEqual(['TK01-020']);
+
+    const amuletFilterView = buildDeckBuilderCatalogView(mockCards, {
+      ...createDefaultDeckRuleConfig(),
+      format: 'other',
+    }, {
+      search: 'crest',
+      costFilter: 'All',
+      expansionFilter: 'All',
+      classFilter: 'All',
+      cardTypeFilter: 'amulet',
+      rarityFilter: 'All',
+      productNameFilter: 'All',
+      selectedSubtypeTags: [],
+      deckSectionFilter: 'token',
+      hideSameNameVariants: false,
+      page: 0,
+      pageSize: 50,
+    });
+
+    expect(amuletFilterView.filteredCards).toEqual([]);
+  });
+
   it('applies rule filtering, dedupe, and pagination for the card catalog', () => {
     const view = buildDeckBuilderCatalogView(mockCards, {
       ...createDefaultDeckRuleConfig(),
@@ -122,8 +179,8 @@ describe('deckBuilderCatalog', () => {
       pageSize: 2,
     });
 
-    expect(view.filteredCards.map(card => card.id)).toEqual(['BP01-001', 'BP01-002', 'LDR01-001', 'TK01-001']);
-    expect(view.displayCards.map(card => card.id)).toEqual(['BP01-001', 'LDR01-001', 'TK01-001']);
+    expect(view.filteredCards.map(card => card.id)).toEqual(['BP01-001', 'BP01-002', 'LDR01-001', 'TK01-001', 'TK01-020']);
+    expect(view.displayCards.map(card => card.id)).toEqual(['BP01-001', 'LDR01-001', 'TK01-001', 'TK01-020']);
     expect(view.paginatedCards.map(card => card.id)).toEqual(['BP01-001', 'LDR01-001']);
     expect(view.totalPages).toBe(2);
   });

--- a/src/utils/deckBuilderDisplay.test.ts
+++ b/src/utils/deckBuilderDisplay.test.ts
@@ -76,6 +76,7 @@ describe('deckBuilderDisplay', () => {
       { card: makeCard({ id: 'spell-1', card_kind_normalized: 'spell' }), count: 2 },
       { card: makeCard({ id: 'amulet-1', card_kind_normalized: 'amulet' }), count: 1 },
       { card: makeCard({ id: 'unknown-1', card_kind_normalized: 'leader' }), count: 4 },
+      { card: makeCard({ id: 'crest-1', card_kind_normalized: 'token_crest' }), count: 5 },
     ])).toEqual({
       follower: 3,
       spell: 2,

--- a/src/utils/deckBuilderRules.test.ts
+++ b/src/utils/deckBuilderRules.test.ts
@@ -174,6 +174,18 @@ const tokenCard: DeckBuilderCardData = {
   is_deck_build_legal: true,
 };
 
+const crestTokenCard: DeckBuilderCardData = {
+  id: 'TK01-020',
+  name: 'Crest Token',
+  image: '/crest.png',
+  class: '-',
+  type: 'クレスト・トークン',
+  card_kind_normalized: 'token_crest',
+  is_token: true,
+  is_evolve_card: false,
+  is_deck_build_legal: true,
+};
+
 const royalLeaderCard: DeckBuilderCardData = {
   id: 'LDR01-001',
   name: 'Royal Leader',
@@ -336,6 +348,7 @@ describe('deckBuilderRules', () => {
     expect(getAllowedSections(advanceAmuletCard)).toEqual(['evolve']);
     expect(getAllowedSections(royalLeaderCard)).toEqual(['leader']);
     expect(getAllowedSections(tokenCard)).toEqual(['token']);
+    expect(getAllowedSections(crestTokenCard)).toEqual(['token']);
   });
 
   it('accepts cards only in their legal deck section', () => {
@@ -346,6 +359,8 @@ describe('deckBuilderRules', () => {
     expect(canAddCardToSection(evolveCard, 'main')).toBe(false);
     expect(canAddCardToSection(royalLeaderCard, 'leader')).toBe(true);
     expect(canAddCardToSection(tokenCard, 'main')).toBe(false);
+    expect(canAddCardToSection(crestTokenCard, 'token')).toBe(true);
+    expect(canAddCardToSection(crestTokenCard, 'main')).toBe(false);
   });
 
   it('prevents adding more than three effective copies per main or evolve deck', () => {

--- a/src/utils/deckBuilderRules.ts
+++ b/src/utils/deckBuilderRules.ts
@@ -50,6 +50,7 @@ const TYPE_TO_CARD_KIND: Record<string, CardKindNormalized> = {
   'スペル・トークン': 'token_spell',
   'アミュレット・トークン': 'token_amulet',
   'イクイップメント・トークン': 'token_equipment',
+  'クレスト・トークン': 'token_crest',
   'フォロワー・アドバンス': 'advance_follower',
   'スペル・アドバンス': 'advance_spell',
   'アミュレット・アドバンス': 'advance_amulet',
@@ -72,6 +73,7 @@ const CARD_KIND_TO_DECK_SECTION: Record<CardKindNormalized, DeckSection> = {
   token_spell: 'token',
   token_amulet: 'token',
   token_equipment: 'token',
+  token_crest: 'token',
   ep: 'neither',
   sep: 'neither',
 };

--- a/src/utils/decklogImport.test.ts
+++ b/src/utils/decklogImport.test.ts
@@ -208,6 +208,42 @@ describe('convertDeckLogResponse', () => {
     expect(result.missingCardIds).toEqual([]);
   });
 
+  it('resolves crest token fallbacks without treating same-name non-crest cards as matches', () => {
+    const fallbackCards: DeckBuilderCardData[] = [
+      {
+        id: 'BP20-001',
+        name: 'Crest Sigil',
+        image: '/crest-amulet.png',
+        class: 'エルフ',
+        type: 'アミュレット',
+        card_kind_normalized: 'amulet',
+        deck_section: 'main',
+      },
+      {
+        id: 'TK20-001',
+        name: 'Crest Sigil',
+        image: '/crest-token.png',
+        class: '-',
+        type: 'クレスト・トークン',
+        card_kind_normalized: 'token_crest',
+        deck_section: 'token',
+        is_token: true,
+      },
+    ];
+
+    const result = convertDeckLogResponse({
+      id: 1,
+      title: 'Crest Fallback Deck',
+      game_title_id: 6,
+      list: [
+        { card_number: 'PR-777', name: 'Crest Sigil', num: 1, card_kind: '・クレスト・トークン・' },
+      ],
+    }, fallbackCards);
+
+    expect(result.deckState.mainDeck.map(card => card.id)).toEqual(['TK20-001']);
+    expect(result.missingCardIds).toEqual([]);
+  });
+
   it('collects missing card ids', () => {
     const result = convertDeckLogResponse({
       id: 1,

--- a/src/utils/decklogImport.ts
+++ b/src/utils/decklogImport.ts
@@ -92,6 +92,7 @@ const DECKLOG_TYPE_TO_CARD_KIND: Record<string, CardKindNormalized> = {
   'スペル・トークン': 'token_spell',
   'アミュレット・トークン': 'token_amulet',
   'イクイップメント・トークン': 'token_equipment',
+  'クレスト・トークン': 'token_crest',
   'フォロワー・アドバンス': 'advance_follower',
   'スペル・アドバンス': 'advance_spell',
   'アミュレット・アドバンス': 'advance_amulet',

--- a/src/utils/gameBoardCatalog.test.ts
+++ b/src/utils/gameBoardCatalog.test.ts
@@ -44,6 +44,15 @@ describe('buildGameBoardCatalogResources', () => {
         card_kind_normalized: 'token_equipment',
         type: 'Amulet',
       },
+      {
+        id: 'crest-token',
+        name: 'Crest Token',
+        title: 'Test Title',
+        image: '/crest.png',
+        deck_section: 'token',
+        card_kind_normalized: 'token_crest',
+        type: 'クレスト・トークン',
+      },
     ];
 
     const resources = buildGameBoardCatalogResources(cards);
@@ -55,5 +64,6 @@ describe('buildGameBoardCatalogResources', () => {
     expect(resources.fieldLinkAutoAttachResolver).not.toBeNull();
     expect(resources.fieldLinkCardIds.has('field-link')).toBe(true);
     expect(resources.tokenEquipmentCardIds.has('token-equipment')).toBe(true);
+    expect(resources.tokenEquipmentCardIds.has('crest-token')).toBe(false);
   });
 });

--- a/src/utils/gameBoardDeckActions.test.ts
+++ b/src/utils/gameBoardDeckActions.test.ts
@@ -29,6 +29,7 @@ describe('gameBoardDeckActions', () => {
       tokenDeck: [
         { id: 'token-1', name: 'Token A', image: '/token-a.png', deck_section: 'token', card_kind_normalized: 'token' },
         { id: 'token-1', name: 'Token A', image: '/token-a.png', deck_section: 'token', card_kind_normalized: 'token' },
+        { id: 'crest-1', name: 'Crest Token', image: '/crest.png', deck_section: 'token', card_kind_normalized: 'token_crest' },
       ],
     }, 'host', createId);
 
@@ -48,6 +49,13 @@ describe('gameBoardDeckActions', () => {
         image: '/token-a.png',
         baseCardType: null,
         cardKindNormalized: 'token',
+      },
+      {
+        cardId: 'crest-1',
+        name: 'Crest Token',
+        image: '/crest.png',
+        baseCardType: null,
+        cardKindNormalized: 'token_crest',
       },
     ]);
   });
@@ -134,5 +142,24 @@ describe('gameBoardDeckActions', () => {
     expect(tokens).toHaveLength(3);
     expect(tokens.map((token) => token.id)).toEqual(['token-1', 'token-2', 'token-3']);
     expect(tokens.every((token) => token.zone === 'ex-guest')).toBe(true);
+  });
+
+  it('spawns crest tokens as token cards without a runtime base card type', () => {
+    const token = buildSpawnTokenInstance('host', {
+      cardId: 'crest-1',
+      name: 'Crest Token',
+      image: '/crest.png',
+      baseCardType: null,
+      cardKindNormalized: 'token_crest',
+    }, 'ex', () => 'crest-token-id');
+
+    expect(token).toMatchObject({
+      id: 'crest-token-id',
+      cardId: 'crest-1',
+      zone: 'ex-host',
+      isTokenCard: true,
+      baseCardType: null,
+      cardKindNormalized: 'token_crest',
+    });
   });
 });

--- a/src/utils/gameBoardManualLink.test.ts
+++ b/src/utils/gameBoardManualLink.test.ts
@@ -41,6 +41,7 @@ describe('gameBoardManualLink', () => {
       const catalogIds = new Set(['CATALOG-EQUIPMENT']);
 
       expect(isTokenEquipmentCard(buildCard({ cardKindNormalized: 'token_equipment' }), new Set())).toBe(true);
+      expect(isTokenEquipmentCard(buildCard({ cardKindNormalized: 'token_crest' }), new Set())).toBe(false);
       expect(isTokenEquipmentCard(buildCard({ cardId: 'CATALOG-EQUIPMENT' }), catalogIds)).toBe(true);
       expect(isTokenEquipmentCard(buildCard({ cardId: 'OTHER' }), catalogIds)).toBe(false);
       expect(isTokenEquipmentCard(undefined, catalogIds)).toBe(false);


### PR DESCRIPTION
## Summary

クレストカード追加に備えて、`クレスト・トークン` を新しい token 専用カード種別として扱えるようにしました。

- `クレスト・トークン` を `token_crest` に分類
- `token_crest` を Token Deck 所属として扱う
- Game Board の token import/spawn 経路で `token_crest` を保持
- DeckLog import のカード種類解決に `クレスト・トークン` を追加
- `token_crest` が `token_equipment` と同じ装備リンク処理に乗らないことをテストで固定
- `token_crest` が follower/spell/amulet の type filter や type count に混ざらないことをテストで固定

## Behavior Notes

既存カードの分類や既存フローは変更していません。

`token_crest` は以下の扱いです。

- `deck_section: token`
- `is_token: true`
- `is_evolve_card: false`
- `baseCardType: null`
- equipment リンク対象外
- amulet 扱いではない

そのため、既存の `token_equipment` の装備リンク挙動や、既存の follower/spell/amulet のフィルタ・集計には影響しません。

## Tests

- `python3 -m unittest card_metadata_test.py`
- `npm run lint`
- `npx tsc --noEmit -p tsconfig.app.json`
- `npx vitest run`
- `npm run build`

## Manual Verification

未実施です。

今回の変更は分類、Deck Builder ルール、DeckLog import、Game Board token payload のロジックとテスト追加が中心で、ブラウザ操作やレイアウトの変更はありません。
