### PR TITLE
equipment の扱いを修正

### DIFF
--- a/src/components/Card.test.tsx
+++ b/src/components/Card.test.tsx
@@ -355,7 +355,7 @@ describe('Card', () => {
 
     rerender(
       <Card
-        card={createCard({ zone: 'ex-host', counters: { atk: 0, hp: 0 }, baseCardType: 'amulet', isTokenCard: true })}
+        card={createCard({ zone: 'ex-host', counters: { atk: 0, hp: 0 }, baseCardType: null, cardKindNormalized: 'token_equipment', isTokenCard: true })}
         onPlayToField={onPlayToField}
       />
     );

--- a/src/components/CardArtwork.test.tsx
+++ b/src/components/CardArtwork.test.tsx
@@ -99,7 +99,7 @@ describe('CardArtwork', () => {
         image="/test.png"
         alt="Token Equipment"
         isTokenCard={true}
-        baseCardType="amulet"
+        baseCardType={null}
         detail={{
           name: 'Token Equipment',
           cost: '1',

--- a/src/models/cardClassification.test.ts
+++ b/src/models/cardClassification.test.ts
@@ -7,7 +7,10 @@ describe('cardClassification helpers', () => {
     expect(getBaseCardType('evolve_follower')).toBe('follower');
     expect(getBaseCardType('advance_spell')).toBe('spell');
     expect(getBaseCardType('token_amulet')).toBe('amulet');
-    expect(getBaseCardType('token_equipment')).toBe('amulet');
+  });
+
+  it('does not treat token equipment as an amulet base card type', () => {
+    expect(getBaseCardType('token_equipment')).toBeNull();
   });
 
   it('recognizes crest as a token-only kind without a base card type', () => {

--- a/src/models/cardClassification.ts
+++ b/src/models/cardClassification.ts
@@ -36,8 +36,7 @@ export const getBaseCardType = (cardKindNormalized?: string | null): BaseCardTyp
 
   if (
     cardKindNormalized === 'amulet' ||
-    cardKindNormalized.endsWith('_amulet') ||
-    cardKindNormalized === 'token_equipment'
+    cardKindNormalized.endsWith('_amulet')
   ) {
     return 'amulet';
   }

--- a/src/utils/cardLogic.test.ts
+++ b/src/utils/cardLogic.test.ts
@@ -1273,7 +1273,8 @@ describe('CardLogic utils', () => {
       const card = {
         ...createMockCard('token-equip', 'ex-host'),
         cardId: 'token-equip',
-        baseCardType: 'amulet' as const,
+        baseCardType: null,
+        cardKindNormalized: 'token_equipment',
         isTokenCard: true,
       };
 

--- a/src/utils/cardType.test.ts
+++ b/src/utils/cardType.test.ts
@@ -13,6 +13,7 @@ describe('cardType', () => {
     expect(normalizeBaseCardType(null)).toBeNull();
     expect(normalizeBaseCardType('leader')).toBeNull();
     expect(normalizeBaseCardType('token_crest')).toBeNull();
+    expect(normalizeBaseCardType('token_equipment')).toBeNull();
   });
 
   it('detects only non-evolve spell cards as main-deck spells', () => {

--- a/src/utils/deckBuilderCatalog.test.ts
+++ b/src/utils/deckBuilderCatalog.test.ts
@@ -91,6 +91,21 @@ const mockCards: DeckBuilderCardData[] = [
     deck_section: 'token',
     is_token: true,
   },
+  {
+    id: 'TK01-002',
+    name: 'Blade Equipment',
+    image: '/equipment.png',
+    cost: '1',
+    class: 'ロイヤル',
+    title: 'Hero Tale',
+    type: 'イクイップメント・トークン',
+    subtype: '兵士',
+    rarity: 'PR',
+    product_name: 'Token Pack',
+    card_kind_normalized: 'token_equipment',
+    deck_section: 'token',
+    is_token: true,
+  },
 ];
 
 describe('deckBuilderCatalog', () => {
@@ -160,6 +175,48 @@ describe('deckBuilderCatalog', () => {
     expect(amuletFilterView.filteredCards).toEqual([]);
   });
 
+  it('shows token equipment in the token section without matching the amulet filter', () => {
+    const tokenSectionView = buildDeckBuilderCatalogView(mockCards, {
+      ...createDefaultDeckRuleConfig(),
+      format: 'other',
+    }, {
+      search: 'equipment',
+      costFilter: 'All',
+      expansionFilter: 'All',
+      classFilter: 'All',
+      cardTypeFilter: 'All',
+      rarityFilter: 'All',
+      productNameFilter: 'All',
+      selectedSubtypeTags: [],
+      deckSectionFilter: 'token',
+      hideSameNameVariants: false,
+      page: 0,
+      pageSize: 50,
+    });
+
+    expect(tokenSectionView.filteredCards.map(card => card.id)).toEqual(['TK01-002']);
+
+    const amuletFilterView = buildDeckBuilderCatalogView(mockCards, {
+      ...createDefaultDeckRuleConfig(),
+      format: 'other',
+    }, {
+      search: 'equipment',
+      costFilter: 'All',
+      expansionFilter: 'All',
+      classFilter: 'All',
+      cardTypeFilter: 'amulet',
+      rarityFilter: 'All',
+      productNameFilter: 'All',
+      selectedSubtypeTags: [],
+      deckSectionFilter: 'token',
+      hideSameNameVariants: false,
+      page: 0,
+      pageSize: 50,
+    });
+
+    expect(amuletFilterView.filteredCards).toEqual([]);
+  });
+
   it('applies rule filtering, dedupe, and pagination for the card catalog', () => {
     const view = buildDeckBuilderCatalogView(mockCards, {
       ...createDefaultDeckRuleConfig(),
@@ -179,10 +236,10 @@ describe('deckBuilderCatalog', () => {
       pageSize: 2,
     });
 
-    expect(view.filteredCards.map(card => card.id)).toEqual(['BP01-001', 'BP01-002', 'LDR01-001', 'TK01-001', 'TK01-020']);
-    expect(view.displayCards.map(card => card.id)).toEqual(['BP01-001', 'LDR01-001', 'TK01-001', 'TK01-020']);
+    expect(view.filteredCards.map(card => card.id)).toEqual(['BP01-001', 'BP01-002', 'LDR01-001', 'TK01-001', 'TK01-020', 'TK01-002']);
+    expect(view.displayCards.map(card => card.id)).toEqual(['BP01-001', 'LDR01-001', 'TK01-001', 'TK01-020', 'TK01-002']);
     expect(view.paginatedCards.map(card => card.id)).toEqual(['BP01-001', 'LDR01-001']);
-    expect(view.totalPages).toBe(2);
+    expect(view.totalPages).toBe(3);
   });
 
   it('supports cost and expansion filters including the 7+ bucket', () => {

--- a/src/utils/deckBuilderDisplay.test.ts
+++ b/src/utils/deckBuilderDisplay.test.ts
@@ -77,6 +77,7 @@ describe('deckBuilderDisplay', () => {
       { card: makeCard({ id: 'amulet-1', card_kind_normalized: 'amulet' }), count: 1 },
       { card: makeCard({ id: 'unknown-1', card_kind_normalized: 'leader' }), count: 4 },
       { card: makeCard({ id: 'crest-1', card_kind_normalized: 'token_crest' }), count: 5 },
+      { card: makeCard({ id: 'equipment-1', card_kind_normalized: 'token_equipment' }), count: 5 },
     ])).toEqual({
       follower: 3,
       spell: 2,

--- a/src/utils/gameBoardDeckActions.test.ts
+++ b/src/utils/gameBoardDeckActions.test.ts
@@ -30,6 +30,7 @@ describe('gameBoardDeckActions', () => {
         { id: 'token-1', name: 'Token A', image: '/token-a.png', deck_section: 'token', card_kind_normalized: 'token' },
         { id: 'token-1', name: 'Token A', image: '/token-a.png', deck_section: 'token', card_kind_normalized: 'token' },
         { id: 'crest-1', name: 'Crest Token', image: '/crest.png', deck_section: 'token', card_kind_normalized: 'token_crest' },
+        { id: 'equipment-1', name: 'Equipment Token', image: '/equipment.png', deck_section: 'token', card_kind_normalized: 'token_equipment' },
       ],
     }, 'host', createId);
 
@@ -56,6 +57,13 @@ describe('gameBoardDeckActions', () => {
         image: '/crest.png',
         baseCardType: null,
         cardKindNormalized: 'token_crest',
+      },
+      {
+        cardId: 'equipment-1',
+        name: 'Equipment Token',
+        image: '/equipment.png',
+        baseCardType: null,
+        cardKindNormalized: 'token_equipment',
       },
     ]);
   });


### PR DESCRIPTION
## 概要

`token_equipment` を `amulet` の派生種別として扱わないように整理します。

これまで equipment は token 専用カードでありながら `getBaseCardType('token_equipment')` が `amulet` を返していたため、Deck Builder のアミュレット検索やデッキ内タイプ集計に含まれていました。今回の変更で、equipment は crest と同様に token 専用の特殊種別として扱い、base card type は持たないようにします。

## 変更内容

- `getBaseCardType('token_equipment')` が `null` を返すように変更
- Deck Builder のカードタイプフィルタで、equipment が `amulet` に一致しないことをテストで明示
- デッキ内タイプ集計で、equipment が `amulet` としてカウントされないことをテストで明示
- Game Board の token 生成候補では、equipment が引き続き表示・生成できることを確認
- `baseCardType: null` でも token equipment の表示・プレイ挙動が維持されることをテストで確認
- crest の token-only 扱いに影響しないよう、既存の crest 契約も維持

## 既存仕様への影響

意図した挙動変更として、equipment は Deck Builder の「アミュレット」タイプ検索・タイプ集計には含まれなくなります。

一方で、以下の既存動作は維持されます。

- equipment は token セクションに表示される
- equipment は token 生成候補に含まれる
- equipment のカード表示では `TOKEN` / `EQUIPMENT` 表示が維持される
- equipment は spell 扱いにならず、これまで通りフィールドへ出せる
- manual link / token equipment 判定は `cardKindNormalized === 'token_equipment'` の直接判定で維持される
- crest の `token_crest` / `baseCardType: null` の扱いには影響しない

## テスト

- [x] `npm run lint`
- [x] `npx tsc --noEmit -p tsconfig.app.json`
- [x] `npx vitest run`
  - 105 files passed
  - 1048 tests passed
- [x] `npm run build`

関連テストも個別に確認済みです。

- [x] `src/models/cardClassification.test.ts`
- [x] `src/utils/cardType.test.ts`
- [x] `src/utils/deckBuilderCatalog.test.ts`
- [x] `src/utils/deckBuilderDisplay.test.ts`
- [x] `src/utils/gameBoardDeckActions.test.ts`
- [x] `src/components/CardArtwork.test.tsx`
- [x] `src/components/Card.test.tsx`
- [x] `src/utils/cardLogic.test.ts`
- [x] `src/utils/gameBoardManualLink.test.ts`
- [x] `src/utils/gameBoardCatalog.test.ts`
- [x] `src/utils/deckBuilderRules.test.ts`
- [x] `src/utils/decklogImport.test.ts`
- [x] `src/components/CardSearchModal.test.tsx`

## 補足

E2E は未実行です。今回の変更はカード種別分類と、それを利用する Deck Builder / Game Board の unit・component 契約で確認できる範囲であり、ドラッグ操作・P2P・実ブラウザ座標に依存する変更ではないためです。
