### PR TITLE
tablet UI 検証

### DIFF
--- a/e2e/solo-tablet-touch.spec.ts
+++ b/e2e/solo-tablet-touch.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import {
+  openMainDeckActions,
+  startSoloGame,
+  zoneCards,
+} from './helpers/gameBoard';
+
+test.use({
+  locale: 'en-US',
+  viewport: { width: 1024, height: 768 },
+  hasTouch: true,
+  isMobile: false,
+});
+
+test.describe('Solo Tablet Touch Controls', () => {
+  test('opens search-card quick actions only after tapping a card on coarse input', async ({ page }) => {
+    await page.addInitScript(() => {
+      const originalMatchMedia = window.matchMedia.bind(window);
+      window.matchMedia = ((query: string) => {
+        if (query.includes('(pointer: coarse)')) {
+          return {
+            matches: true,
+            media: query,
+            onchange: null,
+            addListener: () => {},
+            removeListener: () => {},
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            dispatchEvent: () => false,
+          } as MediaQueryList;
+        }
+
+        return originalMatchMedia(query);
+      }) as typeof window.matchMedia;
+    });
+
+    await startSoloGame(page);
+
+    const boardRoot = page.locator('[data-layout-profile][data-input-profile]').first();
+    await expect(boardRoot).toHaveAttribute('data-layout-profile', 'tablet');
+    await expect(boardRoot).toHaveAttribute('data-input-profile', 'coarse');
+
+    await expect(zoneCards(page, 'mainDeck-host')).toHaveCount(2);
+    await expect(zoneCards(page, 'hand-host')).toHaveCount(4);
+
+    const mainDeckSection = await openMainDeckActions(page, 'host');
+    await mainDeckSection.getByRole('button', { name: 'Search' }).click();
+
+    const searchPanel = page.getByTestId('search-card-modal-panel');
+    await expect(searchPanel).toBeVisible();
+
+    const firstCardContainer = searchPanel.locator('.search-card-container').first();
+    const firstCardControls = firstCardContainer.locator('.modal-card-controls');
+    await expect(firstCardControls).toHaveCSS('opacity', '0');
+    await expect(firstCardControls).toHaveCSS('pointer-events', 'none');
+
+    await firstCardContainer.click();
+    await expect(firstCardControls).toHaveCSS('opacity', '1');
+    await expect(firstCardControls).toHaveCSS('pointer-events', 'auto');
+
+    await firstCardControls.getByRole('button', { name: 'Add to Hand', exact: true }).click();
+
+    await expect(searchPanel).toBeHidden();
+    await expect(zoneCards(page, 'mainDeck-host')).toHaveCount(1);
+    await expect(zoneCards(page, 'hand-host')).toHaveCount(5);
+  });
+});

--- a/src/components/Card.test.tsx
+++ b/src/components/Card.test.tsx
@@ -419,16 +419,15 @@ describe('Card', () => {
       />
     );
 
-    const controls = screen.getByTestId('card-controls');
-    expect(controls).toHaveStyle({ opacity: '0', pointerEvents: 'none' });
+    expect(screen.queryByTestId('card-coarse-action-sheet')).not.toBeInTheDocument();
 
     const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
     fireEvent.pointerDown(cardElement, { clientX: 10, clientY: 20, button: 0 });
     fireEvent.pointerUp(cardElement, { clientX: 10, clientY: 20, button: 0 });
 
-    expect(controls).toHaveStyle({ opacity: '1', pointerEvents: 'auto' });
+    expect(screen.getByTestId('card-coarse-action-sheet')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText('Bot'));
+    fireEvent.click(screen.getByRole('button', { name: 'Send to bottom of deck' }));
     expect(onSendToBottom).toHaveBeenCalledWith('card-1');
   });
 
@@ -441,12 +440,96 @@ describe('Card', () => {
       />
     );
 
-    const controls = screen.getByTestId('card-controls');
     const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
     fireEvent.pointerDown(cardElement, { clientX: 10, clientY: 20, button: 0 });
     fireEvent.pointerUp(cardElement, { clientX: 24, clientY: 20, button: 0 });
 
-    expect(controls).toHaveStyle({ opacity: '0', pointerEvents: 'none' });
+    expect(screen.queryByTestId('card-coarse-action-sheet')).not.toBeInTheDocument();
+  });
+
+  it('renders larger coarse action-sheet buttons for touch usability', () => {
+    renderWithInputProfile(
+      'coarse',
+      <Card
+        card={createCard()}
+        onSendToBottom={vi.fn()}
+      />
+    );
+
+    const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
+    fireEvent.pointerDown(cardElement, { clientX: 10, clientY: 20, button: 0 });
+    fireEvent.pointerUp(cardElement, { clientX: 10, clientY: 20, button: 0 });
+
+    expect(screen.getByRole('button', { name: 'Send to bottom of deck' })).toHaveStyle({ minHeight: '44px' });
+  });
+
+  it('does not open inspector when coarse action sheet is toggled', () => {
+    const onInspect = vi.fn();
+
+    renderWithInputProfile(
+      'coarse',
+      <Card
+        card={createCard()}
+        onSendToBottom={vi.fn()}
+        onInspect={onInspect}
+      />
+    );
+
+    const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
+    fireEvent.pointerDown(cardElement, { clientX: 10, clientY: 20, button: 0 });
+    fireEvent.pointerUp(cardElement, { clientX: 10, clientY: 20, button: 0 });
+
+    expect(screen.getByTestId('card-coarse-action-sheet')).toBeInTheDocument();
+    expect(onInspect).not.toHaveBeenCalled();
+  });
+
+  it('opens inspector from coarse action sheet details button', () => {
+    const onInspect = vi.fn();
+
+    renderWithInputProfile(
+      'coarse',
+      <Card
+        card={createCard()}
+        onSendToBottom={vi.fn()}
+        onInspect={onInspect}
+      />
+    );
+
+    const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
+    fireEvent.pointerDown(cardElement, { clientX: 10, clientY: 20, button: 0 });
+    fireEvent.pointerUp(cardElement, { clientX: 10, clientY: 20, button: 0 });
+
+    const detailsButton = screen.getByRole('button', { name: 'View card details' });
+    fireEvent.click(detailsButton);
+
+    expect(onInspect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'card-1' }),
+      expect.objectContaining({
+        top: expect.any(Number),
+        left: expect.any(Number),
+        right: expect.any(Number),
+        bottom: expect.any(Number),
+      })
+    );
+    expect(screen.queryByTestId('card-coarse-action-sheet')).not.toBeInTheDocument();
+  });
+
+  it('renders coarse action sheet outside rotated card container', () => {
+    renderWithInputProfile(
+      'coarse',
+      <Card
+        card={createCard({ isTapped: true })}
+        onSendToBottom={vi.fn()}
+      />
+    );
+
+    const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
+    fireEvent.pointerDown(cardElement, { clientX: 10, clientY: 20, button: 0 });
+    fireEvent.pointerUp(cardElement, { clientX: 10, clientY: 20, button: 0 });
+
+    const actionSheet = screen.getByTestId('card-coarse-action-sheet');
+    expect(cardElement.contains(actionSheet)).toBe(false);
+    expect(actionSheet.parentElement).toBe(document.body);
   });
 
   it('disables browser touch gestures on coarse input to keep dragging smooth', () => {

--- a/src/components/Card.test.tsx
+++ b/src/components/Card.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import Card, { type CardInstance } from './Card';
+import GameBoardInputProfileProvider from '../contexts/GameBoardInputProfileProvider';
 
 const dndState = {
   transform: null as null | { x: number; y: number },
@@ -32,6 +33,15 @@ const createCard = (overrides: Partial<CardInstance> = {}): CardInstance => ({
   counters: { atk: 1, hp: 2 },
   ...overrides,
 });
+
+const renderWithInputProfile = (
+  profile: 'fine' | 'coarse',
+  ui: React.ReactElement
+) => render(
+  <GameBoardInputProfileProvider value={profile}>
+    {ui}
+  </GameBoardInputProfileProvider>
+);
 
 describe('Card', () => {
   it('rotates tapped cards and combines rotation with drag transform', () => {
@@ -396,6 +406,47 @@ describe('Card', () => {
     );
 
     expect(screen.getByTestId('card-controls')).toHaveStyle({ pointerEvents: 'none' });
+  });
+
+  it('keeps quick actions hidden by default for coarse input until card tap', () => {
+    const onSendToBottom = vi.fn();
+
+    renderWithInputProfile(
+      'coarse',
+      <Card
+        card={createCard()}
+        onSendToBottom={onSendToBottom}
+      />
+    );
+
+    const controls = screen.getByTestId('card-controls');
+    expect(controls).toHaveStyle({ opacity: '0', pointerEvents: 'none' });
+
+    const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
+    fireEvent.pointerDown(cardElement, { clientX: 10, clientY: 20, button: 0 });
+    fireEvent.pointerUp(cardElement, { clientX: 10, clientY: 20, button: 0 });
+
+    expect(controls).toHaveStyle({ opacity: '1', pointerEvents: 'auto' });
+
+    fireEvent.click(screen.getByText('Bot'));
+    expect(onSendToBottom).toHaveBeenCalledWith('card-1');
+  });
+
+  it('does not open quick actions for coarse input when drag threshold is exceeded', () => {
+    renderWithInputProfile(
+      'coarse',
+      <Card
+        card={createCard()}
+        onSendToBottom={vi.fn()}
+      />
+    );
+
+    const controls = screen.getByTestId('card-controls');
+    const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
+    fireEvent.pointerDown(cardElement, { clientX: 10, clientY: 20, button: 0 });
+    fireEvent.pointerUp(cardElement, { clientX: 24, clientY: 20, button: 0 });
+
+    expect(controls).toHaveStyle({ opacity: '0', pointerEvents: 'none' });
   });
 
   it('does not show current stats for hand cards even if base stats are available', () => {

--- a/src/components/Card.test.tsx
+++ b/src/components/Card.test.tsx
@@ -461,6 +461,18 @@ describe('Card', () => {
     expect(cardElement).toHaveStyle({ touchAction: 'none' });
   });
 
+  it('uses compact card dimensions for coarse input', () => {
+    renderWithInputProfile(
+      'coarse',
+      <Card
+        card={createCard()}
+      />
+    );
+
+    const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
+    expect(cardElement).toHaveStyle({ width: '82px', height: '115px' });
+  });
+
   it('does not show current stats for hand cards even if base stats are available', () => {
     render(
       <Card

--- a/src/components/Card.test.tsx
+++ b/src/components/Card.test.tsx
@@ -532,6 +532,24 @@ describe('Card', () => {
     expect(actionSheet.parentElement).toBe(document.body);
   });
 
+  it('uses high-contrast text colors for coarse action-sheet buttons', () => {
+    renderWithInputProfile(
+      'coarse',
+      <Card
+        card={createCard({ isEvolveCard: true, isTapped: false })}
+        onReturnEvolve={vi.fn()}
+        onTap={vi.fn()}
+      />
+    );
+
+    const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
+    fireEvent.pointerDown(cardElement, { clientX: 10, clientY: 20, button: 0 });
+    fireEvent.pointerUp(cardElement, { clientX: 10, clientY: 20, button: 0 });
+
+    expect(screen.getByRole('button', { name: 'Return to evolve deck' })).toHaveStyle({ color: 'rgb(255, 255, 255)' });
+    expect(screen.getByRole('button', { name: 'REST' })).toHaveStyle({ color: 'rgb(255, 255, 255)' });
+  });
+
   it('disables browser touch gestures on coarse input to keep dragging smooth', () => {
     renderWithInputProfile(
       'coarse',

--- a/src/components/Card.test.tsx
+++ b/src/components/Card.test.tsx
@@ -460,7 +460,34 @@ describe('Card', () => {
     fireEvent.pointerDown(cardElement, { clientX: 10, clientY: 20, button: 0 });
     fireEvent.pointerUp(cardElement, { clientX: 10, clientY: 20, button: 0 });
 
-    expect(screen.getByRole('button', { name: 'Send to bottom of deck' })).toHaveStyle({ minHeight: '44px' });
+    expect(screen.getByRole('button', { name: 'Send to bottom of deck' })).toHaveStyle({ minHeight: '34px' });
+  });
+
+  it('keeps coarse action sheet scrollable within viewport height', () => {
+    renderWithInputProfile(
+      'coarse',
+      <Card
+        card={createCard({ isEvolveCard: true })}
+        onSendToBottom={vi.fn()}
+        onCemetery={vi.fn()}
+        onBanish={vi.fn()}
+        onReturnEvolve={vi.fn()}
+        onTap={vi.fn()}
+        onAttack={vi.fn()}
+        onModifyCounter={vi.fn()}
+        onModifyGenericCounter={vi.fn()}
+        onInspect={vi.fn()}
+      />
+    );
+
+    const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
+    fireEvent.pointerDown(cardElement, { clientX: 10, clientY: 20, button: 0 });
+    fireEvent.pointerUp(cardElement, { clientX: 10, clientY: 20, button: 0 });
+
+    expect(screen.getByTestId('card-coarse-action-sheet')).toHaveStyle({
+      position: 'fixed',
+      overflowY: 'auto',
+    });
   });
 
   it('does not open inspector when coarse action sheet is toggled', () => {
@@ -571,7 +598,7 @@ describe('Card', () => {
     );
 
     const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
-    expect(cardElement).toHaveStyle({ width: '82px', height: '115px' });
+    expect(cardElement).toHaveStyle({ width: '76px', height: '106px' });
   });
 
   it('does not show current stats for hand cards even if base stats are available', () => {

--- a/src/components/Card.test.tsx
+++ b/src/components/Card.test.tsx
@@ -449,6 +449,18 @@ describe('Card', () => {
     expect(controls).toHaveStyle({ opacity: '0', pointerEvents: 'none' });
   });
 
+  it('disables browser touch gestures on coarse input to keep dragging smooth', () => {
+    renderWithInputProfile(
+      'coarse',
+      <Card
+        card={createCard()}
+      />
+    );
+
+    const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
+    expect(cardElement).toHaveStyle({ touchAction: 'none' });
+  });
+
   it('does not show current stats for hand cards even if base stats are available', () => {
     render(
       <Card

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 import { useTranslation } from 'react-i18next';
+import { createPortal } from 'react-dom';
 import type { BaseCardStats } from '../utils/cardStats';
 import { isMainDeckSpellCard, type RuntimeBaseCardType } from '../utils/cardType';
 import type { CardDetail } from '../utils/cardDetails';
@@ -65,6 +66,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
   const { t } = useTranslation();
   const inspectPointerStartRef = React.useRef<{ x: number; y: number } | null>(null);
   const cardElementRef = React.useRef<HTMLElement | null>(null);
+  const coarseActionSheetRef = React.useRef<HTMLDivElement | null>(null);
   const inputProfile = useGameBoardInputProfile();
   const [isQuickActionsOpen, setIsQuickActionsOpen] = React.useState(false);
   const isCoarseInput = inputProfile === 'coarse';
@@ -105,6 +107,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
     const handleDocumentPointerDown = (event: PointerEvent) => {
       const cardElement = cardElementRef.current;
       if (!cardElement) return;
+      if (coarseActionSheetRef.current?.contains(event.target as Node)) return;
       if (cardElement.contains(event.target as Node)) return;
       setIsQuickActionsOpen(false);
     };
@@ -139,12 +142,14 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
   const isNormalSpellPlay = isMainDeckSpellCard(card);
   const playActionLabel = isNormalSpellPlay ? t('gameBoard.card.play') : t('gameBoard.modals.search.playToField');
   const quickActionLabels = {
+    inspect: t('gameBoard.card.quickActions.inspect'),
     sendToBottom: t('gameBoard.card.quickActions.sendToBottom'),
     cemetery: t('gameBoard.card.quickActions.cemetery'),
     banish: t('gameBoard.card.quickActions.banish'),
     toEvolveDeck: t('gameBoard.card.quickActions.toEvolveDeck'),
   };
   const quickActionDescriptions = {
+    inspect: t('gameBoard.card.quickActionDescriptions.inspect'),
     sendToBottom: t('gameBoard.card.quickActionDescriptions.sendToBottom'),
     cemetery: t('gameBoard.card.quickActionDescriptions.cemetery'),
     banish: t('gameBoard.card.quickActionDescriptions.banish'),
@@ -167,6 +172,19 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
     border: '1px solid rgba(255,255,255,0.55)',
     fontWeight: 'bold',
     lineHeight: 1,
+  };
+  const coarseSheetButtonStyle: React.CSSProperties = {
+    minHeight: '44px',
+    width: '100%',
+    borderRadius: '8px',
+    fontSize: '0.86rem',
+    fontWeight: 700,
+    border: '1px solid rgba(255,255,255,0.25)',
+    padding: '0.5rem 0.75rem',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    lineHeight: 1.25,
   };
   const currentStats = !hideCurrentStats && isStatDisplayZone && !isHidden && !card.isFlipped && baseStats
     ? {
@@ -217,6 +235,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
 
         if (canToggleQuickActions) {
           setIsQuickActionsOpen(prev => !prev);
+          return;
         }
 
         const rect = (event.currentTarget as HTMLDivElement).getBoundingClientRect();
@@ -346,8 +365,8 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
             </div>
           )}
 
-          {/* Quick Edit Overlay - Only show if not hidden AND not locked */}
-          {canShowQuickActionOverlay && (
+          {/* Quick Edit Overlay - desktop/fine path */}
+          {canShowQuickActionOverlay && !isCoarseInput && (
             <div className="card-controls"
               data-testid="card-controls"
               data-quick-actions-open={String(isQuickActionsOpen)}
@@ -452,6 +471,227 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
                 </div>
               )}
             </div>
+          )}
+
+          {/* Coarse input uses an external action sheet with larger touch targets */}
+          {canShowQuickActionOverlay && isCoarseInput && isQuickActionsOpen && typeof document !== 'undefined' && createPortal(
+            <div
+              ref={coarseActionSheetRef}
+              data-testid="card-coarse-action-sheet"
+              style={{
+                position: 'fixed',
+                left: '50%',
+                bottom: '12px',
+                transform: 'translateX(-50%)',
+                width: 'min(92vw, 420px)',
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                gap: '0.45rem',
+                background: 'rgba(2, 6, 23, 0.97)',
+                border: '1px solid rgba(148, 163, 184, 0.35)',
+                borderRadius: '12px',
+                padding: '0.6rem',
+                boxShadow: '0 18px 30px rgba(0,0,0,0.45)',
+                zIndex: 1200,
+              }}
+            >
+              {onPlayToField && (card.zone.startsWith('hand') || card.zone.startsWith('ex-')) && (
+                <button
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onPlayToField(card.id);
+                    setIsQuickActionsOpen(false);
+                  }}
+                  style={{ ...coarseSheetButtonStyle, gridColumn: '1 / -1', background: '#2563eb', color: 'white' }}
+                >
+                  {playActionLabel}
+                </button>
+              )}
+
+              {onInspect && !card.isFlipped && (
+                <button
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    const rect = cardElementRef.current?.getBoundingClientRect();
+                    if (!rect) return;
+                    onInspect(card, {
+                      top: rect.top,
+                      left: rect.left,
+                      right: rect.right,
+                      bottom: rect.bottom,
+                      width: rect.width,
+                      height: rect.height,
+                    });
+                    setIsQuickActionsOpen(false);
+                  }}
+                  title={quickActionDescriptions.inspect}
+                  aria-label={quickActionDescriptions.inspect}
+                  style={{ ...coarseSheetButtonStyle, gridColumn: '1 / -1', background: '#0f172a', color: 'white' }}
+                >
+                  {quickActionDescriptions.inspect}
+                </button>
+              )}
+
+              {onModifyCounter && isStatDisplayZone && !disableCombatAndCounterControls && (
+                <>
+                  <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onModifyCounter(card.id, 'atk', 1);
+                    }}
+                    style={{ ...coarseSheetButtonStyle, background: '#3b82f6', color: '#fff' }}
+                  >
+                    +ATK
+                  </button>
+                  <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onModifyCounter(card.id, 'atk', -1);
+                    }}
+                    style={{ ...coarseSheetButtonStyle, background: '#1e293b', color: '#fff' }}
+                  >
+                    -ATK
+                  </button>
+                  <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onModifyCounter(card.id, 'hp', 1);
+                    }}
+                    style={{ ...coarseSheetButtonStyle, background: '#ef4444', color: '#fff' }}
+                  >
+                    +HP
+                  </button>
+                  <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onModifyCounter(card.id, 'hp', -1);
+                    }}
+                    style={{ ...coarseSheetButtonStyle, background: '#1e293b', color: '#fff' }}
+                  >
+                    -HP
+                  </button>
+                </>
+              )}
+
+              {onModifyGenericCounter && isStatDisplayZone && !disableCombatAndCounterControls && (
+                <>
+                  <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onModifyGenericCounter(card.id, 1);
+                    }}
+                    style={{ ...coarseSheetButtonStyle, background: '#0f766e', color: '#fff' }}
+                  >
+                    +Counter
+                  </button>
+                  <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onModifyGenericCounter(card.id, -1);
+                    }}
+                    style={{ ...coarseSheetButtonStyle, background: '#7f1d1d', color: '#fff' }}
+                  >
+                    -Counter
+                  </button>
+                </>
+              )}
+
+              {onSendToBottom && (
+                <button
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSendToBottom(card.id);
+                    setIsQuickActionsOpen(false);
+                  }}
+                  title={quickActionDescriptions.sendToBottom}
+                  aria-label={quickActionDescriptions.sendToBottom}
+                  style={{ ...coarseSheetButtonStyle, background: 'var(--bg-surface-elevated)', color: 'white' }}
+                >
+                  {quickActionDescriptions.sendToBottom}
+                </button>
+              )}
+              {onCemetery && (
+                <button
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onCemetery(card.id);
+                    setIsQuickActionsOpen(false);
+                  }}
+                  title={quickActionDescriptions.cemetery}
+                  aria-label={quickActionDescriptions.cemetery}
+                  style={{ ...coarseSheetButtonStyle, background: '#334155', color: 'white' }}
+                >
+                  {quickActionDescriptions.cemetery}
+                </button>
+              )}
+              {onBanish && (
+                <button
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onBanish(card.id);
+                    setIsQuickActionsOpen(false);
+                  }}
+                  title={quickActionDescriptions.banish}
+                  aria-label={quickActionDescriptions.banish}
+                  style={{ ...coarseSheetButtonStyle, background: '#7c3aed', color: 'white' }}
+                >
+                  {quickActionDescriptions.banish}
+                </button>
+              )}
+              {onReturnEvolve && card.isEvolveCard && (
+                <button
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onReturnEvolve(card.id);
+                    setIsQuickActionsOpen(false);
+                  }}
+                  title={quickActionDescriptions.toEvolveDeck}
+                  aria-label={quickActionDescriptions.toEvolveDeck}
+                  style={{ ...coarseSheetButtonStyle, background: 'var(--accent-primary)', color: 'black' }}
+                >
+                  {quickActionDescriptions.toEvolveDeck}
+                </button>
+              )}
+              {onTap && !disableCombatAndCounterControls && (
+                <button
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onTap(card.id);
+                    setIsQuickActionsOpen(false);
+                  }}
+                  style={{ ...coarseSheetButtonStyle, background: card.isTapped ? '#fbbf24' : '#64748b', color: 'black' }}
+                >
+                  {card.isTapped ? t('gameBoard.card.stand') : t('gameBoard.card.rest')}
+                </button>
+              )}
+              {onAttack && card.zone.startsWith('field-') && !card.isTapped && (card.baseCardType === 'follower' || !!baseStats) && (
+                <button
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAttack(card.id);
+                    setIsQuickActionsOpen(false);
+                  }}
+                  style={{ ...coarseSheetButtonStyle, background: '#f97316', color: 'white' }}
+                >
+                  {t('gameBoard.card.attack')}
+                </button>
+              )}
+            </div>,
+            document.body
           )}
         </>
       )}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -659,7 +659,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
                   }}
                   title={quickActionDescriptions.toEvolveDeck}
                   aria-label={quickActionDescriptions.toEvolveDeck}
-                  style={{ ...coarseSheetButtonStyle, background: 'var(--accent-primary)', color: 'black' }}
+                  style={{ ...coarseSheetButtonStyle, background: 'var(--accent-primary)', color: 'white' }}
                 >
                   {quickActionDescriptions.toEvolveDeck}
                 </button>
@@ -672,7 +672,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
                     onTap(card.id);
                     setIsQuickActionsOpen(false);
                   }}
-                  style={{ ...coarseSheetButtonStyle, background: card.isTapped ? '#fbbf24' : '#64748b', color: 'black' }}
+                  style={{ ...coarseSheetButtonStyle, background: card.isTapped ? '#fbbf24' : '#64748b', color: card.isTapped ? 'black' : 'white' }}
                 >
                   {card.isTapped ? t('gameBoard.card.stand') : t('gameBoard.card.rest')}
                 </button>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -69,6 +69,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
   const coarseActionSheetRef = React.useRef<HTMLDivElement | null>(null);
   const inputProfile = useGameBoardInputProfile();
   const [isQuickActionsOpen, setIsQuickActionsOpen] = React.useState(false);
+  const [coarseSheetPlacement, setCoarseSheetPlacement] = React.useState<{ top: number; left: number; width: number; maxHeight: number } | null>(null);
   const isCoarseInput = inputProfile === 'coarse';
   const cardSize = getCardSizeForInputProfile(inputProfile);
   const isInteractionLocked = isLocked || card.isLeaderCard || card.zone.startsWith('leader-');
@@ -100,6 +101,97 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
       setIsQuickActionsOpen(false);
     }
   }, [canToggleQuickActions]);
+
+  const updateCoarseSheetPlacement = React.useCallback(() => {
+    if (!isCoarseInput || typeof window === 'undefined') return;
+
+    const cardElement = cardElementRef.current;
+    if (!cardElement) return;
+
+    const rect = cardElement.getBoundingClientRect();
+    const isExZoneCard = card.zone.startsWith('ex-');
+    const visualViewport = window.visualViewport;
+    const viewportLeft = visualViewport?.offsetLeft ?? 0;
+    const viewportTop = visualViewport?.offsetTop ?? 0;
+    const viewportWidth = visualViewport?.width ?? window.innerWidth;
+    const viewportHeight = visualViewport?.height ?? window.innerHeight;
+    const viewportRight = viewportLeft + viewportWidth;
+    const viewportBottom = viewportTop + viewportHeight;
+    const viewportMargin = 6;
+    const anchorOffset = isExZoneCard ? 4 : 6;
+    const desiredSheetWidth = Math.round(viewportWidth * (isExZoneCard ? 0.7 : 0.74));
+    const sheetWidth = isExZoneCard
+      ? Math.max(208, Math.min(desiredSheetWidth, 272))
+      : Math.max(220, Math.min(desiredSheetWidth, 300));
+    const measuredSheetHeight = coarseActionSheetRef.current?.offsetHeight ?? 0;
+
+    const desiredLeft = rect.left + (rect.width / 2) - (sheetWidth / 2);
+    const minLeft = viewportLeft + viewportMargin;
+    const maxLeft = Math.max(minLeft, viewportRight - sheetWidth - viewportMargin);
+    const left = Math.min(Math.max(desiredLeft, minLeft), maxLeft);
+
+    const rawBelowSpace = viewportBottom - (rect.bottom + anchorOffset) - viewportMargin;
+    const rawAboveSpace = rect.top - anchorOffset - (viewportTop + viewportMargin);
+    const belowSpace = Math.max(0, rawBelowSpace);
+    const aboveSpace = Math.max(0, rawAboveSpace);
+
+    const estimatedSheetHeight = measuredSheetHeight > 0 ? measuredSheetHeight : 220;
+    const minPreferredSpace = Math.min(172, estimatedSheetHeight);
+
+    const placeBelow = isExZoneCard
+      ? (aboveSpace < minPreferredSpace && belowSpace > aboveSpace)
+      : belowSpace >= minPreferredSpace
+        ? true
+        : aboveSpace >= minPreferredSpace
+          ? false
+          : belowSpace >= aboveSpace;
+
+    const maxHeight = Math.floor(placeBelow ? belowSpace : aboveSpace);
+    const effectiveHeight = measuredSheetHeight > 0 ? Math.min(measuredSheetHeight, maxHeight) : maxHeight;
+
+    let top = placeBelow
+      ? rect.bottom + anchorOffset
+      : rect.top - anchorOffset - effectiveHeight;
+
+    const minTop = viewportTop + viewportMargin;
+    const maxTop = Math.max(minTop, viewportBottom - effectiveHeight - viewportMargin);
+    top = Math.min(Math.max(top, minTop), maxTop);
+
+    setCoarseSheetPlacement({
+      top: Math.round(top),
+      left: Math.round(left),
+      width: sheetWidth,
+      maxHeight: Math.max(1, maxHeight),
+    });
+  }, [card.zone, isCoarseInput]);
+
+  React.useEffect(() => {
+    if (!isCoarseInput || !isQuickActionsOpen || typeof window === 'undefined') {
+      setCoarseSheetPlacement(null);
+      return undefined;
+    }
+
+    const handleViewportUpdate = () => {
+      updateCoarseSheetPlacement();
+    };
+
+    handleViewportUpdate();
+    const rafId = window.requestAnimationFrame(handleViewportUpdate);
+    const visualViewport = window.visualViewport;
+
+    window.addEventListener('resize', handleViewportUpdate);
+    document.addEventListener('scroll', handleViewportUpdate, true);
+    visualViewport?.addEventListener('resize', handleViewportUpdate);
+    visualViewport?.addEventListener('scroll', handleViewportUpdate);
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      window.removeEventListener('resize', handleViewportUpdate);
+      document.removeEventListener('scroll', handleViewportUpdate, true);
+      visualViewport?.removeEventListener('resize', handleViewportUpdate);
+      visualViewport?.removeEventListener('scroll', handleViewportUpdate);
+    };
+  }, [isCoarseInput, isQuickActionsOpen, updateCoarseSheetPlacement]);
 
   React.useEffect(() => {
     if (!canToggleQuickActions) return undefined;
@@ -174,17 +266,17 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
     lineHeight: 1,
   };
   const coarseSheetButtonStyle: React.CSSProperties = {
-    minHeight: '44px',
+    minHeight: '34px',
     width: '100%',
-    borderRadius: '8px',
-    fontSize: '0.86rem',
+    borderRadius: '6px',
+    fontSize: '0.7rem',
     fontWeight: 700,
     border: '1px solid rgba(255,255,255,0.25)',
-    padding: '0.5rem 0.75rem',
+    padding: '0.28rem 0.42rem',
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    lineHeight: 1.25,
+    lineHeight: 1.15,
   };
   const currentStats = !hideCurrentStats && isStatDisplayZone && !isHidden && !card.isFlipped && baseStats
     ? {
@@ -234,7 +326,13 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
         if (deltaX > 6 || deltaY > 6) return;
 
         if (canToggleQuickActions) {
-          setIsQuickActionsOpen(prev => !prev);
+          setIsQuickActionsOpen(prev => {
+            const nextOpen = !prev;
+            if (nextOpen) {
+              updateCoarseSheetPlacement();
+            }
+            return nextOpen;
+          });
           return;
         }
 
@@ -480,216 +578,220 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
               data-testid="card-coarse-action-sheet"
               style={{
                 position: 'fixed',
-                left: '50%',
-                bottom: '12px',
-                transform: 'translateX(-50%)',
-                width: 'min(92vw, 420px)',
+                top: coarseSheetPlacement ? `${coarseSheetPlacement.top}px` : '8px',
+                left: coarseSheetPlacement ? `${coarseSheetPlacement.left}px` : '8px',
+                zIndex: 1200,
+                width: coarseSheetPlacement ? `${coarseSheetPlacement.width}px` : 'min(74vw, 300px)',
+                maxHeight: coarseSheetPlacement ? `${coarseSheetPlacement.maxHeight}px` : '60vh',
                 display: 'grid',
                 gridTemplateColumns: '1fr 1fr',
-                gap: '0.45rem',
+                gap: '0.24rem',
                 background: 'rgba(2, 6, 23, 0.97)',
                 border: '1px solid rgba(148, 163, 184, 0.35)',
-                borderRadius: '12px',
-                padding: '0.6rem',
-                boxShadow: '0 18px 30px rgba(0,0,0,0.45)',
-                zIndex: 1200,
+                borderRadius: '8px',
+                padding: '0.36rem',
+                boxShadow: '0 12px 20px rgba(0,0,0,0.4)',
+                overflowY: 'auto',
+                overscrollBehavior: 'contain',
+                WebkitOverflowScrolling: 'touch',
+                visibility: coarseSheetPlacement ? 'visible' : 'hidden',
               }}
             >
-              {onPlayToField && (card.zone.startsWith('hand') || card.zone.startsWith('ex-')) && (
-                <button
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onPlayToField(card.id);
-                    setIsQuickActionsOpen(false);
-                  }}
-                  style={{ ...coarseSheetButtonStyle, gridColumn: '1 / -1', background: '#2563eb', color: 'white' }}
-                >
-                  {playActionLabel}
-                </button>
-              )}
+                {onPlayToField && (card.zone.startsWith('hand') || card.zone.startsWith('ex-')) && (
+                  <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onPlayToField(card.id);
+                      setIsQuickActionsOpen(false);
+                    }}
+                    style={{ ...coarseSheetButtonStyle, gridColumn: '1 / -1', background: '#2563eb', color: 'white' }}
+                  >
+                    {playActionLabel}
+                  </button>
+                )}
 
-              {onInspect && !card.isFlipped && (
-                <button
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    const rect = cardElementRef.current?.getBoundingClientRect();
-                    if (!rect) return;
-                    onInspect(card, {
-                      top: rect.top,
-                      left: rect.left,
-                      right: rect.right,
-                      bottom: rect.bottom,
-                      width: rect.width,
-                      height: rect.height,
-                    });
-                    setIsQuickActionsOpen(false);
-                  }}
-                  title={quickActionDescriptions.inspect}
-                  aria-label={quickActionDescriptions.inspect}
-                  style={{ ...coarseSheetButtonStyle, gridColumn: '1 / -1', background: '#0f172a', color: 'white' }}
-                >
-                  {quickActionDescriptions.inspect}
-                </button>
-              )}
+                {onInspect && !card.isFlipped && (
+                  <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      const rect = cardElementRef.current?.getBoundingClientRect();
+                      if (!rect) return;
+                      onInspect(card, {
+                        top: rect.top,
+                        left: rect.left,
+                        right: rect.right,
+                        bottom: rect.bottom,
+                        width: rect.width,
+                        height: rect.height,
+                      });
+                      setIsQuickActionsOpen(false);
+                    }}
+                    title={quickActionDescriptions.inspect}
+                    aria-label={quickActionDescriptions.inspect}
+                    style={{ ...coarseSheetButtonStyle, gridColumn: '1 / -1', background: '#0f172a', color: 'white' }}
+                  >
+                    {quickActionDescriptions.inspect}
+                  </button>
+                )}
 
-              {onModifyCounter && isStatDisplayZone && !disableCombatAndCounterControls && (
-                <>
-                  <button
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onModifyCounter(card.id, 'atk', 1);
-                    }}
-                    style={{ ...coarseSheetButtonStyle, background: '#3b82f6', color: '#fff' }}
-                  >
-                    +ATK
-                  </button>
-                  <button
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onModifyCounter(card.id, 'atk', -1);
-                    }}
-                    style={{ ...coarseSheetButtonStyle, background: '#1e293b', color: '#fff' }}
-                  >
-                    -ATK
-                  </button>
-                  <button
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onModifyCounter(card.id, 'hp', 1);
-                    }}
-                    style={{ ...coarseSheetButtonStyle, background: '#ef4444', color: '#fff' }}
-                  >
-                    +HP
-                  </button>
-                  <button
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onModifyCounter(card.id, 'hp', -1);
-                    }}
-                    style={{ ...coarseSheetButtonStyle, background: '#1e293b', color: '#fff' }}
-                  >
-                    -HP
-                  </button>
-                </>
-              )}
+                {onModifyCounter && isStatDisplayZone && !disableCombatAndCounterControls && (
+                  <>
+                    <button
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onModifyCounter(card.id, 'atk', 1);
+                      }}
+                      style={{ ...coarseSheetButtonStyle, background: '#3b82f6', color: '#fff' }}
+                    >
+                      +ATK
+                    </button>
+                    <button
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onModifyCounter(card.id, 'atk', -1);
+                      }}
+                      style={{ ...coarseSheetButtonStyle, background: '#1e293b', color: '#fff' }}
+                    >
+                      -ATK
+                    </button>
+                    <button
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onModifyCounter(card.id, 'hp', 1);
+                      }}
+                      style={{ ...coarseSheetButtonStyle, background: '#ef4444', color: '#fff' }}
+                    >
+                      +HP
+                    </button>
+                    <button
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onModifyCounter(card.id, 'hp', -1);
+                      }}
+                      style={{ ...coarseSheetButtonStyle, background: '#1e293b', color: '#fff' }}
+                    >
+                      -HP
+                    </button>
+                  </>
+                )}
 
-              {onModifyGenericCounter && isStatDisplayZone && !disableCombatAndCounterControls && (
-                <>
-                  <button
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onModifyGenericCounter(card.id, 1);
-                    }}
-                    style={{ ...coarseSheetButtonStyle, background: '#0f766e', color: '#fff' }}
-                  >
-                    +Counter
-                  </button>
-                  <button
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onModifyGenericCounter(card.id, -1);
-                    }}
-                    style={{ ...coarseSheetButtonStyle, background: '#7f1d1d', color: '#fff' }}
-                  >
-                    -Counter
-                  </button>
-                </>
-              )}
+                {onModifyGenericCounter && isStatDisplayZone && !disableCombatAndCounterControls && (
+                  <>
+                    <button
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onModifyGenericCounter(card.id, 1);
+                      }}
+                      style={{ ...coarseSheetButtonStyle, background: '#0f766e', color: '#fff' }}
+                    >
+                      +Counter
+                    </button>
+                    <button
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onModifyGenericCounter(card.id, -1);
+                      }}
+                      style={{ ...coarseSheetButtonStyle, background: '#7f1d1d', color: '#fff' }}
+                    >
+                      -Counter
+                    </button>
+                  </>
+                )}
 
-              {onSendToBottom && (
-                <button
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onSendToBottom(card.id);
-                    setIsQuickActionsOpen(false);
-                  }}
-                  title={quickActionDescriptions.sendToBottom}
-                  aria-label={quickActionDescriptions.sendToBottom}
-                  style={{ ...coarseSheetButtonStyle, background: 'var(--bg-surface-elevated)', color: 'white' }}
-                >
-                  {quickActionDescriptions.sendToBottom}
-                </button>
-              )}
-              {onCemetery && (
-                <button
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onCemetery(card.id);
-                    setIsQuickActionsOpen(false);
-                  }}
-                  title={quickActionDescriptions.cemetery}
-                  aria-label={quickActionDescriptions.cemetery}
-                  style={{ ...coarseSheetButtonStyle, background: '#334155', color: 'white' }}
-                >
-                  {quickActionDescriptions.cemetery}
-                </button>
-              )}
-              {onBanish && (
-                <button
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onBanish(card.id);
-                    setIsQuickActionsOpen(false);
-                  }}
-                  title={quickActionDescriptions.banish}
-                  aria-label={quickActionDescriptions.banish}
-                  style={{ ...coarseSheetButtonStyle, background: '#7c3aed', color: 'white' }}
-                >
-                  {quickActionDescriptions.banish}
-                </button>
-              )}
-              {onReturnEvolve && card.isEvolveCard && (
-                <button
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onReturnEvolve(card.id);
-                    setIsQuickActionsOpen(false);
-                  }}
-                  title={quickActionDescriptions.toEvolveDeck}
-                  aria-label={quickActionDescriptions.toEvolveDeck}
-                  style={{ ...coarseSheetButtonStyle, background: 'var(--accent-primary)', color: 'white' }}
-                >
-                  {quickActionDescriptions.toEvolveDeck}
-                </button>
-              )}
-              {onTap && !disableCombatAndCounterControls && (
-                <button
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onTap(card.id);
-                    setIsQuickActionsOpen(false);
-                  }}
-                  style={{ ...coarseSheetButtonStyle, background: card.isTapped ? '#fbbf24' : '#64748b', color: card.isTapped ? 'black' : 'white' }}
-                >
-                  {card.isTapped ? t('gameBoard.card.stand') : t('gameBoard.card.rest')}
-                </button>
-              )}
-              {onAttack && card.zone.startsWith('field-') && !card.isTapped && (card.baseCardType === 'follower' || !!baseStats) && (
-                <button
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onAttack(card.id);
-                    setIsQuickActionsOpen(false);
-                  }}
-                  style={{ ...coarseSheetButtonStyle, background: '#f97316', color: 'white' }}
-                >
-                  {t('gameBoard.card.attack')}
-                </button>
-              )}
+                {onSendToBottom && (
+                  <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSendToBottom(card.id);
+                      setIsQuickActionsOpen(false);
+                    }}
+                    title={quickActionDescriptions.sendToBottom}
+                    aria-label={quickActionDescriptions.sendToBottom}
+                    style={{ ...coarseSheetButtonStyle, background: 'var(--bg-surface-elevated)', color: 'white' }}
+                  >
+                    {quickActionDescriptions.sendToBottom}
+                  </button>
+                )}
+                {onCemetery && (
+                  <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onCemetery(card.id);
+                      setIsQuickActionsOpen(false);
+                    }}
+                    title={quickActionDescriptions.cemetery}
+                    aria-label={quickActionDescriptions.cemetery}
+                    style={{ ...coarseSheetButtonStyle, background: '#334155', color: 'white' }}
+                  >
+                    {quickActionDescriptions.cemetery}
+                  </button>
+                )}
+                {onBanish && (
+                  <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onBanish(card.id);
+                      setIsQuickActionsOpen(false);
+                    }}
+                    title={quickActionDescriptions.banish}
+                    aria-label={quickActionDescriptions.banish}
+                    style={{ ...coarseSheetButtonStyle, background: '#7c3aed', color: 'white' }}
+                  >
+                    {quickActionDescriptions.banish}
+                  </button>
+                )}
+                {onReturnEvolve && card.isEvolveCard && (
+                  <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onReturnEvolve(card.id);
+                      setIsQuickActionsOpen(false);
+                    }}
+                    title={quickActionDescriptions.toEvolveDeck}
+                    aria-label={quickActionDescriptions.toEvolveDeck}
+                    style={{ ...coarseSheetButtonStyle, background: 'var(--accent-primary)', color: 'white' }}
+                  >
+                    {quickActionDescriptions.toEvolveDeck}
+                  </button>
+                )}
+                {onTap && !disableCombatAndCounterControls && (
+                  <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onTap(card.id);
+                      setIsQuickActionsOpen(false);
+                    }}
+                    style={{ ...coarseSheetButtonStyle, background: card.isTapped ? '#fbbf24' : '#64748b', color: card.isTapped ? 'black' : 'white' }}
+                  >
+                    {card.isTapped ? t('gameBoard.card.stand') : t('gameBoard.card.rest')}
+                  </button>
+                )}
+                {onAttack && card.zone.startsWith('field-') && !card.isTapped && (card.baseCardType === 'follower' || !!baseStats) && (
+                  <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onAttack(card.id);
+                      setIsQuickActionsOpen(false);
+                    }}
+                    style={{ ...coarseSheetButtonStyle, background: '#f97316', color: 'white' }}
+                  >
+                    {t('gameBoard.card.attack')}
+                  </button>
+                )}
             </div>,
             document.body
           )}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -6,6 +6,7 @@ import { isMainDeckSpellCard, type RuntimeBaseCardType } from '../utils/cardType
 import type { CardDetail } from '../utils/cardDetails';
 import CardArtwork from './CardArtwork';
 import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
+import { getCardSizeForInputProfile } from '../utils/gameBoardCardLayout';
 
 export interface CardInstance {
   id: string; // unique instance id
@@ -67,6 +68,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
   const inputProfile = useGameBoardInputProfile();
   const [isQuickActionsOpen, setIsQuickActionsOpen] = React.useState(false);
   const isCoarseInput = inputProfile === 'coarse';
+  const cardSize = getCardSizeForInputProfile(inputProfile);
   const isInteractionLocked = isLocked || card.isLeaderCard || card.zone.startsWith('leader-');
   const canShowQuickActionOverlay = !isHidden && !isInteractionLocked;
   const canToggleQuickActions = isCoarseInput && canShowQuickActionOverlay && !quickActionsDisabled;
@@ -118,8 +120,8 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
     cursor: isInteractionLocked ? 'default' : 'grab',
     touchAction: isCoarseInput ? 'none' : undefined,
     position: 'relative',
-    width: '100px',
-    height: '140px',
+    width: `${cardSize.width}px`,
+    height: `${cardSize.height}px`,
     transition: transform ? 'none' : 'transform 0.2s ease', // animate tapping
   };
 

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -116,6 +116,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
     transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
     zIndex: transform ? 999 : 1,
     cursor: isInteractionLocked ? 'default' : 'grab',
+    touchAction: isCoarseInput ? 'none' : undefined,
     position: 'relative',
     width: '100px',
     height: '140px',

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -5,6 +5,7 @@ import type { BaseCardStats } from '../utils/cardStats';
 import { isMainDeckSpellCard, type RuntimeBaseCardType } from '../utils/cardType';
 import type { CardDetail } from '../utils/cardDetails';
 import CardArtwork from './CardArtwork';
+import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 export interface CardInstance {
   id: string; // unique instance id
@@ -62,7 +63,13 @@ interface Props {
 const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideCurrentStats, highlightTone, onInspect, onAttack, onTap, onModifyCounter, onModifyGenericCounter, onSendToBottom, onBanish, onReturnEvolve, onCemetery, onPlayToField, isHidden, isLocked, quickActionsDisabled, disableCombatAndCounterControls, debugIndex }) => {
   const { t } = useTranslation();
   const inspectPointerStartRef = React.useRef<{ x: number; y: number } | null>(null);
+  const cardElementRef = React.useRef<HTMLElement | null>(null);
+  const inputProfile = useGameBoardInputProfile();
+  const [isQuickActionsOpen, setIsQuickActionsOpen] = React.useState(false);
+  const isCoarseInput = inputProfile === 'coarse';
   const isInteractionLocked = isLocked || card.isLeaderCard || card.zone.startsWith('leader-');
+  const canShowQuickActionOverlay = !isHidden && !isInteractionLocked;
+  const canToggleQuickActions = isCoarseInput && canShowQuickActionOverlay && !quickActionsDisabled;
   const { attributes, listeners, setNodeRef: setDraggableRef, transform } = useDraggable({
     id: card.id,
     data: { card },
@@ -75,9 +82,34 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
   });
 
   const setRefs = (node: HTMLElement | null) => {
+    cardElementRef.current = node;
     setDraggableRef(node);
     setDroppableRef(node);
   };
+
+  React.useEffect(() => {
+    setIsQuickActionsOpen(false);
+  }, [card.id, card.zone]);
+
+  React.useEffect(() => {
+    if (!canToggleQuickActions) {
+      setIsQuickActionsOpen(false);
+    }
+  }, [canToggleQuickActions]);
+
+  React.useEffect(() => {
+    if (!canToggleQuickActions) return undefined;
+
+    const handleDocumentPointerDown = (event: PointerEvent) => {
+      const cardElement = cardElementRef.current;
+      if (!cardElement) return;
+      if (cardElement.contains(event.target as Node)) return;
+      setIsQuickActionsOpen(false);
+    };
+
+    document.addEventListener('pointerdown', handleDocumentPointerDown, true);
+    return () => document.removeEventListener('pointerdown', handleDocumentPointerDown, true);
+  }, [canToggleQuickActions]);
 
   const style: React.CSSProperties = {
     // Translate x/y for the drag
@@ -179,6 +211,10 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
         const deltaX = Math.abs(event.clientX - pointerStart.x);
         const deltaY = Math.abs(event.clientY - pointerStart.y);
         if (deltaX > 6 || deltaY > 6) return;
+
+        if (canToggleQuickActions) {
+          setIsQuickActionsOpen(prev => !prev);
+        }
 
         const rect = (event.currentTarget as HTMLDivElement).getBoundingClientRect();
         onInspect?.(card, {
@@ -308,15 +344,16 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
           )}
 
           {/* Quick Edit Overlay - Only show if not hidden AND not locked */}
-          {!isHidden && !isInteractionLocked && (
+          {canShowQuickActionOverlay && (
             <div className="card-controls"
               data-testid="card-controls"
+              data-quick-actions-open={String(isQuickActionsOpen)}
               style={{
                 position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
                 display: 'flex', flexDirection: 'column', gap: '2px', padding: '4px',
-                background: 'rgba(0,0,0,0.6)', opacity: 0, transition: 'opacity 0.2s ease',
+                background: 'rgba(0,0,0,0.6)', opacity: isCoarseInput ? (isQuickActionsOpen ? 1 : 0) : 0, transition: 'opacity 0.2s ease',
                 borderRadius: '4px',
-                pointerEvents: quickActionsDisabled ? 'none' : undefined
+                pointerEvents: quickActionsDisabled ? 'none' : isCoarseInput ? (isQuickActionsOpen ? 'auto' : 'none') : undefined
               }}>
               {onPlayToField && (card.zone.startsWith('hand') || card.zone.startsWith('ex-')) && (
                 <div style={{ display: 'flex', justifyContent: 'center', gap: '4px', marginBottom: '2px' }}>

--- a/src/components/CardSearchModal.test.tsx
+++ b/src/components/CardSearchModal.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import CardSearchModal from './CardSearchModal';
 import type { CardInstance } from './Card';
+import GameBoardInputProfileProvider from '../contexts/GameBoardInputProfileProvider';
 
 const createCard = (overrides: Partial<CardInstance> = {}): CardInstance => ({
   id: 'card-1',
@@ -20,6 +21,15 @@ const getRenderedCardOrder = (): string[] => {
   const cardGrid = screen.getByTestId('search-card-grid');
   return Array.from(cardGrid.querySelectorAll('img[alt]')).map((image) => image.getAttribute('alt') ?? '');
 };
+
+const renderWithInputProfile = (
+  profile: 'fine' | 'coarse',
+  ui: React.ReactElement
+) => render(
+  <GameBoardInputProfileProvider value={profile}>
+    {ui}
+  </GameBoardInputProfileProvider>
+);
 
 describe('CardSearchModal', () => {
   it('does not show hand or EX extraction buttons for evolve cards', () => {
@@ -497,6 +507,56 @@ describe('CardSearchModal', () => {
     expect(screen.queryByText('Play to Field')).not.toBeInTheDocument();
     expect(screen.queryByText('Add to Hand')).not.toBeInTheDocument();
     expect(screen.queryByText('Add to EX Area')).not.toBeInTheDocument();
+  });
+
+  it('keeps quick controls hidden for coarse input until a card is tapped', () => {
+    const onExtractCard = vi.fn();
+
+    renderWithInputProfile(
+      'coarse',
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Main Deck"
+        zoneId="mainDeck-host"
+        cards={[createCard({ isEvolveCard: false, zone: 'mainDeck-host' })]}
+        onExtractCard={onExtractCard}
+        viewerRole="host"
+        allowHandExtraction={true}
+      />
+    );
+
+    const controls = screen.getByTestId('search-card-controls-card-1');
+    expect(controls).toHaveStyle({ opacity: '0', pointerEvents: 'none' });
+
+    fireEvent.click(screen.getByAltText('Test Card'));
+    expect(controls).toHaveStyle({ opacity: '1', pointerEvents: 'auto' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add to Hand' }));
+    expect(onExtractCard).toHaveBeenCalledWith('card-1', 'hand-host');
+  });
+
+  it('closes coarse-input quick controls when tapping modal empty space', () => {
+    renderWithInputProfile(
+      'coarse',
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Main Deck"
+        zoneId="mainDeck-host"
+        cards={[createCard({ isEvolveCard: false, zone: 'mainDeck-host' })]}
+        onExtractCard={vi.fn()}
+        viewerRole="host"
+        allowHandExtraction={true}
+      />
+    );
+
+    const controls = screen.getByTestId('search-card-controls-card-1');
+    fireEvent.click(screen.getByAltText('Test Card'));
+    expect(controls).toHaveStyle({ opacity: '1', pointerEvents: 'auto' });
+
+    fireEvent.pointerDown(screen.getByTestId('search-card-modal-panel'));
+    expect(controls).toHaveStyle({ opacity: '0', pointerEvents: 'none' });
   });
 
   it('shows a compact detail popover when a card is clicked', () => {

--- a/src/components/CardSearchModal.tsx
+++ b/src/components/CardSearchModal.tsx
@@ -5,6 +5,7 @@ import { formatAbilityText, type CardDetailLookup } from '../utils/cardDetails';
 import { normalizeBaseCardType, type RuntimeBaseCardType } from '../utils/cardType';
 import CardArtwork from './CardArtwork';
 import { useTranslation } from 'react-i18next';
+import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 interface CardSearchModalProps {
   isOpen: boolean;
@@ -80,6 +81,8 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
   onRequestMainDeckShuffleConfirm,
 }) => {
   const { t } = useTranslation();
+  const inputProfile = useGameBoardInputProfile();
+  const isCoarseInput = inputProfile === 'coarse';
   const [selectedCardId, setSelectedCardId] = React.useState<string | null>(null);
   const [isBulkSelecting, setIsBulkSelecting] = React.useState(false);
   const [bulkSelectedCardIds, setBulkSelectedCardIds] = React.useState<string[]>([]);
@@ -524,6 +527,7 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
             const canPlayToField = canPlayCardToField();
             const playToFieldLabel = isPreparingMainDeckSearch ? t('gameBoard.modals.search.setFaceDown') : t('gameBoard.modals.search.playToField');
             const isBulkSelected = bulkSelectedCardIds.includes(c.id);
+            const isTouchControlsOpen = isCoarseInput && selectedCardId === c.id;
 
             return (
               <div
@@ -597,11 +601,15 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
                 {!isBulkSelecting && !readOnly && (c.owner === viewerRole || isPublicRecoveryZone) && (
                   <div
                     className="modal-card-controls"
+                    data-testid={`search-card-controls-${c.id}`}
                     style={{
                       position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
                       background: 'rgba(0,0,0,0.85)', display: 'flex', flexDirection: 'column',
                       justifyContent: 'center', alignItems: 'center', gap: '4px',
-                      borderRadius: '4px', padding: '6px'
+                      borderRadius: '4px', padding: '6px',
+                      transition: 'opacity 0.15s ease',
+                      opacity: isCoarseInput ? (isTouchControlsOpen ? 1 : 0) : undefined,
+                      pointerEvents: isCoarseInput ? (isTouchControlsOpen ? 'auto' : 'none') : undefined,
                     }}
                   >
                     {canPlayToField && actionRole && (

--- a/src/components/GameBoardBottomHandSection.tsx
+++ b/src/components/GameBoardBottomHandSection.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Zone from './Zone';
 import GameBoardMulliganButton from './GameBoardMulliganButton';
 import GameBoardZoneActionsSection from './GameBoardZoneActionsSection';
+import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type ZoneAction = {
   label: string;
@@ -32,14 +33,6 @@ type GameBoardBottomHandSectionProps = {
   mulliganButtonStyle: React.CSSProperties;
 };
 
-const actionMenuWrapperStyle: React.CSSProperties = {
-  position: 'absolute',
-  right: '10px',
-  bottom: '-32px',
-  width: '180px',
-  zIndex: 30,
-};
-
 const GameBoardBottomHandSection: React.FC<GameBoardBottomHandSectionProps> = ({
   width,
   zoneProps,
@@ -53,42 +46,56 @@ const GameBoardBottomHandSection: React.FC<GameBoardBottomHandSectionProps> = ({
   mulliganLabel,
   onOpenMulligan,
   mulliganButtonStyle,
-}) => (
-  <div style={{ width: `${width}px`, minHeight: '160px', position: 'relative' }}>
-    <Zone {...zoneProps} />
+}) => {
+  const inputProfile = useGameBoardInputProfile();
+  const isCompactInput = inputProfile === 'coarse';
+  const actionMenuWrapperStyle: React.CSSProperties = {
+    position: 'absolute',
+    right: isCompactInput ? '8px' : '10px',
+    bottom: isCompactInput ? '8px' : '-32px',
+    width: isCompactInput ? '164px' : '180px',
+    zIndex: 30,
+  };
 
-    {showRandomDiscardMenu && (
-      <div style={actionMenuWrapperStyle}>
-        <GameBoardZoneActionsSection
-          menuId={randomDiscardZoneActions.menuId}
-          activeMenuId={activeMenuId}
-          actionsLabel={randomDiscardZoneActions.actionsLabel}
-          actions={randomDiscardZoneActions.actions}
-          onActiveMenuChange={onActiveMenuChange}
+  return (
+    <div style={{ width: `${width}px`, minHeight: '160px', position: 'relative' }}>
+      <Zone {...zoneProps} />
+
+      {showRandomDiscardMenu && (
+        <div style={actionMenuWrapperStyle}>
+          <GameBoardZoneActionsSection
+            menuId={randomDiscardZoneActions.menuId}
+            activeMenuId={activeMenuId}
+            actionsLabel={randomDiscardZoneActions.actionsLabel}
+            actions={randomDiscardZoneActions.actions}
+            direction={isCompactInput ? 'up' : 'down'}
+            onActiveMenuChange={onActiveMenuChange}
+          />
+        </div>
+      )}
+
+      {showRevealHandMenu && (
+        <div style={actionMenuWrapperStyle}>
+          <GameBoardZoneActionsSection
+            menuId={revealHandZoneActions.menuId}
+            activeMenuId={activeMenuId}
+            actionsLabel={revealHandZoneActions.actionsLabel}
+            actions={revealHandZoneActions.actions}
+            direction={isCompactInput ? 'up' : 'down'}
+            onActiveMenuChange={onActiveMenuChange}
+          />
+        </div>
+      )}
+
+      {showMulliganButton && (
+        <GameBoardMulliganButton
+          label={mulliganLabel}
+          onClick={onOpenMulligan}
+          style={mulliganButtonStyle}
         />
-      </div>
-    )}
-
-    {showRevealHandMenu && (
-      <div style={actionMenuWrapperStyle}>
-        <GameBoardZoneActionsSection
-          menuId={revealHandZoneActions.menuId}
-          activeMenuId={activeMenuId}
-          actionsLabel={revealHandZoneActions.actionsLabel}
-          actions={revealHandZoneActions.actions}
-          onActiveMenuChange={onActiveMenuChange}
-        />
-      </div>
-    )}
-
-    {showMulliganButton && (
-      <GameBoardMulliganButton
-        label={mulliganLabel}
-        onClick={onOpenMulligan}
-        style={mulliganButtonStyle}
-      />
-    )}
-  </div>
-);
+      )}
+    </div>
+  );
+};
 
 export default GameBoardBottomHandSection;

--- a/src/components/GameBoardHeader.tsx
+++ b/src/components/GameBoardHeader.tsx
@@ -5,6 +5,7 @@ import GameBoardRoomStatus from './GameBoardRoomStatus';
 import GameBoardTurnPanel from './GameBoardTurnPanel';
 import type { PlayerRole, SyncState } from '../types/game';
 import type { ConnectionBadgeTone, GameBoardConnectionState } from '../utils/gameBoardPresentation';
+import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type GameBoardHeaderProps = {
   room: string;
@@ -60,18 +61,34 @@ const GameBoardHeader: React.FC<GameBoardHeaderProps> = ({
   onRollDice,
   onOpenUndo,
   onPhaseChange,
-}) => (
-  <div
-    style={{
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      background: 'var(--bg-surface)',
-      padding: '0.75rem 1rem',
-      borderRadius: 'var(--radius-md)',
-    }}
-  >
-    <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
+}) => {
+  const inputProfile = useGameBoardInputProfile();
+  const isCompactControls = inputProfile === 'coarse';
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: isCompactControls ? 'stretch' : 'center',
+        flexWrap: isCompactControls ? 'wrap' : 'nowrap',
+        columnGap: isCompactControls ? '0.5rem' : undefined,
+        rowGap: isCompactControls ? '0.4rem' : undefined,
+        background: 'var(--bg-surface)',
+        padding: isCompactControls ? '0.48rem 0.62rem' : '0.75rem 1rem',
+        borderRadius: 'var(--radius-md)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          gap: isCompactControls ? '0.5rem' : '1rem',
+          alignItems: 'center',
+          flexWrap: isCompactControls ? 'wrap' : 'nowrap',
+          minWidth: 0,
+          flex: '1 1 auto',
+        }}
+      >
       <GameBoardRoomStatus
         room={room}
         isSoloMode={isSoloMode}
@@ -111,21 +128,24 @@ const GameBoardHeader: React.FC<GameBoardHeaderProps> = ({
           onOpenUndo={onOpenUndo}
         />
       ) : null}
-    </div>
+      </div>
 
-    {gameState.gameStatus === 'playing' && (
-      <GameBoardTurnPanel
-        isSoloMode={isSoloMode || isSpectator}
-        isCurrentPlayerTurn={gameState.turnPlayer === role}
-        currentTurnLabel={currentTurnLabel}
-        turnCount={gameState.turnCount}
-        phase={gameState.phase}
-        isBottomTurnActive={isBottomTurnActive}
-        canChangePhase={!isSpectator && (isSoloMode || gameState.turnPlayer === role)}
-        onPhaseChange={onPhaseChange}
-      />
-    )}
-  </div>
-);
+      {gameState.gameStatus === 'playing' && (
+        <div style={{ display: 'flex', flex: isCompactControls ? '1 1 100%' : undefined, justifyContent: isCompactControls ? 'flex-start' : 'flex-end', minWidth: 0 }}>
+          <GameBoardTurnPanel
+            isSoloMode={isSoloMode || isSpectator}
+            isCurrentPlayerTurn={gameState.turnPlayer === role}
+            currentTurnLabel={currentTurnLabel}
+            turnCount={gameState.turnCount}
+            phase={gameState.phase}
+            isBottomTurnActive={isBottomTurnActive}
+            canChangePhase={!isSpectator && (isSoloMode || gameState.turnPlayer === role)}
+            onPhaseChange={onPhaseChange}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
 
 export default GameBoardHeader;

--- a/src/components/GameBoardPlayerControlsPanel.test.tsx
+++ b/src/components/GameBoardPlayerControlsPanel.test.tsx
@@ -19,8 +19,8 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('./GameBoardPlayerTrackerSection', () => ({
-  default: ({ testId }: { testId: string }) => (
-    <div data-testid={testId}>Tracker</div>
+  default: ({ testId, compact }: { testId: string; compact?: boolean }) => (
+    <div data-testid={testId} data-compact={String(Boolean(compact))}>Tracker</div>
   ),
 }));
 
@@ -123,5 +123,28 @@ describe('GameBoardPlayerControlsPanel', () => {
     expect(screen.getByRole('button', { name: 'Load from My Decks' })).toHaveStyle({ fontSize: '0.72rem', minHeight: '34px' });
     expect(screen.getByRole('button', { name: 'Draw' })).toHaveStyle({ whiteSpace: 'normal' });
     expect(screen.getByRole('button', { name: 'Load from My Decks' })).toHaveStyle({ gridColumn: '1 / -1' });
+  });
+
+  it('passes compact tracker mode on narrow coarse panels to avoid vertical wrapping', () => {
+    renderWithInputProfile(
+      'coarse',
+      <GameBoardPlayerControlsPanel
+        {...createBaseProps()}
+        panelWidth={132}
+      />
+    );
+
+    expect(screen.getByTestId('player-tracker')).toHaveAttribute('data-compact', 'true');
+  });
+
+  it('keeps tracker in regular mode on desktop width panels', () => {
+    render(
+      <GameBoardPlayerControlsPanel
+        {...createBaseProps()}
+        panelWidth={220}
+      />
+    );
+
+    expect(screen.getByTestId('player-tracker')).toHaveAttribute('data-compact', 'false');
   });
 });

--- a/src/components/GameBoardPlayerControlsPanel.test.tsx
+++ b/src/components/GameBoardPlayerControlsPanel.test.tsx
@@ -13,6 +13,8 @@ vi.mock('react-i18next', () => ({
       if (key === 'gameBoard.zones.mill') return 'Mill';
       if (key === 'gameBoard.zones.topToEx') return 'Top to EX';
       if (key === 'gameBoard.zones.spawnToken') return 'Spawn Token';
+      if (key === 'gameBoard.board.stats.hp') return 'HP';
+      if (key === 'gameBoard.board.stats.playPoints') return 'PP';
       return key;
     },
   }),
@@ -119,8 +121,8 @@ describe('GameBoardPlayerControlsPanel', () => {
       />
     );
 
-    expect(screen.getByRole('button', { name: 'Draw' })).toHaveStyle({ fontSize: '0.68rem', minHeight: '34px' });
-    expect(screen.getByRole('button', { name: 'Load from My Decks' })).toHaveStyle({ fontSize: '0.72rem', minHeight: '34px' });
+    expect(screen.getByRole('button', { name: 'Draw' })).toHaveStyle({ fontSize: '0.64rem', minHeight: '30px' });
+    expect(screen.getByRole('button', { name: 'Load from My Decks' })).toHaveStyle({ fontSize: '0.66rem', minHeight: '30px' });
     expect(screen.getByRole('button', { name: 'Draw' })).toHaveStyle({ whiteSpace: 'normal' });
     expect(screen.getByRole('button', { name: 'Load from My Decks' })).toHaveStyle({ gridColumn: '1 / -1' });
   });
@@ -137,6 +139,20 @@ describe('GameBoardPlayerControlsPanel', () => {
     expect(screen.getByTestId('player-tracker')).toHaveAttribute('data-compact', 'true');
   });
 
+  it('uses collapsed tracker disclosure in coarse mode to save vertical space', () => {
+    renderWithInputProfile(
+      'coarse',
+      <GameBoardPlayerControlsPanel
+        {...createBaseProps()}
+        panelWidth={132}
+      />
+    );
+
+    expect(screen.getByTestId('player-controls-tracker-disclosure')).not.toHaveAttribute('open');
+    expect(screen.getByTestId('player-controls-tracker-summary')).toHaveTextContent('HP: 20');
+    expect(screen.getByTestId('player-controls-tracker-summary')).toHaveTextContent('PP: 0/0');
+  });
+
   it('keeps tracker in regular mode on desktop width panels', () => {
     render(
       <GameBoardPlayerControlsPanel
@@ -146,5 +162,6 @@ describe('GameBoardPlayerControlsPanel', () => {
     );
 
     expect(screen.getByTestId('player-tracker')).toHaveAttribute('data-compact', 'false');
+    expect(screen.queryByTestId('player-controls-tracker-disclosure')).not.toBeInTheDocument();
   });
 });

--- a/src/components/GameBoardPlayerControlsPanel.test.tsx
+++ b/src/components/GameBoardPlayerControlsPanel.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import GameBoardPlayerControlsPanel from './GameBoardPlayerControlsPanel';
+import GameBoardInputProfileProvider from '../contexts/GameBoardInputProfileProvider';
+import { initialState } from '../types/game';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      if (key === 'gameBoard.zones.controls') return `${options?.label ?? ''} Controls`;
+      if (key === 'gameBoard.zones.draw') return 'Draw';
+      if (key === 'gameBoard.zones.mill') return 'Mill';
+      if (key === 'gameBoard.zones.topToEx') return 'Top to EX';
+      if (key === 'gameBoard.zones.spawnToken') return 'Spawn Token';
+      return key;
+    },
+  }),
+}));
+
+vi.mock('./GameBoardPlayerTrackerSection', () => ({
+  default: ({ testId }: { testId: string }) => (
+    <div data-testid={testId}>Tracker</div>
+  ),
+}));
+
+const renderWithInputProfile = (
+  profile: 'fine' | 'coarse',
+  ui: React.ReactElement
+) => render(
+  <GameBoardInputProfileProvider value={profile}>
+    {ui}
+  </GameBoardInputProfileProvider>
+);
+
+const createBaseProps = () => ({
+  label: 'Player 1',
+  panelWidth: 220,
+  importDeckLabel: 'Import Deck',
+  loadSavedDeckLabel: 'Load from My Decks',
+  canImportDeck: true,
+  canOpenSavedDeckPicker: true,
+  onDeckUpload: vi.fn(),
+  onOpenSavedDeckPicker: vi.fn(),
+  canUsePlayingActions: true,
+  onDraw: vi.fn(),
+  onMill: vi.fn(),
+  onMoveTopCardToEx: vi.fn(),
+  drawButtonBackground: '#3b82f6',
+  canOpenTokenSpawn: true,
+  onOpenTokenSpawn: vi.fn(),
+  spawnButtonBackground: '#f59e0b',
+  trackerTestId: 'player-tracker',
+  playerState: initialState.host,
+  onAdjustStat: vi.fn(),
+});
+
+describe('GameBoardPlayerControlsPanel', () => {
+  it('keeps the primary actions stacked in a single column for fine input', () => {
+    render(
+      <GameBoardPlayerControlsPanel
+        {...createBaseProps()}
+      />
+    );
+
+    expect(screen.getByTestId('player-controls-primary-actions')).toHaveStyle({
+      display: 'flex',
+      flexDirection: 'column',
+    });
+  });
+
+  it('renders the primary actions in a two-column grid for coarse input', () => {
+    renderWithInputProfile(
+      'coarse',
+      <GameBoardPlayerControlsPanel
+        {...createBaseProps()}
+      />
+    );
+
+    expect(screen.getByTestId('player-controls-primary-actions')).toHaveStyle({
+      display: 'grid',
+      gridTemplateColumns: '1fr 1fr',
+    });
+  });
+
+  it('keeps draw action wiring intact in compact coarse mode', () => {
+    const props = createBaseProps();
+
+    renderWithInputProfile(
+      'coarse',
+      <GameBoardPlayerControlsPanel
+        {...props}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Draw' }));
+    expect(props.onDraw).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/GameBoardPlayerControlsPanel.test.tsx
+++ b/src/components/GameBoardPlayerControlsPanel.test.tsx
@@ -96,4 +96,18 @@ describe('GameBoardPlayerControlsPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Draw' }));
     expect(props.onDraw).toHaveBeenCalledTimes(1);
   });
+
+  it('uses readable text colors for primary action buttons', () => {
+    renderWithInputProfile(
+      'coarse',
+      <GameBoardPlayerControlsPanel
+        {...createBaseProps()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Draw' })).toHaveStyle({ color: 'rgb(248, 250, 252)' });
+    expect(screen.getByRole('button', { name: 'Mill' })).toHaveStyle({ color: 'rgb(248, 250, 252)' });
+    expect(screen.getByRole('button', { name: 'Top to EX' })).toHaveStyle({ color: 'rgb(248, 250, 252)' });
+    expect(screen.getByRole('button', { name: 'Spawn Token' })).toHaveStyle({ color: 'rgb(248, 250, 252)' });
+  });
 });

--- a/src/components/GameBoardPlayerControlsPanel.test.tsx
+++ b/src/components/GameBoardPlayerControlsPanel.test.tsx
@@ -110,4 +110,18 @@ describe('GameBoardPlayerControlsPanel', () => {
     expect(screen.getByRole('button', { name: 'Top to EX' })).toHaveStyle({ color: 'rgb(248, 250, 252)' });
     expect(screen.getByRole('button', { name: 'Spawn Token' })).toHaveStyle({ color: 'rgb(248, 250, 252)' });
   });
+
+  it('uses compact typography and touch target sizing for coarse input buttons', () => {
+    renderWithInputProfile(
+      'coarse',
+      <GameBoardPlayerControlsPanel
+        {...createBaseProps()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Draw' })).toHaveStyle({ fontSize: '0.68rem', minHeight: '34px' });
+    expect(screen.getByRole('button', { name: 'Load from My Decks' })).toHaveStyle({ fontSize: '0.72rem', minHeight: '34px' });
+    expect(screen.getByRole('button', { name: 'Draw' })).toHaveStyle({ whiteSpace: 'normal' });
+    expect(screen.getByRole('button', { name: 'Load from My Decks' })).toHaveStyle({ gridColumn: '1 / -1' });
+  });
 });

--- a/src/components/GameBoardPlayerControlsPanel.tsx
+++ b/src/components/GameBoardPlayerControlsPanel.tsx
@@ -67,6 +67,26 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
   const { t } = useTranslation();
   const inputProfile = useGameBoardInputProfile();
   const isCompactControls = inputProfile === 'coarse';
+  const compactButtonBaseStyle: React.CSSProperties = isCompactControls
+    ? {
+        minHeight: '34px',
+        fontSize: '0.68rem',
+        lineHeight: 1.15,
+        whiteSpace: 'normal',
+        overflowWrap: 'anywhere',
+        wordBreak: 'break-word',
+      }
+    : {};
+  const compactPrimaryActionLabelStyle: React.CSSProperties = isCompactControls
+    ? {
+        minHeight: '34px',
+        fontSize: '0.72rem',
+        lineHeight: 1.15,
+        whiteSpace: 'normal',
+        overflowWrap: 'anywhere',
+        wordBreak: 'break-word',
+      }
+    : {};
 
   return (
     <div
@@ -99,10 +119,15 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
           style={{
             padding: '0.5rem',
             background: 'var(--bg-surface-elevated)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
             textAlign: 'center',
+            gridColumn: isCompactControls ? '1 / -1' : undefined,
             cursor: canImportDeck ? 'pointer' : 'not-allowed',
-            fontSize: '0.875rem',
+            fontSize: isCompactControls ? '0.72rem' : '0.875rem',
             opacity: canImportDeck ? 1 : 0.5,
+            ...compactPrimaryActionLabelStyle,
           }}
         >
           {importDeckLabel}
@@ -131,12 +156,14 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
             color: '#f8fafc',
             fontWeight: 700,
             textAlign: 'center',
+            gridColumn: isCompactControls ? '1 / -1' : undefined,
             cursor: canImportDeck && canOpenSavedDeckPicker ? 'pointer' : 'not-allowed',
-            fontSize: '0.875rem',
+            fontSize: isCompactControls ? '0.72rem' : '0.875rem',
             boxShadow: canImportDeck && canOpenSavedDeckPicker
               ? '0 8px 18px rgba(5, 150, 105, 0.28)'
               : 'none',
             opacity: canImportDeck && canOpenSavedDeckPicker ? 1 : 0.5,
+            ...compactPrimaryActionLabelStyle,
           }}
         >
           {loadSavedDeckLabel}
@@ -153,6 +180,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
             fontWeight: 'bold',
             opacity: canUsePlayingActions ? 1 : 0.5,
             cursor: canUsePlayingActions ? 'pointer' : 'not-allowed',
+            ...compactButtonBaseStyle,
           }}
         >
           {t('gameBoard.zones.draw', { label })}
@@ -169,6 +197,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
             fontWeight: 'bold',
             opacity: canUsePlayingActions ? 1 : 0.5,
             cursor: canUsePlayingActions ? 'pointer' : 'not-allowed',
+            ...compactButtonBaseStyle,
           }}
         >
           {t('gameBoard.zones.mill', { label })}
@@ -185,6 +214,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
             fontWeight: 'bold',
             opacity: canUsePlayingActions ? 1 : 0.5,
             cursor: canUsePlayingActions ? 'pointer' : 'not-allowed',
+            ...compactButtonBaseStyle,
           }}
         >
           {t('gameBoard.zones.topToEx', { label })}
@@ -199,6 +229,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
             color: '#f8fafc',
             opacity: canOpenTokenSpawn ? 1 : 0.5,
             cursor: canOpenTokenSpawn ? 'pointer' : 'not-allowed',
+            ...compactButtonBaseStyle,
           }}
         >
           {t('gameBoard.zones.spawnToken', { label })}

--- a/src/components/GameBoardPlayerControlsPanel.tsx
+++ b/src/components/GameBoardPlayerControlsPanel.tsx
@@ -67,11 +67,14 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
   const { t } = useTranslation();
   const inputProfile = useGameBoardInputProfile();
   const isCompactControls = inputProfile === 'coarse';
+  const compactPanelPadding = isCompactControls ? '0.55rem' : '1rem';
+  const compactSectionGap = isCompactControls ? '0.3rem' : '0.5rem';
+  const compactCellPadding = isCompactControls ? '0.36rem' : '0.5rem';
   const compactButtonBaseStyle: React.CSSProperties = isCompactControls
     ? {
-        minHeight: '34px',
-        fontSize: '0.68rem',
-        lineHeight: 1.15,
+        minHeight: '30px',
+        fontSize: '0.64rem',
+        lineHeight: 1.1,
         whiteSpace: 'normal',
         overflowWrap: 'anywhere',
         wordBreak: 'break-word',
@@ -79,14 +82,15 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
     : {};
   const compactPrimaryActionLabelStyle: React.CSSProperties = isCompactControls
     ? {
-        minHeight: '34px',
-        fontSize: '0.72rem',
-        lineHeight: 1.15,
+        minHeight: '30px',
+        fontSize: '0.66rem',
+        lineHeight: 1.1,
         whiteSpace: 'normal',
         overflowWrap: 'anywhere',
         wordBreak: 'break-word',
       }
     : {};
+  const compactTrackerSummary = `${t('gameBoard.board.stats.hp')}: ${playerState.hp}  ${t('gameBoard.board.stats.playPoints')}: ${playerState.pp}/${playerState.maxPp}`;
 
   return (
     <div
@@ -95,14 +99,14 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
         boxSizing: 'border-box',
         display: 'flex',
         flexDirection: 'column',
-        gap: isCompactControls ? '0.4rem' : '0.5rem',
+        gap: isCompactControls ? '0.32rem' : '0.5rem',
         background: 'rgba(0,0,0,0.8)',
-        padding: isCompactControls ? '0.75rem' : '1rem',
+        padding: compactPanelPadding,
         borderRadius: 'var(--radius-md)',
         ...containerStyle,
       }}
     >
-      <div style={{ fontSize: '0.8rem', fontWeight: 'bold', color: 'white', marginBottom: '0.25rem' }}>
+      <div style={{ fontSize: isCompactControls ? '0.72rem' : '0.8rem', fontWeight: 'bold', color: 'white', marginBottom: isCompactControls ? '0.16rem' : '0.25rem' }}>
         {t('gameBoard.zones.controls', { label })}
       </div>
       <div
@@ -111,13 +115,13 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
           display: isCompactControls ? 'grid' : 'flex',
           flexDirection: isCompactControls ? undefined : 'column',
           gridTemplateColumns: isCompactControls ? '1fr 1fr' : undefined,
-          gap: isCompactControls ? '0.35rem' : '0.5rem',
+          gap: isCompactControls ? '0.28rem' : '0.5rem',
         }}
       >
         <label
           className="glass-panel"
           style={{
-            padding: '0.5rem',
+            padding: compactCellPadding,
             background: 'var(--bg-surface-elevated)',
             display: 'flex',
             alignItems: 'center',
@@ -146,7 +150,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
           disabled={!canImportDeck || !canOpenSavedDeckPicker}
           title={!canImportDeck || !canOpenSavedDeckPicker ? savedDeckPickerUnavailableTitle : undefined}
           style={{
-            padding: '0.5rem',
+            padding: compactCellPadding,
             background: canImportDeck && canOpenSavedDeckPicker
               ? 'linear-gradient(135deg, rgba(16, 185, 129, 0.9), rgba(5, 150, 105, 0.9))'
               : 'rgba(34, 197, 94, 0.18)',
@@ -174,7 +178,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
           disabled={!canUsePlayingActions}
           title={!canUsePlayingActions ? playingActionsDisabledTitle : undefined}
           style={{
-            padding: '0.5rem',
+            padding: compactCellPadding,
             background: drawButtonBackground,
             color: '#f8fafc',
             fontWeight: 'bold',
@@ -191,7 +195,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
           disabled={!canUsePlayingActions}
           title={!canUsePlayingActions ? playingActionsDisabledTitle : undefined}
           style={{
-            padding: '0.5rem',
+            padding: compactCellPadding,
             background: '#475569',
             color: '#f8fafc',
             fontWeight: 'bold',
@@ -208,7 +212,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
           disabled={!canUsePlayingActions}
           title={!canUsePlayingActions ? playingActionsDisabledTitle : undefined}
           style={{
-            padding: '0.5rem',
+            padding: compactCellPadding,
             background: '#334155',
             color: '#f8fafc',
             fontWeight: 'bold',
@@ -224,7 +228,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
           className="glass-panel"
           disabled={!canOpenTokenSpawn}
           style={{
-            padding: '0.5rem',
+            padding: compactCellPadding,
             background: spawnButtonBackground,
             color: '#f8fafc',
             opacity: canOpenTokenSpawn ? 1 : 0.5,
@@ -235,17 +239,60 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
           {t('gameBoard.zones.spawnToken', { label })}
         </button>
       </div>
-      {middleControls}
-      {afterSpawnControls}
-      {undoMoveButton}
-      <GameBoardPlayerTrackerSection
-        testId={trackerTestId}
-        label={label}
-        playerState={playerState}
-        onAdjustStat={onAdjustStat}
-        compact={isCompactControls && panelWidth <= 160}
-        readOnly={readOnlyTracker}
-      />
+      {(middleControls || afterSpawnControls || undoMoveButton) && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: compactSectionGap }}>
+          {middleControls}
+          {afterSpawnControls}
+          {undoMoveButton}
+        </div>
+      )}
+      {isCompactControls ? (
+        <details
+          data-testid="player-controls-tracker-disclosure"
+          style={{
+            marginTop: '0.04rem',
+            padding: '0.2rem 0.26rem',
+            background: 'rgba(255,255,255,0.03)',
+            border: '1px solid rgba(255,255,255,0.12)',
+            borderRadius: '8px',
+          }}
+        >
+          <summary
+            data-testid="player-controls-tracker-summary"
+            style={{
+              cursor: 'pointer',
+              color: '#bfdbfe',
+              fontSize: '0.58rem',
+              fontWeight: 700,
+              lineHeight: 1.2,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {compactTrackerSummary}
+          </summary>
+          <div style={{ marginTop: '0.2rem' }}>
+            <GameBoardPlayerTrackerSection
+              testId={trackerTestId}
+              label={label}
+              playerState={playerState}
+              onAdjustStat={onAdjustStat}
+              compact={panelWidth <= 180}
+              readOnly={readOnlyTracker}
+            />
+          </div>
+        </details>
+      ) : (
+        <GameBoardPlayerTrackerSection
+          testId={trackerTestId}
+          label={label}
+          playerState={playerState}
+          onAdjustStat={onAdjustStat}
+          compact={false}
+          readOnly={readOnlyTracker}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/GameBoardPlayerControlsPanel.tsx
+++ b/src/components/GameBoardPlayerControlsPanel.tsx
@@ -149,6 +149,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
           style={{
             padding: '0.5rem',
             background: drawButtonBackground,
+            color: '#f8fafc',
             fontWeight: 'bold',
             opacity: canUsePlayingActions ? 1 : 0.5,
             cursor: canUsePlayingActions ? 'pointer' : 'not-allowed',
@@ -164,6 +165,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
           style={{
             padding: '0.5rem',
             background: '#475569',
+            color: '#f8fafc',
             fontWeight: 'bold',
             opacity: canUsePlayingActions ? 1 : 0.5,
             cursor: canUsePlayingActions ? 'pointer' : 'not-allowed',
@@ -179,6 +181,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
           style={{
             padding: '0.5rem',
             background: '#334155',
+            color: '#f8fafc',
             fontWeight: 'bold',
             opacity: canUsePlayingActions ? 1 : 0.5,
             cursor: canUsePlayingActions ? 'pointer' : 'not-allowed',
@@ -193,6 +196,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
           style={{
             padding: '0.5rem',
             background: spawnButtonBackground,
+            color: '#f8fafc',
             opacity: canOpenTokenSpawn ? 1 : 0.5,
             cursor: canOpenTokenSpawn ? 'pointer' : 'not-allowed',
           }}

--- a/src/components/GameBoardPlayerControlsPanel.tsx
+++ b/src/components/GameBoardPlayerControlsPanel.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import GameBoardPlayerTrackerSection from './GameBoardPlayerTrackerSection';
 import type { SyncState } from '../types/game';
+import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type GameBoardPlayerControlsPanelProps = {
   label: string;
@@ -64,6 +65,8 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
   containerStyle,
 }) => {
   const { t } = useTranslation();
+  const inputProfile = useGameBoardInputProfile();
+  const isCompactControls = inputProfile === 'coarse';
 
   return (
     <div
@@ -72,9 +75,9 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
         boxSizing: 'border-box',
         display: 'flex',
         flexDirection: 'column',
-        gap: '0.5rem',
+        gap: isCompactControls ? '0.4rem' : '0.5rem',
         background: 'rgba(0,0,0,0.8)',
-        padding: '1rem',
+        padding: isCompactControls ? '0.75rem' : '1rem',
         borderRadius: 'var(--radius-md)',
         ...containerStyle,
       }}
@@ -82,112 +85,122 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
       <div style={{ fontSize: '0.8rem', fontWeight: 'bold', color: 'white', marginBottom: '0.25rem' }}>
         {t('gameBoard.zones.controls', { label })}
       </div>
-      <label
-        className="glass-panel"
+      <div
+        data-testid="player-controls-primary-actions"
         style={{
-          padding: '0.5rem',
-          background: 'var(--bg-surface-elevated)',
-          textAlign: 'center',
-          cursor: canImportDeck ? 'pointer' : 'not-allowed',
-          fontSize: '0.875rem',
-          opacity: canImportDeck ? 1 : 0.5,
+          display: isCompactControls ? 'grid' : 'flex',
+          flexDirection: isCompactControls ? undefined : 'column',
+          gridTemplateColumns: isCompactControls ? '1fr 1fr' : undefined,
+          gap: isCompactControls ? '0.35rem' : '0.5rem',
         }}
       >
-        {importDeckLabel}
-        <input
-          type="file"
-          accept=".json"
-          style={{ display: 'none' }}
-          onChange={onDeckUpload}
-          disabled={!canImportDeck}
-        />
-      </label>
-      <button
-        type="button"
-        className="glass-panel"
-        onClick={onOpenSavedDeckPicker}
-        disabled={!canImportDeck || !canOpenSavedDeckPicker}
-        title={!canImportDeck || !canOpenSavedDeckPicker ? savedDeckPickerUnavailableTitle : undefined}
-        style={{
-          padding: '0.5rem',
-          background: canImportDeck && canOpenSavedDeckPicker
-            ? 'linear-gradient(135deg, rgba(16, 185, 129, 0.9), rgba(5, 150, 105, 0.9))'
-            : 'rgba(34, 197, 94, 0.18)',
-          border: canImportDeck && canOpenSavedDeckPicker
-            ? '1px solid rgba(110, 231, 183, 0.45)'
-            : '1px solid var(--border-light)',
-          color: '#f8fafc',
-          fontWeight: 700,
-          textAlign: 'center',
-          cursor: canImportDeck && canOpenSavedDeckPicker ? 'pointer' : 'not-allowed',
-          fontSize: '0.875rem',
-          boxShadow: canImportDeck && canOpenSavedDeckPicker
-            ? '0 8px 18px rgba(5, 150, 105, 0.28)'
-            : 'none',
-          opacity: canImportDeck && canOpenSavedDeckPicker ? 1 : 0.5,
-        }}
-      >
-        {loadSavedDeckLabel}
-      </button>
-      <button
-        onClick={onDraw}
-        className="glass-panel"
-        disabled={!canUsePlayingActions}
-        title={!canUsePlayingActions ? playingActionsDisabledTitle : undefined}
-        style={{
-          padding: '0.5rem',
-          background: drawButtonBackground,
-          fontWeight: 'bold',
-          opacity: canUsePlayingActions ? 1 : 0.5,
-          cursor: canUsePlayingActions ? 'pointer' : 'not-allowed',
-        }}
-      >
-        {t('gameBoard.zones.draw', { label })}
-      </button>
-      <button
-        onClick={onMill}
-        className="glass-panel"
-        disabled={!canUsePlayingActions}
-        title={!canUsePlayingActions ? playingActionsDisabledTitle : undefined}
-        style={{
-          padding: '0.5rem',
-          background: '#475569',
-          fontWeight: 'bold',
-          opacity: canUsePlayingActions ? 1 : 0.5,
-          cursor: canUsePlayingActions ? 'pointer' : 'not-allowed',
-        }}
-      >
-        {t('gameBoard.zones.mill', { label })}
-      </button>
-      <button
-        onClick={onMoveTopCardToEx}
-        className="glass-panel"
-        disabled={!canUsePlayingActions}
-        title={!canUsePlayingActions ? playingActionsDisabledTitle : undefined}
-        style={{
-          padding: '0.5rem',
-          background: '#334155',
-          fontWeight: 'bold',
-          opacity: canUsePlayingActions ? 1 : 0.5,
-          cursor: canUsePlayingActions ? 'pointer' : 'not-allowed',
-        }}
-      >
-        {t('gameBoard.zones.topToEx', { label })}
-      </button>
+        <label
+          className="glass-panel"
+          style={{
+            padding: '0.5rem',
+            background: 'var(--bg-surface-elevated)',
+            textAlign: 'center',
+            cursor: canImportDeck ? 'pointer' : 'not-allowed',
+            fontSize: '0.875rem',
+            opacity: canImportDeck ? 1 : 0.5,
+          }}
+        >
+          {importDeckLabel}
+          <input
+            type="file"
+            accept=".json"
+            style={{ display: 'none' }}
+            onChange={onDeckUpload}
+            disabled={!canImportDeck}
+          />
+        </label>
+        <button
+          type="button"
+          className="glass-panel"
+          onClick={onOpenSavedDeckPicker}
+          disabled={!canImportDeck || !canOpenSavedDeckPicker}
+          title={!canImportDeck || !canOpenSavedDeckPicker ? savedDeckPickerUnavailableTitle : undefined}
+          style={{
+            padding: '0.5rem',
+            background: canImportDeck && canOpenSavedDeckPicker
+              ? 'linear-gradient(135deg, rgba(16, 185, 129, 0.9), rgba(5, 150, 105, 0.9))'
+              : 'rgba(34, 197, 94, 0.18)',
+            border: canImportDeck && canOpenSavedDeckPicker
+              ? '1px solid rgba(110, 231, 183, 0.45)'
+              : '1px solid var(--border-light)',
+            color: '#f8fafc',
+            fontWeight: 700,
+            textAlign: 'center',
+            cursor: canImportDeck && canOpenSavedDeckPicker ? 'pointer' : 'not-allowed',
+            fontSize: '0.875rem',
+            boxShadow: canImportDeck && canOpenSavedDeckPicker
+              ? '0 8px 18px rgba(5, 150, 105, 0.28)'
+              : 'none',
+            opacity: canImportDeck && canOpenSavedDeckPicker ? 1 : 0.5,
+          }}
+        >
+          {loadSavedDeckLabel}
+        </button>
+        <button
+          onClick={onDraw}
+          className="glass-panel"
+          disabled={!canUsePlayingActions}
+          title={!canUsePlayingActions ? playingActionsDisabledTitle : undefined}
+          style={{
+            padding: '0.5rem',
+            background: drawButtonBackground,
+            fontWeight: 'bold',
+            opacity: canUsePlayingActions ? 1 : 0.5,
+            cursor: canUsePlayingActions ? 'pointer' : 'not-allowed',
+          }}
+        >
+          {t('gameBoard.zones.draw', { label })}
+        </button>
+        <button
+          onClick={onMill}
+          className="glass-panel"
+          disabled={!canUsePlayingActions}
+          title={!canUsePlayingActions ? playingActionsDisabledTitle : undefined}
+          style={{
+            padding: '0.5rem',
+            background: '#475569',
+            fontWeight: 'bold',
+            opacity: canUsePlayingActions ? 1 : 0.5,
+            cursor: canUsePlayingActions ? 'pointer' : 'not-allowed',
+          }}
+        >
+          {t('gameBoard.zones.mill', { label })}
+        </button>
+        <button
+          onClick={onMoveTopCardToEx}
+          className="glass-panel"
+          disabled={!canUsePlayingActions}
+          title={!canUsePlayingActions ? playingActionsDisabledTitle : undefined}
+          style={{
+            padding: '0.5rem',
+            background: '#334155',
+            fontWeight: 'bold',
+            opacity: canUsePlayingActions ? 1 : 0.5,
+            cursor: canUsePlayingActions ? 'pointer' : 'not-allowed',
+          }}
+        >
+          {t('gameBoard.zones.topToEx', { label })}
+        </button>
+        <button
+          onClick={onOpenTokenSpawn}
+          className="glass-panel"
+          disabled={!canOpenTokenSpawn}
+          style={{
+            padding: '0.5rem',
+            background: spawnButtonBackground,
+            opacity: canOpenTokenSpawn ? 1 : 0.5,
+            cursor: canOpenTokenSpawn ? 'pointer' : 'not-allowed',
+          }}
+        >
+          {t('gameBoard.zones.spawnToken', { label })}
+        </button>
+      </div>
       {middleControls}
-      <button
-        onClick={onOpenTokenSpawn}
-        className="glass-panel"
-        disabled={!canOpenTokenSpawn}
-        style={{
-          padding: '0.5rem',
-          background: spawnButtonBackground,
-          opacity: canOpenTokenSpawn ? 1 : 0.5,
-          cursor: canOpenTokenSpawn ? 'pointer' : 'not-allowed',
-        }}
-      >
-        {t('gameBoard.zones.spawnToken', { label })}
-      </button>
       {afterSpawnControls}
       {undoMoveButton}
       <GameBoardPlayerTrackerSection

--- a/src/components/GameBoardPlayerControlsPanel.tsx
+++ b/src/components/GameBoardPlayerControlsPanel.tsx
@@ -243,6 +243,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
         label={label}
         playerState={playerState}
         onAdjustStat={onAdjustStat}
+        compact={isCompactControls && panelWidth <= 160}
         readOnly={readOnlyTracker}
       />
     </div>

--- a/src/components/GameBoardPlayerTracker.test.tsx
+++ b/src/components/GameBoardPlayerTracker.test.tsx
@@ -39,18 +39,18 @@ describe('GameBoardPlayerTracker', () => {
     );
 
     expect(screen.getByTestId('player-tracker-host')).toHaveStyle({
-      marginTop: '0.45rem',
-      padding: '0.45rem',
-      gap: '0.28rem',
+      marginTop: '0.25rem',
+      padding: '0.36rem',
+      gap: '0.24rem',
     });
     expect(screen.getByText('Player 2 Status')).toHaveStyle({
-      fontSize: '0.66rem',
+      fontSize: '0.62rem',
       whiteSpace: 'nowrap',
       textOverflow: 'ellipsis',
     });
     expect(screen.getByText('HP: 20').parentElement).toHaveStyle({
       flexWrap: 'nowrap',
-      gap: '0.22rem',
+      gap: '0.16rem',
     });
   });
 

--- a/src/components/GameBoardPlayerTracker.test.tsx
+++ b/src/components/GameBoardPlayerTracker.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import GameBoardPlayerTracker from './GameBoardPlayerTracker';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      if (key === 'gameBoard.board.statusLabel') return `${options?.label ?? ''} Status`;
+      if (key === 'gameBoard.board.stats.hp') return 'HP';
+      if (key === 'gameBoard.board.stats.ep') return 'EP';
+      if (key === 'gameBoard.board.stats.sep') return 'SEP';
+      if (key === 'gameBoard.board.stats.combo') return 'Combo';
+      if (key === 'gameBoard.board.stats.max') return 'MAX';
+      if (key === 'gameBoard.board.stats.playPoints') return 'PP';
+      return key;
+    },
+  }),
+}));
+
+const createBaseProps = () => ({
+  testId: 'player-tracker-host',
+  label: 'Player 2',
+  hp: 20,
+  ep: 2,
+  sep: 1,
+  combo: 0,
+  pp: 3,
+  maxPp: 4,
+  onAdjustStat: vi.fn(),
+});
+
+describe('GameBoardPlayerTracker', () => {
+  it('uses compact spacing and nowrap rows when compact mode is enabled', () => {
+    render(
+      <GameBoardPlayerTracker
+        {...createBaseProps()}
+        compact={true}
+      />
+    );
+
+    expect(screen.getByTestId('player-tracker-host')).toHaveStyle({
+      marginTop: '0.45rem',
+      padding: '0.45rem',
+      gap: '0.28rem',
+    });
+    expect(screen.getByText('Player 2 Status')).toHaveStyle({
+      fontSize: '0.66rem',
+      whiteSpace: 'nowrap',
+      textOverflow: 'ellipsis',
+    });
+    expect(screen.getByText('HP: 20').parentElement).toHaveStyle({
+      flexWrap: 'nowrap',
+      gap: '0.22rem',
+    });
+  });
+
+  it('keeps tracker adjustment wiring in compact mode', () => {
+    const props = createBaseProps();
+
+    render(
+      <GameBoardPlayerTracker
+        {...props}
+        compact={true}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('player-tracker-host-hp-increase'));
+    fireEvent.click(screen.getByTestId('player-tracker-host-pp-decrease'));
+
+    expect(props.onAdjustStat).toHaveBeenCalledWith('hp', 1);
+    expect(props.onAdjustStat).toHaveBeenCalledWith('pp', -1);
+  });
+});

--- a/src/components/GameBoardPlayerTracker.tsx
+++ b/src/components/GameBoardPlayerTracker.tsx
@@ -35,15 +35,15 @@ const GameBoardPlayerTracker: React.FC<GameBoardPlayerTrackerProps> = ({
   const trackerContainerStyle: React.CSSProperties = {
     display: 'flex',
     flexDirection: 'column',
-    gap: compact ? '0.28rem' : '0.4rem',
-    marginTop: compact ? '0.45rem' : '0.8rem',
-    padding: compact ? '0.45rem' : '0.6rem',
+    gap: compact ? '0.24rem' : '0.4rem',
+    marginTop: compact ? '0.25rem' : '0.8rem',
+    padding: compact ? '0.36rem' : '0.6rem',
     background: 'rgba(255,255,255,0.04)',
     borderRadius: 'var(--radius-md)',
     border: '1px solid var(--border-light)',
   };
   const trackerHeaderStyle: React.CSSProperties = {
-    fontSize: compact ? '0.66rem' : '0.8rem',
+    fontSize: compact ? '0.62rem' : '0.8rem',
     fontWeight: 'bold',
     color: 'white',
     lineHeight: 1.1,
@@ -55,24 +55,24 @@ const GameBoardPlayerTracker: React.FC<GameBoardPlayerTrackerProps> = ({
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    gap: compact ? '0.22rem' : '0.35rem',
+    gap: compact ? '0.16rem' : '0.35rem',
     flexWrap: 'nowrap',
   };
   const trackerStatLabelBaseStyle: React.CSSProperties = {
     fontWeight: 'bold',
-    fontSize: compact ? '0.66rem' : undefined,
+    fontSize: compact ? '0.62rem' : undefined,
     lineHeight: 1.1,
     whiteSpace: 'nowrap',
   };
   const trackerAdjustButtonBaseStyle: React.CSSProperties = {
-    minWidth: compact ? '22px' : '28px',
-    minHeight: compact ? '20px' : undefined,
-    padding: compact ? '1px 6px' : '2px 8px',
+    minWidth: compact ? '20px' : '28px',
+    minHeight: compact ? '18px' : undefined,
+    padding: compact ? '1px 5px' : '2px 8px',
     borderRadius: '4px',
     border: '1px solid',
     color: '#f8fafc',
     fontWeight: 'bold',
-    fontSize: compact ? '0.72rem' : undefined,
+    fontSize: compact ? '0.66rem' : undefined,
     cursor: 'pointer',
     boxShadow: '0 2px 6px rgba(0,0,0,0.22)',
   };
@@ -88,14 +88,14 @@ const GameBoardPlayerTracker: React.FC<GameBoardPlayerTrackerProps> = ({
   };
   const trackerButtonRowStyle: React.CSSProperties = {
     display: 'flex',
-    gap: compact ? '0.2rem' : '0.35rem',
+    gap: compact ? '0.16rem' : '0.35rem',
     flexShrink: 0,
   };
   const ppSectionStyle: React.CSSProperties = {
     display: 'flex',
     flexDirection: 'column',
-    gap: compact ? '0.28rem' : '0.4rem',
-    padding: compact ? '0.45rem' : '0.6rem',
+    gap: compact ? '0.22rem' : '0.4rem',
+    padding: compact ? '0.36rem' : '0.6rem',
     background: 'rgba(59, 130, 246, 0.15)',
     borderRadius: 'var(--radius-md)',
     border: '1px solid rgba(59, 130, 246, 0.3)',

--- a/src/components/GameBoardPlayerTracker.tsx
+++ b/src/components/GameBoardPlayerTracker.tsx
@@ -12,6 +12,7 @@ type GameBoardPlayerTrackerProps = {
   combo: number;
   pp: number;
   maxPp: number;
+  compact?: boolean;
   onAdjustStat: (stat: TrackerStat, delta: number) => void;
   readOnly?: boolean;
 };
@@ -25,18 +26,53 @@ const GameBoardPlayerTracker: React.FC<GameBoardPlayerTrackerProps> = ({
   combo,
   pp,
   maxPp,
+  compact = false,
   onAdjustStat,
   readOnly = false,
 }) => {
   const { t } = useTranslation();
 
+  const trackerContainerStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: compact ? '0.28rem' : '0.4rem',
+    marginTop: compact ? '0.45rem' : '0.8rem',
+    padding: compact ? '0.45rem' : '0.6rem',
+    background: 'rgba(255,255,255,0.04)',
+    borderRadius: 'var(--radius-md)',
+    border: '1px solid var(--border-light)',
+  };
+  const trackerHeaderStyle: React.CSSProperties = {
+    fontSize: compact ? '0.66rem' : '0.8rem',
+    fontWeight: 'bold',
+    color: 'white',
+    lineHeight: 1.1,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  };
+  const trackerStatRowStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: compact ? '0.22rem' : '0.35rem',
+    flexWrap: 'nowrap',
+  };
+  const trackerStatLabelBaseStyle: React.CSSProperties = {
+    fontWeight: 'bold',
+    fontSize: compact ? '0.66rem' : undefined,
+    lineHeight: 1.1,
+    whiteSpace: 'nowrap',
+  };
   const trackerAdjustButtonBaseStyle: React.CSSProperties = {
-    minWidth: '28px',
-    padding: '2px 8px',
+    minWidth: compact ? '22px' : '28px',
+    minHeight: compact ? '20px' : undefined,
+    padding: compact ? '1px 6px' : '2px 8px',
     borderRadius: '4px',
     border: '1px solid',
     color: '#f8fafc',
     fontWeight: 'bold',
+    fontSize: compact ? '0.72rem' : undefined,
     cursor: 'pointer',
     boxShadow: '0 2px 6px rgba(0,0,0,0.22)',
   };
@@ -52,58 +88,68 @@ const GameBoardPlayerTracker: React.FC<GameBoardPlayerTrackerProps> = ({
   };
   const trackerButtonRowStyle: React.CSSProperties = {
     display: 'flex',
-    gap: '0.35rem',
+    gap: compact ? '0.2rem' : '0.35rem',
+    flexShrink: 0,
+  };
+  const ppSectionStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: compact ? '0.28rem' : '0.4rem',
+    padding: compact ? '0.45rem' : '0.6rem',
+    background: 'rgba(59, 130, 246, 0.15)',
+    borderRadius: 'var(--radius-md)',
+    border: '1px solid rgba(59, 130, 246, 0.3)',
   };
 
   return (
-    <div data-testid={testId} style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem', marginTop: '0.8rem', padding: '0.6rem', background: 'rgba(255,255,255,0.04)', borderRadius: 'var(--radius-md)', border: '1px solid var(--border-light)' }}>
-      <div style={{ fontSize: '0.8rem', fontWeight: 'bold', color: 'white' }}>{t('gameBoard.board.statusLabel', { label })}</div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <span style={{ color: '#ef4444', fontWeight: 'bold' }}>{t('gameBoard.board.stats.hp')}: {hp}</span>
+    <div data-testid={testId} style={trackerContainerStyle}>
+      <div title={t('gameBoard.board.statusLabel', { label })} style={trackerHeaderStyle}>{t('gameBoard.board.statusLabel', { label })}</div>
+      <div style={trackerStatRowStyle}>
+        <span style={{ ...trackerStatLabelBaseStyle, color: '#ef4444' }}>{t('gameBoard.board.stats.hp')}: {hp}</span>
         {!readOnly && <div style={trackerButtonRowStyle}>
           <button data-testid={`${testId}-hp-increase`} onClick={() => onAdjustStat('hp', 1)} style={trackerIncreaseButtonStyle}>+</button>
           <button data-testid={`${testId}-hp-decrease`} onClick={() => onAdjustStat('hp', -1)} style={trackerDecreaseButtonStyle}>-</button>
         </div>}
       </div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <span style={{ color: '#fbbf24', fontWeight: 'bold' }}>{t('gameBoard.board.stats.ep')}: {ep}</span>
+      <div style={trackerStatRowStyle}>
+        <span style={{ ...trackerStatLabelBaseStyle, color: '#fbbf24' }}>{t('gameBoard.board.stats.ep')}: {ep}</span>
         {!readOnly && <div style={trackerButtonRowStyle}>
           <button data-testid={`${testId}-ep-increase`} onClick={() => onAdjustStat('ep', 1)} style={trackerIncreaseButtonStyle}>+</button>
           <button data-testid={`${testId}-ep-decrease`} onClick={() => onAdjustStat('ep', -1)} style={trackerDecreaseButtonStyle}>-</button>
         </div>}
       </div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <span style={{ color: '#facc15', fontWeight: 'bold' }}>{t('gameBoard.board.stats.sep')}: {sep}</span>
+      <div style={trackerStatRowStyle}>
+        <span style={{ ...trackerStatLabelBaseStyle, color: '#facc15' }}>{t('gameBoard.board.stats.sep')}: {sep}</span>
         {!readOnly && <div style={trackerButtonRowStyle}>
           <button data-testid={`${testId}-sep-increase`} onClick={() => onAdjustStat('sep', 1)} style={trackerIncreaseButtonStyle}>+</button>
           <button data-testid={`${testId}-sep-decrease`} onClick={() => onAdjustStat('sep', -1)} style={trackerDecreaseButtonStyle}>-</button>
         </div>}
       </div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <span style={{ color: '#fff', fontWeight: 'bold' }}>{t('gameBoard.board.stats.combo')}: {combo}</span>
+      <div style={trackerStatRowStyle}>
+        <span style={{ ...trackerStatLabelBaseStyle, color: '#fff' }}>{t('gameBoard.board.stats.combo')}: {combo}</span>
         {!readOnly && <div style={trackerButtonRowStyle}>
           <button data-testid={`${testId}-combo-increase`} onClick={() => onAdjustStat('combo', 1)} style={trackerIncreaseButtonStyle}>+</button>
           <button data-testid={`${testId}-combo-decrease`} onClick={() => onAdjustStat('combo', -1)} style={trackerDecreaseButtonStyle}>-</button>
         </div>}
       </div>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem', padding: '0.6rem', background: 'rgba(59, 130, 246, 0.15)', borderRadius: 'var(--radius-md)', border: '1px solid rgba(59, 130, 246, 0.3)' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          {!readOnly && <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '2px' }}>
-            <button data-testid={`${testId}-maxPp-increase`} onClick={() => onAdjustStat('maxPp', 1)} style={{ ...trackerIncreaseButtonStyle, width: '24px', height: '20px', minWidth: '24px', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 0, fontSize: '0.75rem' }}>+</button>
-            <span style={{ fontSize: '0.6rem', color: '#93c5fd', fontWeight: 'bold' }}>{t('gameBoard.board.stats.max')}</span>
-            <button data-testid={`${testId}-maxPp-decrease`} onClick={() => onAdjustStat('maxPp', -1)} style={{ ...trackerDecreaseButtonStyle, width: '24px', height: '20px', minWidth: '24px', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 0, fontSize: '0.75rem' }}>-</button>
+      <div style={ppSectionStyle}>
+        <div style={trackerStatRowStyle}>
+          {!readOnly && <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: compact ? '1px' : '2px', flexShrink: 0 }}>
+            <button data-testid={`${testId}-maxPp-increase`} onClick={() => onAdjustStat('maxPp', 1)} style={{ ...trackerIncreaseButtonStyle, width: compact ? '20px' : '24px', height: compact ? '18px' : '20px', minWidth: compact ? '20px' : '24px', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 0, fontSize: compact ? '0.66rem' : '0.75rem' }}>+</button>
+            <span style={{ fontSize: compact ? '0.54rem' : '0.6rem', color: '#93c5fd', fontWeight: 'bold', lineHeight: 1 }}>{t('gameBoard.board.stats.max')}</span>
+            <button data-testid={`${testId}-maxPp-decrease`} onClick={() => onAdjustStat('maxPp', -1)} style={{ ...trackerDecreaseButtonStyle, width: compact ? '20px' : '24px', height: compact ? '18px' : '20px', minWidth: compact ? '20px' : '24px', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 0, fontSize: compact ? '0.66rem' : '0.75rem' }}>-</button>
           </div>}
           <div style={{ textAlign: 'center', flex: 1 }}>
-            <div style={{ fontSize: '0.7rem', color: '#3b82f6', fontWeight: 'bold', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '-2px' }}>{t('gameBoard.board.stats.playPoints')}</div>
+            <div style={{ fontSize: compact ? '0.58rem' : '0.7rem', color: '#3b82f6', fontWeight: 'bold', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: compact ? 0 : '-2px', lineHeight: 1.1 }}>{t('gameBoard.board.stats.playPoints')}</div>
             <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'center', gap: '2px' }}>
-              <span style={{ color: '#3b82f6', fontWeight: '900', fontSize: '1.75rem' }}>{pp}</span>
-              <span style={{ color: 'rgba(255,255,255,0.5)', fontSize: '1rem', fontWeight: 'bold' }}>/</span>
-              <span style={{ color: '#fff', fontSize: '1.25rem', fontWeight: 'bold' }}>{maxPp}</span>
+              <span style={{ color: '#3b82f6', fontWeight: '900', fontSize: compact ? '1.2rem' : '1.75rem', lineHeight: 1 }}>{pp}</span>
+              <span style={{ color: 'rgba(255,255,255,0.5)', fontSize: compact ? '0.72rem' : '1rem', fontWeight: 'bold' }}>/</span>
+              <span style={{ color: '#fff', fontSize: compact ? '0.92rem' : '1.25rem', fontWeight: 'bold', lineHeight: 1 }}>{maxPp}</span>
             </div>
           </div>
-          {!readOnly && <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', alignItems: 'center' }}>
-            <button data-testid={`${testId}-pp-increase`} onClick={() => onAdjustStat('pp', 1)} style={{ width: '30px', height: '30px', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--bg-surface-elevated)', border: '1px solid var(--border-light)', borderRadius: '50%', cursor: 'pointer', fontSize: '1rem', color: '#3b82f6', fontWeight: 'bold' }}>∧</button>
-            <button data-testid={`${testId}-pp-decrease`} onClick={() => onAdjustStat('pp', -1)} style={{ width: '30px', height: '30px', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--bg-surface-elevated)', border: '1px solid var(--border-light)', borderRadius: '50%', cursor: 'pointer', fontSize: '1rem', color: '#3b82f6', fontWeight: 'bold' }}>∨</button>
+          {!readOnly && <div style={{ display: 'flex', flexDirection: 'column', gap: compact ? '4px' : '6px', alignItems: 'center', flexShrink: 0 }}>
+            <button data-testid={`${testId}-pp-increase`} onClick={() => onAdjustStat('pp', 1)} style={{ width: compact ? '24px' : '30px', height: compact ? '24px' : '30px', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--bg-surface-elevated)', border: '1px solid var(--border-light)', borderRadius: '50%', cursor: 'pointer', fontSize: compact ? '0.86rem' : '1rem', color: '#3b82f6', fontWeight: 'bold' }}>∧</button>
+            <button data-testid={`${testId}-pp-decrease`} onClick={() => onAdjustStat('pp', -1)} style={{ width: compact ? '24px' : '30px', height: compact ? '24px' : '30px', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--bg-surface-elevated)', border: '1px solid var(--border-light)', borderRadius: '50%', cursor: 'pointer', fontSize: compact ? '0.86rem' : '1rem', color: '#3b82f6', fontWeight: 'bold' }}>∨</button>
           </div>}
         </div>
       </div>

--- a/src/components/GameBoardPlayerTrackerSection.tsx
+++ b/src/components/GameBoardPlayerTrackerSection.tsx
@@ -6,6 +6,7 @@ type GameBoardPlayerTrackerSectionProps = {
   testId: string;
   label: string;
   playerState: SyncState['host'];
+  compact?: boolean;
   onAdjustStat: (
     stat: 'hp' | 'pp' | 'maxPp' | 'ep' | 'sep' | 'combo',
     delta: number
@@ -17,6 +18,7 @@ const GameBoardPlayerTrackerSection: React.FC<GameBoardPlayerTrackerSectionProps
   testId,
   label,
   playerState,
+  compact = false,
   onAdjustStat,
   readOnly = false,
 }) => (
@@ -29,6 +31,7 @@ const GameBoardPlayerTrackerSection: React.FC<GameBoardPlayerTrackerSectionProps
     combo={playerState.combo}
     pp={playerState.pp}
     maxPp={playerState.maxPp}
+    compact={compact}
     onAdjustStat={onAdjustStat}
     readOnly={readOnly}
   />

--- a/src/components/GameBoardPlayingControls.tsx
+++ b/src/components/GameBoardPlayingControls.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type GameBoardPlayingControlsProps = {
   canShowUndoTurn: boolean;
@@ -15,18 +16,26 @@ const GameBoardPlayingControls: React.FC<GameBoardPlayingControlsProps> = ({
   onOpenUndo,
 }) => {
   const { t } = useTranslation();
+  const inputProfile = useGameBoardInputProfile();
+  const isCompactControls = inputProfile === 'coarse';
+  const compactButtonStyle: React.CSSProperties = isCompactControls
+    ? { padding: '0.23rem 0.4rem', fontSize: '0.68rem', minHeight: '30px', lineHeight: 1.15 }
+    : { padding: '0.3rem 0.6rem', fontSize: '0.875rem' };
 
   return (
-    <>
+    <div
+      data-testid="gameboard-playing-controls"
+      style={{ display: 'flex', gap: isCompactControls ? '0.35rem' : '0.4rem', flexWrap: isCompactControls ? 'wrap' : 'nowrap' }}
+    >
       <button
         onClick={onTossCoin}
-        style={{ padding: '0.3rem 0.6rem', background: 'var(--bg-surface-elevated)', border: '1px solid var(--border-light)', color: 'white', borderRadius: '4px', cursor: 'pointer', fontSize: '0.875rem' }}
+        style={{ ...compactButtonStyle, background: 'var(--bg-surface-elevated)', border: '1px solid var(--border-light)', color: 'white', borderRadius: '4px', cursor: 'pointer' }}
       >
         {t('gameBoard.controls.tossCoin')}
       </button>
       <button
         onClick={onRollDice}
-        style={{ padding: '0.3rem 0.6rem', background: '#8b5cf6', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '0.875rem', fontWeight: 'bold' }}
+        style={{ ...compactButtonStyle, background: '#8b5cf6', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontWeight: 'bold' }}
       >
         {t('gameBoard.controls.rollDice')}
       </button>
@@ -35,14 +44,13 @@ const GameBoardPlayingControls: React.FC<GameBoardPlayingControlsProps> = ({
         <button
           onClick={onOpenUndo}
           style={{
-            padding: '0.3rem 0.6rem',
+            ...compactButtonStyle,
             background: '#ec4899',
             color: 'white',
             fontWeight: 'bold',
             border: '1px solid rgba(255,255,255,0.5)',
             borderRadius: '4px',
             cursor: 'pointer',
-            fontSize: '0.75rem',
             display: 'flex',
             alignItems: 'center',
             gap: '4px',
@@ -51,7 +59,7 @@ const GameBoardPlayingControls: React.FC<GameBoardPlayingControlsProps> = ({
           {t('gameBoard.turn.undo')}
         </button>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/GameBoardPreparationControls.tsx
+++ b/src/components/GameBoardPreparationControls.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import type { PlayerRole } from '../types/game';
 import GameBoardPreparationReadyStatus from './GameBoardPreparationReadyStatus';
+import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type GameBoardPreparationControlsProps = {
   isSoloMode: boolean;
@@ -41,29 +42,33 @@ const GameBoardPreparationControls: React.FC<GameBoardPreparationControlsProps> 
   onStartGame,
 }) => {
   const { t } = useTranslation();
+  const inputProfile = useGameBoardInputProfile();
+  const isCompactControls = inputProfile === 'coarse';
   const canConfigureTurnOrder = isHost || isSoloMode;
   const canStartGame = canConfigureTurnOrder && hostReady && guestReady;
+  const compactButtonPadding = isCompactControls ? '0.2rem 0.36rem' : '0.3rem 0.5rem';
+  const compactButtonFontSize = isCompactControls ? '0.66rem' : '0.75rem';
 
   return (
-    <div data-testid="preparation-controls" style={{ display: 'flex', gap: '0.4rem' }}>
+    <div data-testid="preparation-controls" style={{ display: 'flex', gap: isCompactControls ? '0.3rem' : '0.4rem', flexWrap: isCompactControls ? 'wrap' : 'nowrap' }}>
       <button
         onClick={() => onSetInitialTurnOrder()}
         disabled={!canConfigureTurnOrder}
-        style={{ padding: '0.3rem 0.5rem', background: 'var(--bg-surface-elevated)', border: '1px solid var(--border-light)', color: 'white', borderRadius: '4px', cursor: 'pointer', fontSize: '0.75rem', opacity: canConfigureTurnOrder ? 1 : 0.5 }}
+        style={{ padding: compactButtonPadding, background: 'var(--bg-surface-elevated)', border: '1px solid var(--border-light)', color: 'white', borderRadius: '4px', cursor: 'pointer', fontSize: compactButtonFontSize, opacity: canConfigureTurnOrder ? 1 : 0.5 }}
       >
         {t('gameBoard.controls.decideTurnOrder')}
       </button>
       <button
         onClick={() => onSetInitialTurnOrder(bottomRole)}
         disabled={!canConfigureTurnOrder}
-        style={{ padding: '0.3rem 0.5rem', background: '#3b82f6', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '0.75rem', opacity: canConfigureTurnOrder ? 1 : 0.5 }}
+        style={{ padding: compactButtonPadding, background: '#3b82f6', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: compactButtonFontSize, opacity: canConfigureTurnOrder ? 1 : 0.5 }}
       >
         {isSoloMode ? t('gameBoard.controls.p1First') : t('gameBoard.controls.meFirst')}
       </button>
       <button
         onClick={() => onSetInitialTurnOrder(topRole)}
         disabled={!canConfigureTurnOrder}
-        style={{ padding: '0.3rem 0.5rem', background: '#6366f1', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '0.75rem', opacity: canConfigureTurnOrder ? 1 : 0.5 }}
+        style={{ padding: compactButtonPadding, background: '#6366f1', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: compactButtonFontSize, opacity: canConfigureTurnOrder ? 1 : 0.5 }}
       >
         {isSoloMode ? t('gameBoard.controls.p2First') : t('gameBoard.controls.oppFirst')}
       </button>
@@ -71,7 +76,7 @@ const GameBoardPreparationControls: React.FC<GameBoardPreparationControlsProps> 
       {!bottomInitialHandDrawn && (
         <button
           onClick={() => onDrawInitialHand(bottomRole)}
-          style={{ padding: '0.3rem 0.6rem', background: '#3b82f6', color: 'white', fontWeight: 'bold', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '0.75rem' }}
+          style={{ padding: isCompactControls ? '0.24rem 0.5rem' : '0.3rem 0.6rem', background: '#3b82f6', color: 'white', fontWeight: 'bold', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: compactButtonFontSize }}
         >
           {t('gameBoard.controls.drawHand')}
         </button>
@@ -81,14 +86,14 @@ const GameBoardPreparationControls: React.FC<GameBoardPreparationControlsProps> 
         <button
           onClick={() => onToggleReady(bottomRole)}
           style={{
-            padding: '0.3rem 0.6rem',
+            padding: isCompactControls ? '0.24rem 0.5rem' : '0.3rem 0.6rem',
             background: bottomReady ? '#ef4444' : 'var(--vivid-green-cyan)',
             color: bottomReady ? 'white' : 'black',
             fontWeight: 'bold',
             border: 'none',
             borderRadius: '4px',
             cursor: 'pointer',
-            fontSize: '0.75rem',
+            fontSize: compactButtonFontSize,
           }}
         >
           {bottomReady ? t('gameBoard.controls.cancelReady') : (isSoloMode ? t('gameBoard.controls.p1Ready') : t('gameBoard.controls.ready'))}
@@ -98,7 +103,7 @@ const GameBoardPreparationControls: React.FC<GameBoardPreparationControlsProps> 
       {isSoloMode && !topInitialHandDrawn && (
         <button
           onClick={() => onDrawInitialHand(topRole)}
-          style={{ padding: '0.3rem 0.6rem', background: '#6366f1', color: 'white', fontWeight: 'bold', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '0.75rem' }}
+          style={{ padding: isCompactControls ? '0.24rem 0.5rem' : '0.3rem 0.6rem', background: '#6366f1', color: 'white', fontWeight: 'bold', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: compactButtonFontSize }}
         >
           {t('gameBoard.controls.drawP2Hand')}
         </button>
@@ -108,14 +113,14 @@ const GameBoardPreparationControls: React.FC<GameBoardPreparationControlsProps> 
         <button
           onClick={() => onToggleReady(topRole)}
           style={{
-            padding: '0.3rem 0.6rem',
+            padding: isCompactControls ? '0.24rem 0.5rem' : '0.3rem 0.6rem',
             background: topReady ? '#ef4444' : '#6366f1',
             color: 'white',
             fontWeight: 'bold',
             border: 'none',
             borderRadius: '4px',
             cursor: 'pointer',
-            fontSize: '0.75rem',
+            fontSize: compactButtonFontSize,
           }}
         >
           {topReady ? t('gameBoard.controls.cancelP2Ready') : t('gameBoard.controls.p2Ready')}
@@ -126,14 +131,14 @@ const GameBoardPreparationControls: React.FC<GameBoardPreparationControlsProps> 
         onClick={onStartGame}
         disabled={!canStartGame}
         style={{
-          padding: '0.3rem 0.6rem',
+          padding: isCompactControls ? '0.24rem 0.5rem' : '0.3rem 0.6rem',
           background: 'var(--vivid-green-cyan)',
           color: 'black',
           fontWeight: 'bold',
           border: 'none',
           borderRadius: '4px',
           cursor: canStartGame ? 'pointer' : 'not-allowed',
-          fontSize: '0.75rem',
+          fontSize: compactButtonFontSize,
           opacity: canStartGame ? 1 : 0.5,
           boxShadow: canStartGame ? '0 0 10px rgba(0, 208, 132, 0.4)' : 'none',
           transition: 'all 0.2s',

--- a/src/components/GameBoardRecentEventsPanel.tsx
+++ b/src/components/GameBoardRecentEventsPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type GameBoardRecentEventsPanelProps = {
   eventHistory: string[];
@@ -9,38 +10,49 @@ const GameBoardRecentEventsPanel: React.FC<GameBoardRecentEventsPanelProps> = ({
   eventHistory,
 }) => {
   const { t } = useTranslation();
+  const inputProfile = useGameBoardInputProfile();
+  const isCompact = inputProfile === 'coarse';
+  const maxVisibleEvents = isCompact ? 2 : eventHistory.length;
+  const visibleEvents = eventHistory.slice(0, maxVisibleEvents);
+  const hiddenEventsCount = Math.max(0, eventHistory.length - visibleEvents.length);
 
   return (
     <div
+      data-testid="gameboard-recent-events"
       style={{
         alignSelf: 'flex-end',
-        width: 'min(320px, 100%)',
+        width: isCompact ? 'min(240px, 100%)' : 'min(320px, 100%)',
         background: 'rgba(15, 23, 42, 0.88)',
         border: '1px solid rgba(148, 163, 184, 0.22)',
         borderRadius: '12px',
-        padding: '0.75rem 0.85rem',
+        padding: isCompact ? '0.45rem 0.52rem' : '0.75rem 0.85rem',
         display: 'flex',
         flexDirection: 'column',
-        gap: '0.45rem',
+        gap: isCompact ? '0.3rem' : '0.45rem',
       }}
     >
-      <div style={{ color: '#f8fafc', fontWeight: 800, fontSize: '0.8rem', letterSpacing: '0.03em' }}>
+      <div style={{ color: '#f8fafc', fontWeight: 800, fontSize: isCompact ? '0.66rem' : '0.8rem', letterSpacing: '0.03em' }}>
         {t('gameBoard.alerts.recentEvents')}
       </div>
-      {eventHistory.map((entry, index) => (
+      {visibleEvents.map((entry, index) => (
         <div
           key={`${entry}-${index}`}
           style={{
             color: index === 0 ? '#f8fafc' : '#cbd5e1',
-            fontSize: '0.78rem',
+            fontSize: isCompact ? '0.66rem' : '0.78rem',
             opacity: index === 0 ? 1 : 0.8,
             whiteSpace: 'pre-wrap',
-            lineHeight: 1.35,
+            lineHeight: isCompact ? 1.2 : 1.35,
           }}
         >
           {entry}
         </div>
       ))}
+      {hiddenEventsCount > 0 && (
+        <div style={{ fontSize: '0.62rem', color: '#93c5fd', fontWeight: 700 }}>
+          +{hiddenEventsCount}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/GameBoardRoomStatus.tsx
+++ b/src/components/GameBoardRoomStatus.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type ConnectionBadgeTone = {
   background: string;
@@ -34,10 +35,24 @@ const GameBoardRoomStatus: React.FC<GameBoardRoomStatusProps> = ({
   onReconnect,
 }) => {
   const { t } = useTranslation();
+  const inputProfile = useGameBoardInputProfile();
+  const isCompactControls = inputProfile === 'coarse';
+  const pillFontSize = isCompactControls ? '0.62rem' : '0.72rem';
+  const statusFontSize = isCompactControls ? '0.66rem' : undefined;
+  const buttonPadding = isCompactControls ? '0.2rem 0.4rem' : '0.28rem 0.55rem';
 
   return (
-    <>
-      <span>
+    <div
+      data-testid="gameboard-room-status"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: isCompactControls ? '0.4rem' : '0.6rem',
+        flexWrap: isCompactControls ? 'wrap' : 'nowrap',
+        minWidth: 0,
+      }}
+    >
+      <span style={{ fontSize: isCompactControls ? '0.68rem' : undefined, lineHeight: 1.2 }}>
         {isSoloMode ? t('gameBoard.header.mode') : t('gameBoard.header.room')}:{' '}
         <strong>{isSoloMode ? t('gameBoard.header.soloPlayBeta') : room}</strong>
       </span>
@@ -46,13 +61,13 @@ const GameBoardRoomStatus: React.FC<GameBoardRoomStatusProps> = ({
           type="button"
           onClick={onCopyRoomId}
           style={{
-            padding: '0.28rem 0.55rem',
+            padding: buttonPadding,
             background: isRoomCopied ? 'rgba(16, 185, 129, 0.18)' : '#334155',
             color: isRoomCopied ? '#d1fae5' : 'white',
             border: `1px solid ${isRoomCopied ? 'rgba(16, 185, 129, 0.38)' : 'rgba(255,255,255,0.14)'}`,
             borderRadius: '999px',
             cursor: 'pointer',
-            fontSize: '0.72rem',
+            fontSize: pillFontSize,
             fontWeight: 'bold',
             transition: 'all 0.2s ease',
           }}
@@ -64,12 +79,13 @@ const GameBoardRoomStatus: React.FC<GameBoardRoomStatusProps> = ({
       {isSoloMode && (
         <span
           style={{
-            fontSize: '0.75rem',
+            fontSize: isCompactControls ? '0.68rem' : '0.75rem',
             fontWeight: 'bold',
             color: '#111827',
             background: '#f59e0b',
             padding: '0.2rem 0.45rem',
             borderRadius: '999px',
+            whiteSpace: 'nowrap',
           }}
         >
           {t('home.cards.soloPlay.badge')}
@@ -83,35 +99,48 @@ const GameBoardRoomStatus: React.FC<GameBoardRoomStatusProps> = ({
             border: `1px solid ${connectionBadgeTone.border}`,
             background: connectionBadgeTone.background,
             color: connectionBadgeTone.color,
-            fontSize: '0.72rem',
+            fontSize: pillFontSize,
             fontWeight: 'bold',
             letterSpacing: '0.02em',
+            whiteSpace: 'nowrap',
           }}
         >
           {connectionBadgeTone.label}
         </span>
       )}
-      <span style={{ color: isSoloMode ? 'var(--vivid-green-cyan)' : 'var(--text-muted)' }}>{status}</span>
+      <span
+        style={{
+          color: isSoloMode ? 'var(--vivid-green-cyan)' : 'var(--text-muted)',
+          fontSize: statusFontSize,
+          lineHeight: 1.2,
+          minWidth: 0,
+          whiteSpace: isCompactControls ? 'normal' : undefined,
+          overflowWrap: isCompactControls ? 'anywhere' : undefined,
+        }}
+      >
+        {status}
+      </span>
       {!isSoloMode && !isHost && connectionState !== 'connected' && (
         <button
           onClick={onReconnect}
           disabled={connectionState === 'connecting'}
           title={connectionState === 'connecting' ? t('gameBoard.header.reconnectMessageConnecting') : t('gameBoard.header.reconnectMessageRetry')}
           style={{
-            padding: '0.3rem 0.6rem',
+            padding: isCompactControls ? '0.25rem 0.5rem' : '0.3rem 0.6rem',
             background: '#334155',
             color: 'white',
             border: '1px solid rgba(255,255,255,0.14)',
             borderRadius: '4px',
             cursor: connectionState === 'connecting' ? 'not-allowed' : 'pointer',
-            fontSize: '0.75rem',
+            fontSize: isCompactControls ? '0.68rem' : '0.75rem',
             opacity: connectionState === 'connecting' ? 0.6 : 1,
+            whiteSpace: 'nowrap',
           }}
         >
           {connectionState === 'reconnecting' ? t('gameBoard.header.reconnectNow') : t('gameBoard.header.reconnect')}
         </button>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/GameBoardStatusUi.test.tsx
+++ b/src/components/GameBoardStatusUi.test.tsx
@@ -387,6 +387,26 @@ describe('GameBoard extracted UI components - status and preparation', () => {
     expect(screen.getByText('Guest evolved Alpha Knight.')).toBeInTheDocument();
   });
 
+  it('shows a compact recent events panel and truncates history in coarse mode', () => {
+    renderWithInputProfile(
+      'coarse',
+      <GameBoardRecentEventsPanel
+        eventHistory={[
+          'Host drew a card.',
+          'Guest evolved Alpha Knight.',
+          'Host attacked the leader.',
+        ]}
+      />
+    );
+
+    const panel = screen.getByTestId('gameboard-recent-events');
+    expect(panel).toHaveStyle({ width: 'min(240px, 100%)', padding: '0.45rem 0.52rem' });
+    expect(screen.getByText('Host drew a card.')).toBeInTheDocument();
+    expect(screen.getByText('Guest evolved Alpha Knight.')).toBeInTheDocument();
+    expect(screen.queryByText('Host attacked the leader.')).not.toBeInTheDocument();
+    expect(screen.getByText('+1')).toBeInTheDocument();
+  });
+
   it('renders reconnect alert message', () => {
     render(<GameBoardReconnectAlert />);
 

--- a/src/components/GameBoardStatusUi.test.tsx
+++ b/src/components/GameBoardStatusUi.test.tsx
@@ -11,6 +11,7 @@ import GameBoardRecentEventsPanel from './GameBoardRecentEventsPanel';
 import GameBoardReconnectAlert from './GameBoardReconnectAlert';
 import GameBoardRoomStatus from './GameBoardRoomStatus';
 import GameBoardSavedSessionPrompt from './GameBoardSavedSessionPrompt';
+import GameBoardInputProfileProvider from '../contexts/GameBoardInputProfileProvider';
 
 vi.mock('./CardArtwork', () => ({
   default: ({ alt }: { alt: string }) => <img alt={alt} />,
@@ -31,6 +32,15 @@ vi.mock('./Zone', () => ({
     </section>
   ),
 }));
+
+const renderWithInputProfile = (
+  profile: 'fine' | 'coarse',
+  ui: React.ReactElement
+) => render(
+  <GameBoardInputProfileProvider value={profile}>
+    {ui}
+  </GameBoardInputProfileProvider>
+);
 
 describe('GameBoard extracted UI components - status and preparation', () => {
   it('renders room status in multiplayer and wires copy action', () => {
@@ -91,6 +101,32 @@ describe('GameBoard extracted UI components - status and preparation', () => {
 
     expect(onReconnect).toHaveBeenCalledTimes(1);
     expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+  });
+
+  it('allows status text wrapping for coarse room status instead of ellipsis', () => {
+    renderWithInputProfile(
+      'coarse',
+      <GameBoardRoomStatus
+        room="ROOM123"
+        isSoloMode={false}
+        isHost={false}
+        status="Connected with additional details shown in status area"
+        connectionState="connected"
+        connectionBadgeTone={{
+          label: 'Connected',
+          background: 'rgba(16, 185, 129, 0.16)',
+          border: 'rgba(16, 185, 129, 0.4)',
+          color: '#d1fae5',
+        }}
+        isRoomCopied={false}
+        onCopyRoomId={vi.fn()}
+        onReconnect={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Connected with additional details shown in status area')).toHaveStyle({
+      whiteSpace: 'normal',
+    });
   });
 
   it('renders saved session prompt and wires discard/resume actions', () => {
@@ -319,6 +355,21 @@ describe('GameBoard extracted UI components - status and preparation', () => {
     expect(onTossCoin).toHaveBeenCalledTimes(1);
     expect(onRollDice).toHaveBeenCalledTimes(1);
     expect(onOpenUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses compact button typography for coarse playing controls', () => {
+    renderWithInputProfile(
+      'coarse',
+      <GameBoardPlayingControls
+        canShowUndoTurn={true}
+        onTossCoin={vi.fn()}
+        onRollDice={vi.fn()}
+        onOpenUndo={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: '🪙 Toss Coin' })).toHaveStyle({ fontSize: '0.68rem' });
+    expect(screen.getByRole('button', { name: '🎲 Roll Dice' })).toHaveStyle({ fontSize: '0.68rem' });
   });
 
   it('renders recent events in order', () => {

--- a/src/components/GameBoardTopHandSection.tsx
+++ b/src/components/GameBoardTopHandSection.tsx
@@ -3,6 +3,7 @@ import Zone from './Zone';
 import GameBoardHandRow from './GameBoardHandRow';
 import GameBoardMulliganButton from './GameBoardMulliganButton';
 import GameBoardZoneActionsSection from './GameBoardZoneActionsSection';
+import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type ZoneAction = {
   label: string;
@@ -31,14 +32,6 @@ type GameBoardTopHandSectionProps = {
   mulliganButtonStyle?: React.CSSProperties;
 };
 
-const actionMenuWrapperStyle: React.CSSProperties = {
-  position: 'absolute',
-  right: '10px',
-  bottom: '-32px',
-  width: '180px',
-  zIndex: 30,
-};
-
 const GameBoardTopHandSection: React.FC<GameBoardTopHandSectionProps> = ({
   columns,
   width,
@@ -54,36 +47,49 @@ const GameBoardTopHandSection: React.FC<GameBoardTopHandSectionProps> = ({
   mulliganLabel,
   onOpenMulligan,
   mulliganButtonStyle,
-}) => (
-  <GameBoardHandRow
-    columns={columns}
-    width={width}
-    centerWidth={centerWidth}
-    justifyCenter={justifyCenter}
-    minHeight={minHeight}
-  >
-    <Zone {...zoneProps} />
+}) => {
+  const inputProfile = useGameBoardInputProfile();
+  const isCompactInput = inputProfile === 'coarse';
+  const actionMenuWrapperStyle: React.CSSProperties = {
+    position: 'absolute',
+    right: isCompactInput ? '8px' : '10px',
+    bottom: isCompactInput ? '8px' : '-32px',
+    width: isCompactInput ? '164px' : '180px',
+    zIndex: 30,
+  };
 
-    {showActionMenu && (
-      <div style={actionMenuWrapperStyle}>
-        <GameBoardZoneActionsSection
-          menuId={actionMenu.menuId}
-          activeMenuId={activeMenuId}
-          actionsLabel={actionMenu.actionsLabel}
-          actions={actionMenu.actions}
-          onActiveMenuChange={onActiveMenuChange}
+  return (
+    <GameBoardHandRow
+      columns={columns}
+      width={width}
+      centerWidth={centerWidth}
+      justifyCenter={justifyCenter}
+      minHeight={minHeight}
+    >
+      <Zone {...zoneProps} />
+
+      {showActionMenu && (
+        <div style={actionMenuWrapperStyle}>
+          <GameBoardZoneActionsSection
+            menuId={actionMenu.menuId}
+            activeMenuId={activeMenuId}
+            actionsLabel={actionMenu.actionsLabel}
+            actions={actionMenu.actions}
+            direction={isCompactInput ? 'up' : 'down'}
+            onActiveMenuChange={onActiveMenuChange}
+          />
+        </div>
+      )}
+
+      {showMulliganButton && mulliganLabel && onOpenMulligan && mulliganButtonStyle && (
+        <GameBoardMulliganButton
+          label={mulliganLabel}
+          onClick={onOpenMulligan}
+          style={mulliganButtonStyle}
         />
-      </div>
-    )}
-
-    {showMulliganButton && mulliganLabel && onOpenMulligan && mulliganButtonStyle && (
-      <GameBoardMulliganButton
-        label={mulliganLabel}
-        onClick={onOpenMulligan}
-        style={mulliganButtonStyle}
-      />
-    )}
-  </GameBoardHandRow>
-);
+      )}
+    </GameBoardHandRow>
+  );
+};
 
 export default GameBoardTopHandSection;

--- a/src/components/GameBoardTurnPanel.tsx
+++ b/src/components/GameBoardTurnPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type GamePhase = 'Start' | 'Main' | 'End';
 
@@ -25,17 +26,21 @@ const GameBoardTurnPanel: React.FC<GameBoardTurnPanelProps> = ({
   onPhaseChange,
 }) => {
   const { t } = useTranslation();
+  const inputProfile = useGameBoardInputProfile();
+  const isCompactControls = inputProfile === 'coarse';
 
   return (
     <div
+      data-testid="gameboard-turn-panel"
       style={{
         display: 'flex',
-        gap: '1rem',
+        gap: isCompactControls ? '0.5rem' : '1rem',
+        flexWrap: isCompactControls ? 'wrap' : 'nowrap',
         alignItems: 'center',
         background: isBottomTurnActive
           ? 'linear-gradient(90deg, rgba(0, 208, 132, 0.18), rgba(17, 24, 39, 0.92))'
           : 'var(--bg-overlay)',
-        padding: '0.55rem 1rem',
+        padding: isCompactControls ? '0.36rem 0.55rem' : '0.55rem 1rem',
         borderRadius: '10px',
         border: isBottomTurnActive ? '1px solid rgba(0, 208, 132, 0.28)' : '1px solid transparent',
         boxShadow: isBottomTurnActive ? '0 0 18px rgba(0, 208, 132, 0.16)' : 'none',
@@ -45,7 +50,9 @@ const GameBoardTurnPanel: React.FC<GameBoardTurnPanelProps> = ({
       <span
         style={{
           color: isSoloMode || isCurrentPlayerTurn ? 'var(--vivid-green-cyan)' : 'var(--vivid-red)',
-          fontSize: isBottomTurnActive ? '1rem' : '0.92rem',
+          fontSize: isCompactControls
+            ? (isBottomTurnActive ? '0.78rem' : '0.74rem')
+            : (isBottomTurnActive ? '1rem' : '0.92rem'),
           fontWeight: 900,
           letterSpacing: '0.06em',
           textShadow: isBottomTurnActive ? '0 0 12px rgba(0, 208, 132, 0.35)' : 'none',
@@ -55,7 +62,7 @@ const GameBoardTurnPanel: React.FC<GameBoardTurnPanelProps> = ({
           ? t('gameBoard.turn.p1', { label: currentTurnLabel.toUpperCase() })
           : isCurrentPlayerTurn ? t('gameBoard.turn.your') : t('gameBoard.turn.opponent')}
       </span>
-      <span className="Garamond" style={{ fontSize: isBottomTurnActive ? '1.08rem' : undefined }}>
+      <span className="Garamond" style={{ fontSize: isCompactControls ? (isBottomTurnActive ? '0.84rem' : '0.78rem') : (isBottomTurnActive ? '1.08rem' : undefined) }}>
         {t('gameBoard.turn.count', { count: turnCount })}
       </span>
       <select
@@ -64,10 +71,12 @@ const GameBoardTurnPanel: React.FC<GameBoardTurnPanelProps> = ({
         onChange={(event) => onPhaseChange(event.target.value as GamePhase)}
         disabled={!canChangePhase}
         style={{
-          padding: '0.2rem',
+          padding: isCompactControls ? '0.14rem 0.24rem' : '0.2rem',
           borderRadius: '4px',
           background: 'black',
           color: 'white',
+          fontSize: isCompactControls ? '0.66rem' : undefined,
+          minHeight: isCompactControls ? '28px' : undefined,
           border: isBottomTurnActive ? '1px solid rgba(0, 208, 132, 0.35)' : undefined,
         }}
       >

--- a/src/components/GameBoardZoneUi.test.tsx
+++ b/src/components/GameBoardZoneUi.test.tsx
@@ -13,6 +13,7 @@ import GameBoardTurnPanel from './GameBoardTurnPanel';
 import GameBoardZoneActionsMenu from './GameBoardZoneActionsMenu';
 import GameBoardZoneActionsSection from './GameBoardZoneActionsSection';
 import GameBoardZoneSearchButton from './GameBoardZoneSearchButton';
+import GameBoardInputProfileProvider from '../contexts/GameBoardInputProfileProvider';
 
 vi.mock('./CardArtwork', () => ({
   default: ({ alt }: { alt: string }) => <img alt={alt} />,
@@ -35,6 +36,15 @@ vi.mock('./Zone', () => ({
     </section>
   ),
 }));
+
+const renderWithInputProfile = (
+  profile: 'fine' | 'coarse',
+  ui: React.ReactElement
+) => render(
+  <GameBoardInputProfileProvider value={profile}>
+    {ui}
+  </GameBoardInputProfileProvider>
+);
 
 describe('GameBoard extracted UI components - zones and controls', () => {
   it('renders leader zone section and wires search action', () => {
@@ -424,5 +434,24 @@ describe('GameBoard extracted UI components - zones and controls', () => {
     fireEvent.change(screen.getByRole('combobox', { name: 'Phase' }), { target: { value: 'End' } });
 
     expect(onPhaseChange).toHaveBeenCalledWith('End');
+  });
+
+  it('uses compact spacing in turn panel for coarse input', () => {
+    renderWithInputProfile(
+      'coarse',
+      <GameBoardTurnPanel
+        isSoloMode={false}
+        isCurrentPlayerTurn={true}
+        currentTurnLabel="Self"
+        turnCount={3}
+        phase="Main"
+        isBottomTurnActive={true}
+        canChangePhase={true}
+        onPhaseChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('gameboard-turn-panel')).toHaveStyle({ gap: '0.5rem' });
+    expect(screen.getByRole('combobox', { name: 'Phase' })).toHaveStyle({ fontSize: '0.66rem' });
   });
 });

--- a/src/components/Zone.test.tsx
+++ b/src/components/Zone.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Zone from './Zone';
 import type { CardInstance } from './Card';
+import GameBoardInputProfileProvider from '../contexts/GameBoardInputProfileProvider';
 
 const droppableState = { isOver: false };
 
@@ -67,6 +68,15 @@ const createCard = (id: string, overrides: Partial<CardInstance> = {}): CardInst
   counters: { atk: 0, hp: 0 },
   ...overrides,
 });
+
+const renderWithInputProfile = (
+  profile: 'fine' | 'coarse',
+  ui: React.ReactElement
+) => render(
+  <GameBoardInputProfileProvider value={profile}>
+    {ui}
+  </GameBoardInputProfileProvider>
+);
 
 describe('Zone', () => {
   beforeEach(() => {
@@ -269,5 +279,18 @@ describe('Zone', () => {
     expect(linkedCard).toHaveAttribute('data-has-banish', 'false');
     expect(linkedCard).toHaveAttribute('data-has-cemetery', 'false');
     expect(linkedCard).toHaveAttribute('data-has-return-evolve', 'true');
+  });
+
+  it('uses tighter field spacing for coarse input', () => {
+    const { container } = renderWithInputProfile(
+      'coarse',
+      <Zone
+        id="field-host"
+        label="Field"
+        cards={[createCard('host-card')]}
+      />
+    );
+
+    expect(container.firstChild).toHaveStyle({ gap: '0.5rem' });
   });
 });

--- a/src/components/Zone.test.tsx
+++ b/src/components/Zone.test.tsx
@@ -293,4 +293,42 @@ describe('Zone', () => {
 
     expect(container.firstChild).toHaveStyle({ gap: '0.5rem' });
   });
+
+  it('uses compact zone label typography for coarse input', () => {
+    renderWithInputProfile(
+      'coarse',
+      <Zone
+        id="field-host"
+        label="Opponent Cemetery"
+        cards={[createCard('host-card')]}
+      />
+    );
+
+    const zoneLabel = screen.getByText('Cemetery');
+    expect(zoneLabel).toHaveStyle({ fontSize: '0.54rem' });
+    expect(zoneLabel).toHaveStyle({
+      whiteSpace: 'normal',
+      textOverflow: 'clip',
+      overflowWrap: 'normal',
+      wordBreak: 'keep-all',
+    });
+    expect(zoneLabel).toHaveAttribute('title', 'Cemetery');
+  });
+
+  it('keeps katakana zone labels from breaking mid-word in coarse input', () => {
+    renderWithInputProfile(
+      'coarse',
+      <Zone
+        id="evolve-host"
+        label="エボルヴ"
+        cards={[createCard('host-card')]}
+      />
+    );
+
+    const zoneLabel = screen.getByText('エボルヴ');
+    expect(zoneLabel).toHaveStyle({
+      overflowWrap: 'normal',
+      wordBreak: 'keep-all',
+    });
+  });
 });

--- a/src/components/Zone.test.tsx
+++ b/src/components/Zone.test.tsx
@@ -291,7 +291,7 @@ describe('Zone', () => {
       />
     );
 
-    expect(container.firstChild).toHaveStyle({ gap: '0.5rem' });
+    expect(container.firstChild).toHaveStyle({ gap: '0.36rem' });
   });
 
   it('uses compact zone label typography for coarse input', () => {
@@ -305,7 +305,7 @@ describe('Zone', () => {
     );
 
     const zoneLabel = screen.getByText('Cemetery');
-    expect(zoneLabel).toHaveStyle({ fontSize: '0.54rem' });
+    expect(zoneLabel).toHaveStyle({ fontSize: '0.5rem' });
     expect(zoneLabel).toHaveStyle({
       whiteSpace: 'normal',
       textOverflow: 'clip',

--- a/src/components/Zone.tsx
+++ b/src/components/Zone.tsx
@@ -42,6 +42,7 @@ interface Props {
 
 const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLookup, onInspectCard, onAttack, onTap, onModifyCounter, onModifyGenericCounter, onSendToBottom, onBanish, onReturnEvolve, onCemetery, onPlayToField, hideCards, layout = 'horizontal', isProtected, lockCards, disableQuickActionsForCard, getHighlightTone, viewerRole, containerStyle, isDebug }) => {
   const inputProfile = useGameBoardInputProfile();
+  const isCompactInput = inputProfile === 'coarse';
   const { isOver, setNodeRef } = useDroppable({ id });
   const cardSize = getCardSizeForInputProfile(inputProfile);
   const stackAttachmentOffset = getStackAttachmentOffsetForInputProfile(inputProfile);
@@ -133,14 +134,15 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
       <div
         style={{
           position: 'absolute',
-          top: -12,
-          left: 10,
+          top: isCompactInput ? -10 : -12,
+          left: isCompactInput ? 8 : 10,
           zIndex: 20,
-          display: 'inline-flex',
+          display: isCompactInput ? 'grid' : 'inline-flex',
+          gridTemplateColumns: isCompactInput ? 'minmax(0, 1fr) auto' : undefined,
           alignItems: 'center',
-          gap: '6px',
+          gap: isCompactInput ? '4px' : '6px',
           maxWidth: 'calc(100% - 20px)',
-          padding: '2px 8px',
+          padding: isCompactInput ? '2px 6px' : '2px 8px',
           background: 'rgba(17, 24, 39, 0.92)',
           border: '1px solid rgba(255,255,255,0.16)',
           borderRadius: '999px',
@@ -165,13 +167,19 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
           {label} ({topLevelCards.length})
         </span>
         <span
+          title={displayLabel}
           style={{
-            fontSize: '0.72rem',
+            maxWidth: isCompactInput ? '100%' : undefined,
+            minWidth: 0,
+            fontSize: isCompactInput ? '0.54rem' : '0.72rem',
             fontWeight: 'bold',
             color: 'white',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
+            whiteSpace: isCompactInput ? 'normal' : 'nowrap',
+            overflow: isCompactInput ? 'visible' : 'hidden',
+            textOverflow: isCompactInput ? 'clip' : 'ellipsis',
+            overflowWrap: isCompactInput ? 'normal' : undefined,
+            wordBreak: isCompactInput ? 'keep-all' : undefined,
+            lineHeight: isCompactInput ? 1.1 : undefined,
           }}
         >
           {displayLabel}
@@ -179,12 +187,12 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
         <span
           style={{
             flex: '0 0 auto',
-            minWidth: '22px',
-            padding: '0 6px',
+            minWidth: isCompactInput ? '20px' : '22px',
+            padding: isCompactInput ? '0 5px' : '0 6px',
             borderRadius: '999px',
             background: 'rgba(59, 130, 246, 0.24)',
             color: '#bfdbfe',
-            fontSize: '0.7rem',
+            fontSize: isCompactInput ? '0.52rem' : '0.7rem',
             fontWeight: 'bold',
             textAlign: 'center'
           }}

--- a/src/components/Zone.tsx
+++ b/src/components/Zone.tsx
@@ -4,6 +4,14 @@ import Card, { type CardInspectAnchor, type CardInstance } from './Card';
 import type { PlayerRole } from '../types/game';
 import type { CardStatLookup } from '../utils/cardStats';
 import type { CardDetailLookup } from '../utils/cardDetails';
+import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
+import {
+  getCardSizeForInputProfile,
+  getExZoneGapForInputProfile,
+  getFieldZoneGapForInputProfile,
+  getLinkedCardOffsetForInputProfile,
+  getStackAttachmentOffsetForInputProfile,
+} from '../utils/gameBoardCardLayout';
 
 interface Props {
   id: string;
@@ -33,12 +41,16 @@ interface Props {
 }
 
 const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLookup, onInspectCard, onAttack, onTap, onModifyCounter, onModifyGenericCounter, onSendToBottom, onBanish, onReturnEvolve, onCemetery, onPlayToField, hideCards, layout = 'horizontal', isProtected, lockCards, disableQuickActionsForCard, getHighlightTone, viewerRole, containerStyle, isDebug }) => {
+  const inputProfile = useGameBoardInputProfile();
   const { isOver, setNodeRef } = useDroppable({ id });
-  const attachmentTopOffset = 20;
-  const attachmentLeftOffset = 15;
-  const linkedCardTopOffset = 20;
-  const linkedCardLeftOffset = 15;
-  const linkedCardPaddingBottom = 24;
+  const cardSize = getCardSizeForInputProfile(inputProfile);
+  const stackAttachmentOffset = getStackAttachmentOffsetForInputProfile(inputProfile);
+  const linkedCardOffset = getLinkedCardOffsetForInputProfile(inputProfile);
+  const attachmentTopOffset = stackAttachmentOffset.top;
+  const attachmentLeftOffset = stackAttachmentOffset.left;
+  const linkedCardTopOffset = linkedCardOffset.top;
+  const linkedCardLeftOffset = linkedCardOffset.left;
+  const linkedCardPaddingBottom = linkedCardOffset.paddingBottom;
 
   const isStack = layout === 'stack';
   const isFieldZone = id.startsWith('field-');
@@ -105,7 +117,13 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
         position: 'relative',
         display: 'flex',
         flexDirection: isStack ? 'column' : 'row',
-        gap: isStack ? '0.5rem' : isFieldZone ? '1.9rem' : isExZone ? '1rem' : '0.5rem',
+        gap: isStack
+          ? '0.5rem'
+          : isFieldZone
+            ? getFieldZoneGapForInputProfile(inputProfile)
+            : isExZone
+              ? getExZoneGapForInputProfile(inputProfile)
+              : '0.5rem',
         flexWrap: isStack ? 'nowrap' : 'wrap',
         alignItems: isStack ? 'center' : 'flex-start',
         transition: 'var(--transition-fast)',
@@ -178,7 +196,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
       {(() => {
         if (isStack && topLevelCards.length > 0) {
           return (
-            <div style={{ position: 'relative', width: '100px', height: '140px' }}>
+            <div style={{ position: 'relative', width: `${cardSize.width}px`, height: `${cardSize.height}px` }}>
               {topLevelCards.map((card, index) => {
                 // To make index 0 (Top card) appear at the absolute top of the stack:
                 // 1. Give it the highest zIndex

--- a/src/components/Zone.tsx
+++ b/src/components/Zone.tsx
@@ -114,7 +114,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
         border: `2px dashed ${isOver ? 'var(--vivid-green-cyan)' : 'var(--border-light)'}`,
         backgroundColor: isOver ? 'rgba(0, 208, 132, 0.1)' : 'rgba(26, 29, 36, 0.5)',
         borderRadius: 'var(--radius-md)',
-        padding: '0.5rem',
+        padding: isCompactInput ? '0.36rem' : '0.5rem',
         position: 'relative',
         display: 'flex',
         flexDirection: isStack ? 'column' : 'row',
@@ -134,15 +134,15 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
       <div
         style={{
           position: 'absolute',
-          top: isCompactInput ? -10 : -12,
+          top: isCompactInput ? -8 : -12,
           left: isCompactInput ? 8 : 10,
           zIndex: 20,
           display: isCompactInput ? 'grid' : 'inline-flex',
           gridTemplateColumns: isCompactInput ? 'minmax(0, 1fr) auto' : undefined,
           alignItems: 'center',
-          gap: isCompactInput ? '4px' : '6px',
+          gap: isCompactInput ? '3px' : '6px',
           maxWidth: 'calc(100% - 20px)',
-          padding: isCompactInput ? '2px 6px' : '2px 8px',
+          padding: isCompactInput ? '1px 5px' : '2px 8px',
           background: 'rgba(17, 24, 39, 0.92)',
           border: '1px solid rgba(255,255,255,0.16)',
           borderRadius: '999px',
@@ -171,7 +171,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
           style={{
             maxWidth: isCompactInput ? '100%' : undefined,
             minWidth: 0,
-            fontSize: isCompactInput ? '0.54rem' : '0.72rem',
+            fontSize: isCompactInput ? '0.5rem' : '0.72rem',
             fontWeight: 'bold',
             color: 'white',
             whiteSpace: isCompactInput ? 'normal' : 'nowrap',
@@ -187,12 +187,12 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
         <span
           style={{
             flex: '0 0 auto',
-            minWidth: isCompactInput ? '20px' : '22px',
-            padding: isCompactInput ? '0 5px' : '0 6px',
+            minWidth: isCompactInput ? '18px' : '22px',
+            padding: isCompactInput ? '0 4px' : '0 6px',
             borderRadius: '999px',
             background: 'rgba(59, 130, 246, 0.24)',
             color: '#bfdbfe',
-            fontSize: isCompactInput ? '0.52rem' : '0.7rem',
+            fontSize: isCompactInput ? '0.48rem' : '0.7rem',
             fontWeight: 'bold',
             textAlign: 'center'
           }}

--- a/src/contexts/GameBoardInputProfileProvider.tsx
+++ b/src/contexts/GameBoardInputProfileProvider.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import type { GameBoardInputProfile } from '../utils/gameBoardInputProfile';
+import GameBoardInputProfileContext from './gameBoardInputProfileContext';
+
+type GameBoardInputProfileProviderProps = {
+  value: GameBoardInputProfile;
+  children: React.ReactNode;
+};
+
+const GameBoardInputProfileProvider: React.FC<GameBoardInputProfileProviderProps> = ({
+  value,
+  children,
+}) => (
+  <GameBoardInputProfileContext.Provider value={value}>
+    {children}
+  </GameBoardInputProfileContext.Provider>
+);
+
+export default GameBoardInputProfileProvider;

--- a/src/contexts/gameBoardInputProfileContext.ts
+++ b/src/contexts/gameBoardInputProfileContext.ts
@@ -1,0 +1,8 @@
+import React from 'react';
+import type { GameBoardInputProfile } from '../utils/gameBoardInputProfile';
+
+const GameBoardInputProfileContext = React.createContext<GameBoardInputProfile>('fine');
+
+export const useGameBoardInputProfile = () => React.useContext(GameBoardInputProfileContext);
+
+export default GameBoardInputProfileContext;

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -487,12 +487,14 @@
       "stand": "STAND",
       "attack": "Attack",
       "quickActions": {
+        "inspect": "Details",
         "sendToBottom": "Bot",
         "cemetery": "Cem",
         "banish": "Ban",
         "toEvolveDeck": "Evolve"
       },
       "quickActionDescriptions": {
+        "inspect": "View card details",
         "sendToBottom": "Send to bottom of deck",
         "cemetery": "Send to cemetery",
         "banish": "Banish this card",

--- a/src/i18n/ja/translation.json
+++ b/src/i18n/ja/translation.json
@@ -433,12 +433,14 @@
       "stand": "スタンド",
       "attack": "攻撃",
       "quickActions": {
+        "inspect": "詳細",
         "sendToBottom": "山下",
         "cemetery": "墓地",
         "banish": "消滅",
         "toEvolveDeck": "進化へ"
       },
       "quickActionDescriptions": {
+        "inspect": "カード詳細を表示",
         "sendToBottom": "山札の下に送る",
         "cemetery": "墓地に送る",
         "banish": "消滅させる",

--- a/src/pages/GameBoard.test.tsx
+++ b/src/pages/GameBoard.test.tsx
@@ -2759,7 +2759,7 @@ describe('GameBoard', () => {
       const topSection = screen.getByTestId('board-section-top');
       const topGrid = topSection.firstElementChild as HTMLElement;
 
-      expect(topGrid).toHaveStyle({ gridTemplateColumns: '148px 880px 180px' });
+      expect(topGrid).toHaveStyle({ gridTemplateColumns: '132px 629px 151px' });
     } finally {
       Object.defineProperty(window, 'innerWidth', {
         configurable: true,

--- a/src/pages/GameBoard.test.tsx
+++ b/src/pages/GameBoard.test.tsx
@@ -2880,4 +2880,43 @@ describe('GameBoard', () => {
       });
     }
   });
+
+  it('uses compact tablet spacing to reduce scroll amount in coarse mode', () => {
+    const originalInnerWidth = window.innerWidth;
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1024,
+    });
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => ({ matches: true })),
+    });
+
+    try {
+      const { container } = render(<GameBoard />);
+      const shell = container.firstElementChild as HTMLElement;
+      const playmat = screen.getByTestId('board-playmat');
+      const topSection = screen.getByTestId('board-section-top');
+      const topGrid = topSection.firstElementChild as HTMLElement;
+
+      expect(shell).toHaveStyle({ padding: '0.52rem', gap: '0.48rem' });
+      expect(playmat).toHaveStyle({ padding: '0.42rem', gap: '0.24rem' });
+      expect(topSection).toHaveStyle({ padding: '0.28rem 0.32rem' });
+      expect(topGrid).toHaveStyle({ columnGap: '0.5rem' });
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        writable: true,
+        value: originalInnerWidth,
+      });
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
+      });
+    }
+  });
 });

--- a/src/pages/GameBoard.test.tsx
+++ b/src/pages/GameBoard.test.tsx
@@ -2720,4 +2720,118 @@ describe('GameBoard', () => {
 
     expect(screen.getByText('ATTACK MODE')).toBeInTheDocument();
   });
+
+  it('uses desktop board shell columns when viewport width is 1280px', () => {
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1280,
+    });
+
+    try {
+      render(<GameBoard />);
+
+      const topSection = screen.getByTestId('board-section-top');
+      const topGrid = topSection.firstElementChild as HTMLElement;
+
+      expect(topGrid).toHaveStyle({ gridTemplateColumns: '188px 1080px 220px' });
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        writable: true,
+        value: originalInnerWidth,
+      });
+    }
+  });
+
+  it('uses tablet board shell columns when viewport width is 1024px', () => {
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1024,
+    });
+
+    try {
+      render(<GameBoard />);
+
+      const topSection = screen.getByTestId('board-section-top');
+      const topGrid = topSection.firstElementChild as HTMLElement;
+
+      expect(topGrid).toHaveStyle({ gridTemplateColumns: '148px 880px 180px' });
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        writable: true,
+        value: originalInnerWidth,
+      });
+    }
+  });
+
+  it('exposes fine input profile for desktop width by default', () => {
+    const originalInnerWidth = window.innerWidth;
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1280,
+    });
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    try {
+      const { container } = render(<GameBoard />);
+      const shell = container.firstElementChild as HTMLElement;
+      expect(shell).toHaveAttribute('data-layout-profile', 'desktop');
+      expect(shell).toHaveAttribute('data-input-profile', 'fine');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        writable: true,
+        value: originalInnerWidth,
+      });
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
+      });
+    }
+  });
+
+  it('exposes coarse input profile when viewport is tablet and pointer is coarse', () => {
+    const originalInnerWidth = window.innerWidth;
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1024,
+    });
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => ({ matches: true })),
+    });
+
+    try {
+      const { container } = render(<GameBoard />);
+      const shell = container.firstElementChild as HTMLElement;
+      expect(shell).toHaveAttribute('data-layout-profile', 'tablet');
+      expect(shell).toHaveAttribute('data-input-profile', 'coarse');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        writable: true,
+        value: originalInnerWidth,
+      });
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
+      });
+    }
+  });
 });

--- a/src/pages/GameBoard.test.tsx
+++ b/src/pages/GameBoard.test.tsx
@@ -2745,12 +2745,53 @@ describe('GameBoard', () => {
     }
   });
 
-  it('uses tablet board shell columns when viewport width is 1024px', () => {
+  it('keeps desktop board shell columns when viewport width is 1024px on fine pointer', () => {
     const originalInnerWidth = window.innerWidth;
+    const originalMatchMedia = window.matchMedia;
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
       writable: true,
       value: 1024,
+    });
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => ({ matches: false })),
+    });
+
+    try {
+      render(<GameBoard />);
+
+      const topSection = screen.getByTestId('board-section-top');
+      const topGrid = topSection.firstElementChild as HTMLElement;
+
+      expect(topGrid).toHaveStyle({ gridTemplateColumns: '188px 1080px 220px' });
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        writable: true,
+        value: originalInnerWidth,
+      });
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
+      });
+    }
+  });
+
+  it('uses tablet board shell columns when viewport width is 1024px on coarse pointer', () => {
+    const originalInnerWidth = window.innerWidth;
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1024,
+    });
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => ({ matches: true })),
     });
 
     try {
@@ -2765,6 +2806,11 @@ describe('GameBoard', () => {
         configurable: true,
         writable: true,
         value: originalInnerWidth,
+      });
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
       });
     }
   });

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -74,6 +74,10 @@ const GameBoard: React.FC = () => {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
+  const inputProfile = React.useMemo(
+    () => resolveInputProfile(viewportWidth),
+    [viewportWidth]
+  );
   const {
     profile: layoutProfile,
     sidePanelWidth,
@@ -83,10 +87,9 @@ const GameBoard: React.FC = () => {
     boardContentWidth,
     boardColumns,
     boardShellColumns,
-  } = React.useMemo(() => resolveBoardLayout(viewportWidth), [viewportWidth]);
-  const inputProfile = React.useMemo(
-    () => resolveInputProfile(viewportWidth),
-    [viewportWidth]
+  } = React.useMemo(
+    () => resolveBoardLayout(viewportWidth, inputProfile),
+    [viewportWidth, inputProfile]
   );
   const { t } = useTranslation();
   const {

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -78,6 +78,20 @@ const GameBoard: React.FC = () => {
     () => resolveInputProfile(viewportWidth),
     [viewportWidth]
   );
+  const isCompactBoard = inputProfile === 'coarse';
+  const boardShellPadding = isCompactBoard ? '0.52rem' : '1rem';
+  const boardShellGap = isCompactBoard ? '0.48rem' : '1rem';
+  const playmatPadding = isCompactBoard ? '0.42rem' : '1rem';
+  const playmatGap = isCompactBoard ? '0.24rem' : '0.5rem';
+  const boardSectionPadding = isCompactBoard ? '0.28rem 0.32rem' : '0.55rem 0.6rem';
+  const boardSectionGap = isCompactBoard ? '0.22rem' : '0.5rem';
+  const boardShellColumnGap = isCompactBoard ? '0.5rem' : '1rem';
+  const boardColumnStackGap = isCompactBoard ? '0.34rem' : '0.65rem';
+  const boardSectionDividerMargin = isCompactBoard ? '0.4rem 0' : '1rem 0';
+  const stackZoneMinHeight = isCompactBoard ? '110px' : '150px';
+  const fieldZoneMinHeight = isCompactBoard ? '124px' : '160px';
+  const handZoneMinHeight = isCompactBoard ? '116px' : '150px';
+  const bottomHandZoneMinHeight = isCompactBoard ? '124px' : '160px';
   const {
     profile: layoutProfile,
     sidePanelWidth,
@@ -421,7 +435,7 @@ const GameBoard: React.FC = () => {
     columns: boardColumns,
     width: boardContentWidth,
     centerWidth: centerZoneWidth,
-    minHeight: '150px',
+    minHeight: handZoneMinHeight,
     zoneProps: {
       id: `hand-${topRole}`,
       label: t('gameBoard.zones.hand', { label: topLabel }),
@@ -439,7 +453,7 @@ const GameBoard: React.FC = () => {
       onBanish: handleBanish,
       onCemetery: handleSendToCemetery,
       onPlayToField: (cardId: string) => handlePlayToField(cardId, topRole),
-      containerStyle: { minHeight: '150px' },
+      containerStyle: { minHeight: handZoneMinHeight },
     },
     activeMenuId: activeZoneActions,
     onActiveMenuChange: setActiveZoneActions,
@@ -466,7 +480,7 @@ const GameBoard: React.FC = () => {
       isProtected: true,
       lockCards: isPreparingHandMoveLocked,
       viewerRole,
-      containerStyle: { minHeight: '150px' },
+      containerStyle: { minHeight: handZoneMinHeight },
     },
     activeMenuId: activeZoneActions,
     onActiveMenuChange: setActiveZoneActions,
@@ -489,7 +503,7 @@ const GameBoard: React.FC = () => {
       isProtected: true,
       lockCards: isPreparingHandMoveLocked,
       viewerRole,
-      containerStyle: { minHeight: '160px' },
+      containerStyle: { minHeight: bottomHandZoneMinHeight },
       isDebug,
     },
     activeMenuId: activeZoneActions,
@@ -586,7 +600,7 @@ const GameBoard: React.FC = () => {
         <div
           data-layout-profile={layoutProfile}
           data-input-profile={inputProfile}
-          style={{ padding: '1rem', display: 'flex', flexDirection: 'column', height: '100%', gap: '1rem', overflow: 'hidden' }}
+          style={{ padding: boardShellPadding, display: 'flex', flexDirection: 'column', height: '100%', gap: boardShellGap, overflow: 'hidden' }}
         >
 
         <GameBoardHeader
@@ -654,16 +668,19 @@ const GameBoard: React.FC = () => {
         )}
 
         {/* Board Playmat */}
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '0.5rem', background: 'url("https://shadowverse-evolve.com/wordpress/wp-content/themes/shadowverse-evolve-release_v0/assets/images/common/bg.jpg")', backgroundSize: 'cover', backgroundPosition: 'center', borderRadius: 'var(--radius-lg)', padding: '1rem', overflowY: 'auto', overflowX: 'auto', alignItems: 'center' }}>
+        <div
+          data-testid="board-playmat"
+          style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: playmatGap, background: 'url("https://shadowverse-evolve.com/wordpress/wp-content/themes/shadowverse-evolve-release_v0/assets/images/common/bg.jpg")', backgroundSize: 'cover', backgroundPosition: 'center', borderRadius: 'var(--radius-lg)', padding: playmatPadding, overflowY: 'auto', overflowX: 'auto', alignItems: 'center' }}
+        >
 
           {/* OPPONENT BOARD */}
           <div
             data-testid="board-section-top"
             data-turn-active={String(shouldHighlightTopBoard)}
-            style={{ ...activeBoardSectionStyle(shouldHighlightTopBoard), opacity: 0.9 }}
+            style={{ ...activeBoardSectionStyle(shouldHighlightTopBoard), padding: boardSectionPadding, gap: boardSectionGap, opacity: 0.9 }}
           >
             {isSoloMode ? (
-              <div style={{ display: 'grid', gridTemplateColumns: boardShellColumns, columnGap: '1rem', alignItems: 'flex-start', width: '100%', maxWidth: '1568px', justifyContent: 'center' }}>
+              <div style={{ display: 'grid', gridTemplateColumns: boardShellColumns, columnGap: boardShellColumnGap, alignItems: 'flex-start', width: '100%', maxWidth: '1568px', justifyContent: 'center' }}>
                 <GameBoardPlayerControlsPanel
                   {...topControlsPanelProps}
                   middleControls={
@@ -682,12 +699,12 @@ const GameBoard: React.FC = () => {
                   readOnlyTracker={isSpectator}
                 />
 
-                <div style={{ width: `${boardContentWidth}px`, minWidth: 0, display: 'flex', flexDirection: 'column', gap: '0.65rem', alignItems: 'flex-start' }}>
+                <div style={{ width: `${boardContentWidth}px`, minWidth: 0, display: 'flex', flexDirection: 'column', gap: boardColumnStackGap, alignItems: 'flex-start' }}>
                   <GameBoardTopHandSection {...topSoloHandSectionProps} />
 
                   <GameBoardBoardRow columns={boardColumns} width={boardContentWidth}>
                     <GameBoardSearchableStackSection
-                      zoneProps={{ id: `cemetery-${topRole}`, label: t('gameBoard.zones.cemetery', { label: topLabel }), cards: getCards(`cemetery-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: '150px' }, isDebug }}
+                      zoneProps={{ id: `cemetery-${topRole}`, label: t('gameBoard.zones.cemetery', { label: topLabel }), cards: getCards(`cemetery-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                       searchLabel={t('gameBoard.zones.search')}
                       onSearch={() => openSearchZone(`cemetery-${topRole}`, t('gameBoard.zones.cemetery', { label: topLabel }))}
                       searchTitle={interactionBlockedTitle}
@@ -709,10 +726,10 @@ const GameBoard: React.FC = () => {
                       onReturnEvolve={handleReturnEvolve}
                       onCemetery={handleSendToCemetery}
                       onPlayToField={(cardId) => handlePlayToField(cardId, topRole)}
-                      containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: '150px', flex: 'none', width: `${centerZoneWidth}px` }}
+                      containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: stackZoneMinHeight, flex: 'none', width: `${centerZoneWidth}px` }}
                       />
                     <GameBoardSearchableStackSection
-                      zoneProps={{ id: `banish-${topRole}`, label: t('gameBoard.zones.banish', { label: topLabel }), cards: getCards(`banish-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: '150px' }, isDebug }}
+                      zoneProps={{ id: `banish-${topRole}`, label: t('gameBoard.zones.banish', { label: topLabel }), cards: getCards(`banish-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                       searchLabel={t('gameBoard.zones.search')}
                       onSearch={() => openSearchZone(`banish-${topRole}`, t('gameBoard.zones.banish', { label: topLabel }))}
                       searchTitle={interactionBlockedTitle}
@@ -744,7 +761,7 @@ const GameBoard: React.FC = () => {
                     }
                   >
                       <GameBoardMainDeckSection
-                        zoneProps={{ id: `mainDeck-${topRole}`, label: t('gameBoard.zones.mainDeck', { label: topLabel }), cards: getCards(`mainDeck-${topRole}`), cardDetailLookup, layout: 'stack', isProtected: true, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: '150px' }, isDebug }}
+                        zoneProps={{ id: `mainDeck-${topRole}`, label: t('gameBoard.zones.mainDeck', { label: topLabel }), cards: getCards(`mainDeck-${topRole}`), cardDetailLookup, layout: 'stack', isProtected: true, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                         menuId={topMainDeckZoneActions.menuId}
                         activeMenuId={activeZoneActions}
                         actionsLabel={topMainDeckZoneActions.actionsLabel}
@@ -771,11 +788,11 @@ const GameBoard: React.FC = () => {
                         onPlayToField={(cardId) => handlePlayToField(cardId, topRole)}
                         disableQuickActionsForCard={shouldDisableQuickActionsForAttackTarget}
                         viewerRole={viewerRole}
-                        containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: '160px', width: `${centerZoneWidth}px`, flex: 'none' }}
+                        containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: fieldZoneMinHeight, width: `${centerZoneWidth}px`, flex: 'none' }}
                         isDebug={isDebug}
                       />
                       <GameBoardSearchableStackSection
-                        zoneProps={{ id: `evolveDeck-${topRole}`, label: t('gameBoard.zones.evolveDeck', { label: topLabel }), cards: getCards(`evolveDeck-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, isProtected: true, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: '150px' }, isDebug }}
+                        zoneProps={{ id: `evolveDeck-${topRole}`, label: t('gameBoard.zones.evolveDeck', { label: topLabel }), cards: getCards(`evolveDeck-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, isProtected: true, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                         searchLabel={t('gameBoard.zones.search')}
                         onSearch={() => openSearchZone(`evolveDeck-${topRole}`, t('gameBoard.zones.evolveDeck', { label: topLabel }))}
                         searchTitle={interactionBlockedTitle}
@@ -786,7 +803,7 @@ const GameBoard: React.FC = () => {
                 <div />
               </div>
             ) : (
-              <div style={{ display: 'grid', gridTemplateColumns: boardShellColumns, columnGap: '1rem', alignItems: 'flex-start', width: '100%', maxWidth: '1568px', justifyContent: 'center' }}>
+              <div style={{ display: 'grid', gridTemplateColumns: boardShellColumns, columnGap: boardShellColumnGap, alignItems: 'flex-start', width: '100%', maxWidth: '1568px', justifyContent: 'center' }}>
                 <div style={{ width: `${topPanelWidth}px`, alignSelf: 'end' }}>
                   <GameBoardReadOnlyStatusSection
                     label={topLabel}
@@ -794,12 +811,12 @@ const GameBoard: React.FC = () => {
                   />
                 </div>
 
-                <div style={{ width: `${boardContentWidth}px`, minWidth: 0, display: 'flex', flexDirection: 'column', gap: '0.65rem', alignItems: 'flex-start' }}>
+                <div style={{ width: `${boardContentWidth}px`, minWidth: 0, display: 'flex', flexDirection: 'column', gap: boardColumnStackGap, alignItems: 'flex-start' }}>
                   <GameBoardTopHandSection {...topReadOnlyHandSectionProps} />
 
                   <GameBoardBoardRow columns={boardColumns} width={boardContentWidth}>
                     <GameBoardSearchableStackSection
-                      zoneProps={{ id: `cemetery-${topRole}`, label: t('gameBoard.zones.cemetery', { label: topLabel }), cards: getCards(`cemetery-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: '150px' }, isDebug }}
+                      zoneProps={{ id: `cemetery-${topRole}`, label: t('gameBoard.zones.cemetery', { label: topLabel }), cards: getCards(`cemetery-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                       searchLabel={t('gameBoard.zones.search')}
                       onSearch={() => openSearchZone(`cemetery-${topRole}`, t('gameBoard.zones.cemetery', { label: topLabel }))}
                     />
@@ -812,10 +829,10 @@ const GameBoard: React.FC = () => {
                       onInspectCard={handleInspectCard}
                       isProtected={false}
                       viewerRole={viewerRole}
-                      containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: '150px', flex: 'none', width: `${centerZoneWidth}px` }}
+                      containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: stackZoneMinHeight, flex: 'none', width: `${centerZoneWidth}px` }}
                     />
                     <GameBoardSearchableStackSection
-                      zoneProps={{ id: `banish-${topRole}`, label: t('gameBoard.zones.banish', { label: topLabel }), cards: getCards(`banish-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: '150px' }, isDebug }}
+                      zoneProps={{ id: `banish-${topRole}`, label: t('gameBoard.zones.banish', { label: topLabel }), cards: getCards(`banish-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                       searchLabel={t('gameBoard.zones.search')}
                       onSearch={() => openSearchZone(`banish-${topRole}`, t('gameBoard.zones.banish', { label: topLabel }))}
                     />
@@ -845,7 +862,7 @@ const GameBoard: React.FC = () => {
                     }
                   >
                       <GameBoardMainDeckSection
-                        zoneProps={{ id: `mainDeck-${topRole}`, label: t('gameBoard.zones.mainDeck', { label: topLabel }), cards: getCards(`mainDeck-${topRole}`), cardDetailLookup, layout: 'stack', isProtected: true, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: '150px' }, isDebug }}
+                        zoneProps={{ id: `mainDeck-${topRole}`, label: t('gameBoard.zones.mainDeck', { label: topLabel }), cards: getCards(`mainDeck-${topRole}`), cardDetailLookup, layout: 'stack', isProtected: true, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                         menuId={topReadOnlyMainDeckZoneActions.menuId}
                         activeMenuId={activeZoneActions}
                         actionsLabel={topReadOnlyMainDeckZoneActions.actionsLabel}
@@ -865,11 +882,11 @@ const GameBoard: React.FC = () => {
                         onCemetery={handleSendToCemetery}
                         disableQuickActionsForCard={shouldDisableQuickActionsForAttackTarget}
                         viewerRole={viewerRole}
-                        containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: '160px', width: `${centerZoneWidth}px`, flex: 'none' }}
+                        containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: fieldZoneMinHeight, width: `${centerZoneWidth}px`, flex: 'none' }}
                         isDebug={isDebug}
                       />
                       <GameBoardSearchableStackSection
-                        zoneProps={{ id: `evolveDeck-${topRole}`, label: t('gameBoard.zones.evolveDeck', { label: topLabel }), cards: getCards(`evolveDeck-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, isProtected: true, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: '150px' }, isDebug }}
+                        zoneProps={{ id: `evolveDeck-${topRole}`, label: t('gameBoard.zones.evolveDeck', { label: topLabel }), cards: getCards(`evolveDeck-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, isProtected: true, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                         searchLabel={t('common.buttons.search')}
                         onSearch={() => openSearchZone(`evolveDeck-${topRole}`, t('gameBoard.zones.evolveDeck', { label: topLabel }))}
                       />
@@ -880,17 +897,17 @@ const GameBoard: React.FC = () => {
             )}
           </div>
 
-          <hr style={{ borderColor: 'rgba(255,255,255,0.1)', margin: '1rem 0' }} />
+          <hr style={{ borderColor: 'rgba(255,255,255,0.1)', margin: boardSectionDividerMargin }} />
 
           {/* MY BOARD */}
           <div
             data-testid="board-section-bottom"
             data-turn-active={String(isBottomTurnActive)}
-            style={activeBoardSectionStyle(isBottomTurnActive)}
+            style={{ ...activeBoardSectionStyle(isBottomTurnActive), padding: boardSectionPadding, gap: boardSectionGap }}
           >
-	            <div style={{ display: 'grid', gridTemplateColumns: boardShellColumns, columnGap: '1rem', alignItems: 'flex-start', width: '100%', maxWidth: '1568px', justifyContent: 'center' }}>
+		            <div style={{ display: 'grid', gridTemplateColumns: boardShellColumns, columnGap: boardShellColumnGap, alignItems: 'flex-start', width: '100%', maxWidth: '1568px', justifyContent: 'center' }}>
                 <div />
-	              <div style={{ width: `${boardContentWidth}px`, minWidth: 0, display: 'flex', flexDirection: 'column', gap: '0.65rem', alignItems: 'flex-start' }}>
+		              <div style={{ width: `${boardContentWidth}px`, minWidth: 0, display: 'flex', flexDirection: 'column', gap: boardColumnStackGap, alignItems: 'flex-start' }}>
 	                <GameBoardBoardRow
                     columns={boardColumns}
                     width={boardContentWidth}
@@ -914,15 +931,15 @@ const GameBoard: React.FC = () => {
                     }
                   >
                   <GameBoardSearchableStackSection
-                    zoneProps={{ id: `evolveDeck-${bottomRole}`, label: t('gameBoard.zones.evolveDeck', { label: bottomLabel }), cards: getCards(`evolveDeck-${bottomRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, isProtected: true, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: '150px' }, isDebug }}
+                    zoneProps={{ id: `evolveDeck-${bottomRole}`, label: t('gameBoard.zones.evolveDeck', { label: bottomLabel }), cards: getCards(`evolveDeck-${bottomRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, isProtected: true, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                     searchLabel={t('common.buttons.search')}
                     onSearch={() => openSearchZone(`evolveDeck-${bottomRole}`, t('gameBoard.zones.evolveDeck', { label: bottomLabel }))}
                     searchTitle={interactionBlockedTitle}
                     isSearchInteractive={canView}
                   />
-                  <Zone id={`field-${bottomRole}`} label={t('gameBoard.zones.field', { label: bottomLabel })} cards={getCards(`field-${bottomRole}`)} cardStatLookup={cardStatLookup} cardDetailLookup={cardDetailLookup} getHighlightTone={getAttackHighlightTone} onInspectCard={handleInspectCard} onAttack={gameState.turnPlayer === bottomRole ? handleStartAttack : undefined} onTap={toggleTap} onModifyCounter={handleModifyCounter} onModifyGenericCounter={handleModifyGenericCounter} onSendToBottom={handleSendToBottom} onBanish={handleBanish} onReturnEvolve={handleReturnEvolve} onCemetery={handleSendToCemetery} onPlayToField={handlePlayToField} disableQuickActionsForCard={shouldDisableQuickActionsForAttackTarget} viewerRole={viewerRole} containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: '160px', width: `${centerZoneWidth}px`, flex: 'none' }} isDebug={isDebug} />
+                  <Zone id={`field-${bottomRole}`} label={t('gameBoard.zones.field', { label: bottomLabel })} cards={getCards(`field-${bottomRole}`)} cardStatLookup={cardStatLookup} cardDetailLookup={cardDetailLookup} getHighlightTone={getAttackHighlightTone} onInspectCard={handleInspectCard} onAttack={gameState.turnPlayer === bottomRole ? handleStartAttack : undefined} onTap={toggleTap} onModifyCounter={handleModifyCounter} onModifyGenericCounter={handleModifyGenericCounter} onSendToBottom={handleSendToBottom} onBanish={handleBanish} onReturnEvolve={handleReturnEvolve} onCemetery={handleSendToCemetery} onPlayToField={handlePlayToField} disableQuickActionsForCard={shouldDisableQuickActionsForAttackTarget} viewerRole={viewerRole} containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: fieldZoneMinHeight, width: `${centerZoneWidth}px`, flex: 'none' }} isDebug={isDebug} />
                   <GameBoardMainDeckSection
-                    zoneProps={{ id: `mainDeck-${bottomRole}`, label: t('gameBoard.zones.mainDeck', { label: bottomLabel }), cards: getCards(`mainDeck-${bottomRole}`), cardDetailLookup, layout: 'stack', isProtected: true, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: '150px' }, isDebug }}
+                    zoneProps={{ id: `mainDeck-${bottomRole}`, label: t('gameBoard.zones.mainDeck', { label: bottomLabel }), cards: getCards(`mainDeck-${bottomRole}`), cardDetailLookup, layout: 'stack', isProtected: true, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                     menuId={bottomMainDeckZoneActions.menuId}
                     activeMenuId={activeZoneActions}
                     actionsLabel={bottomMainDeckZoneActions.actionsLabel}
@@ -933,15 +950,15 @@ const GameBoard: React.FC = () => {
 
 	                <GameBoardBoardRow columns={boardColumns} width={boardContentWidth}>
                   <GameBoardSearchableStackSection
-                    zoneProps={{ id: `banish-${bottomRole}`, label: t('gameBoard.zones.banish', { label: bottomLabel }), cards: getCards(`banish-${bottomRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, onModifyCounter: handleModifyCounter, onSendToBottom: handleSendToBottom, onCemetery: handleSendToCemetery, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: '150px' }, isDebug }}
+                    zoneProps={{ id: `banish-${bottomRole}`, label: t('gameBoard.zones.banish', { label: bottomLabel }), cards: getCards(`banish-${bottomRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, onModifyCounter: handleModifyCounter, onSendToBottom: handleSendToBottom, onCemetery: handleSendToCemetery, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                     searchLabel={t('common.buttons.search')}
                     onSearch={() => openSearchZone(`banish-${bottomRole}`, t('gameBoard.zones.banish', { label: bottomLabel }))}
                     searchTitle={interactionBlockedTitle}
                     isSearchInteractive={canView}
                   />
-	                  <Zone id={`ex-${bottomRole}`} label={t('gameBoard.zones.exArea', { label: bottomLabel })} cards={getCards(`ex-${bottomRole}`)} cardStatLookup={cardStatLookup} cardDetailLookup={cardDetailLookup} onInspectCard={handleInspectCard} onModifyCounter={handleModifyCounter} onModifyGenericCounter={handleModifyGenericCounter} onSendToBottom={handleSendToBottom} onBanish={handleBanish} onReturnEvolve={handleReturnEvolve} onCemetery={handleSendToCemetery} onPlayToField={handlePlayToField} viewerRole={viewerRole} containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: '150px', flex: 'none', width: `${centerZoneWidth}px` }} isDebug={isDebug} />
+		                  <Zone id={`ex-${bottomRole}`} label={t('gameBoard.zones.exArea', { label: bottomLabel })} cards={getCards(`ex-${bottomRole}`)} cardStatLookup={cardStatLookup} cardDetailLookup={cardDetailLookup} onInspectCard={handleInspectCard} onModifyCounter={handleModifyCounter} onModifyGenericCounter={handleModifyGenericCounter} onSendToBottom={handleSendToBottom} onBanish={handleBanish} onReturnEvolve={handleReturnEvolve} onCemetery={handleSendToCemetery} onPlayToField={handlePlayToField} viewerRole={viewerRole} containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: stackZoneMinHeight, flex: 'none', width: `${centerZoneWidth}px` }} isDebug={isDebug} />
                   <GameBoardSearchableStackSection
-                    zoneProps={{ id: `cemetery-${bottomRole}`, label: t('gameBoard.zones.cemetery', { label: bottomLabel }), cards: getCards(`cemetery-${bottomRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, onModifyCounter: handleModifyCounter, onSendToBottom: handleSendToBottom, onBanish: handleBanish, onCemetery: handleSendToCemetery, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: '150px' }, isDebug }}
+                    zoneProps={{ id: `cemetery-${bottomRole}`, label: t('gameBoard.zones.cemetery', { label: bottomLabel }), cards: getCards(`cemetery-${bottomRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, onModifyCounter: handleModifyCounter, onSendToBottom: handleSendToBottom, onBanish: handleBanish, onCemetery: handleSendToCemetery, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                     searchLabel={t('common.buttons.search')}
                     onSearch={() => openSearchZone(`cemetery-${bottomRole}`, t('gameBoard.zones.cemetery', { label: bottomLabel }))}
                     searchTitle={interactionBlockedTitle}

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -651,7 +651,7 @@ const GameBoard: React.FC = () => {
         )}
 
         {/* Board Playmat */}
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '0.5rem', background: 'url("https://shadowverse-evolve.com/wordpress/wp-content/themes/shadowverse-evolve-release_v0/assets/images/common/bg.jpg")', backgroundSize: 'cover', backgroundPosition: 'center', borderRadius: 'var(--radius-lg)', padding: '1rem', overflowY: 'auto', alignItems: 'center' }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '0.5rem', background: 'url("https://shadowverse-evolve.com/wordpress/wp-content/themes/shadowverse-evolve-release_v0/assets/images/common/bg.jpg")', backgroundSize: 'cover', backgroundPosition: 'center', borderRadius: 'var(--radius-lg)', padding: '1rem', overflowY: 'auto', overflowX: 'auto', alignItems: 'center' }}>
 
           {/* OPPONENT BOARD */}
           <div

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -28,6 +28,7 @@ import GameBoardTopHandSection from '../components/GameBoardTopHandSection';
 import GameBoardTopNDialog from '../components/GameBoardTopNDialog';
 import GameBoardTokenSpawnDialog from '../components/GameBoardTokenSpawnDialog';
 import GameBoardUndoTurnDialog from '../components/GameBoardUndoTurnDialog';
+import GameBoardInputProfileProvider from '../contexts/GameBoardInputProfileProvider';
 import {
   buildMainDeckZoneActions,
   buildRandomDiscardHandZoneActions,
@@ -45,25 +46,48 @@ import type { AttackTarget } from '../types/sync';
 import {
   formatSavedSessionTimestamp,
 } from '../utils/gameBoardPresentation';
+import { resolveInputProfile } from '../utils/gameBoardInputProfile';
 import {
   shouldDismissModalOnBackdropClick,
 } from '../utils/gameBoardDismissals';
 import {
   activeBoardSectionStyle,
-  boardColumns,
-  boardContentWidth,
-  boardShellColumns,
-  centerZoneWidth,
-  sidePanelWidth,
-  sideZoneWidth,
+  resolveBoardLayout,
   soloMulliganButtonStyle,
-  topPanelWidth,
 } from './gameBoardLayout';
 import {
   getAttackTargetFromCard as resolveAttackTargetFromCard,
 } from '../utils/gameBoardCombat';
 
 const GameBoard: React.FC = () => {
+  const [viewportWidth, setViewportWidth] = React.useState(() => (
+    typeof window === 'undefined' ? 1280 : window.innerWidth
+  ));
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const handleResize = () => {
+      setViewportWidth(window.innerWidth);
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const {
+    profile: layoutProfile,
+    sidePanelWidth,
+    topPanelWidth,
+    sideZoneWidth,
+    centerZoneWidth,
+    boardContentWidth,
+    boardColumns,
+    boardShellColumns,
+  } = React.useMemo(() => resolveBoardLayout(viewportWidth), [viewportWidth]);
+  const inputProfile = React.useMemo(
+    () => resolveInputProfile(viewportWidth),
+    [viewportWidth]
+  );
   const { t } = useTranslation();
   const {
     room, isSoloMode, isHost, isSpectator, role, status, connectionState, canInteract, canView, attemptReconnect, gameState, savedSessionCandidate, resumeSavedSession, discardSavedSession, searchZone, setSearchZone,
@@ -555,7 +579,12 @@ const GameBoard: React.FC = () => {
       if (!canInteract) return;
       handleDragEnd(event);
     }}>
-      <div style={{ padding: '1rem', display: 'flex', flexDirection: 'column', height: '100%', gap: '1rem', overflow: 'hidden' }}>
+      <GameBoardInputProfileProvider value={inputProfile}>
+        <div
+          data-layout-profile={layoutProfile}
+          data-input-profile={inputProfile}
+          style={{ padding: '1rem', display: 'flex', flexDirection: 'column', height: '100%', gap: '1rem', overflow: 'hidden' }}
+        >
 
         <GameBoardHeader
           room={room}
@@ -1140,12 +1169,13 @@ const GameBoard: React.FC = () => {
         />
       )}
 
-      <GameBoardDialogsHost
-        savedDeckPicker={savedDeckPickerDialogProps}
-        evolveAutoAttach={evolveAutoAttachDialogProps}
-        searchShuffleConfirm={searchShuffleConfirmDialogProps}
-      />
-      <GameBoardCardInspectorSection {...cardInspectorSectionProps} />
+        <GameBoardDialogsHost
+          savedDeckPicker={savedDeckPickerDialogProps}
+          evolveAutoAttach={evolveAutoAttachDialogProps}
+          searchShuffleConfirm={searchShuffleConfirmDialogProps}
+        />
+        <GameBoardCardInspectorSection {...cardInspectorSectionProps} />
+      </GameBoardInputProfileProvider>
     </DndContext>
   );
 };

--- a/src/pages/gameBoardLayout.test.ts
+++ b/src/pages/gameBoardLayout.test.ts
@@ -45,4 +45,15 @@ describe('gameBoardLayout', () => {
     expect(getLayoutProfileForViewportWidth(899)).toBe('desktop');
     expect(getLayoutProfileForViewportWidth(1280)).toBe('desktop');
   });
+
+  it('fits tablet board shell within the viewport budget', () => {
+    const viewportWidth = 1024;
+    const layout = resolveBoardLayout(viewportWidth);
+
+    expect(layout.profile).toBe('tablet');
+    expect(layout.boardShellColumns).toBe('132px 629px 151px');
+
+    const boardShellWidth = layout.topPanelWidth + layout.boardContentWidth + layout.sidePanelWidth + (16 * 2);
+    expect(boardShellWidth).toBeLessThanOrEqual(944);
+  });
 });

--- a/src/pages/gameBoardLayout.test.ts
+++ b/src/pages/gameBoardLayout.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  boardColumns,
+  boardContentWidth,
+  boardShellColumns,
+  centerZoneWidth,
+  getLayoutProfileForViewportWidth,
+  resolveBoardLayout,
+  sidePanelWidth,
+  sideZoneWidth,
+  topPanelWidth,
+} from './gameBoardLayout';
+
+describe('gameBoardLayout', () => {
+  it('keeps legacy desktop constants unchanged', () => {
+    expect(sidePanelWidth).toBe(220);
+    expect(topPanelWidth).toBe(188);
+    expect(sideZoneWidth).toBe(140);
+    expect(centerZoneWidth).toBe(800);
+    expect(boardContentWidth).toBe(1080);
+    expect(boardColumns).toBe('140px 800px 140px');
+    expect(boardShellColumns).toBe('188px 1080px 220px');
+  });
+
+  it('uses desktop profile for widths >= 1280px', () => {
+    expect(getLayoutProfileForViewportWidth(1280)).toBe('desktop');
+    expect(getLayoutProfileForViewportWidth(1600)).toBe('desktop');
+
+    const layout = resolveBoardLayout(1280);
+    expect(layout.profile).toBe('desktop');
+    expect(layout.sidePanelWidth).toBe(220);
+    expect(layout.topPanelWidth).toBe(188);
+    expect(layout.sideZoneWidth).toBe(140);
+    expect(layout.centerZoneWidth).toBe(800);
+    expect(layout.boardContentWidth).toBe(1080);
+    expect(layout.boardColumns).toBe('140px 800px 140px');
+    expect(layout.boardShellColumns).toBe('188px 1080px 220px');
+  });
+
+  it('uses tablet profile only for widths between 900px and 1279px', () => {
+    expect(getLayoutProfileForViewportWidth(900)).toBe('tablet');
+    expect(getLayoutProfileForViewportWidth(1024)).toBe('tablet');
+    expect(getLayoutProfileForViewportWidth(1279)).toBe('tablet');
+
+    expect(getLayoutProfileForViewportWidth(899)).toBe('desktop');
+    expect(getLayoutProfileForViewportWidth(1280)).toBe('desktop');
+  });
+});

--- a/src/pages/gameBoardLayout.test.ts
+++ b/src/pages/gameBoardLayout.test.ts
@@ -23,10 +23,12 @@ describe('gameBoardLayout', () => {
   });
 
   it('uses desktop profile for widths >= 1280px', () => {
-    expect(getLayoutProfileForViewportWidth(1280)).toBe('desktop');
-    expect(getLayoutProfileForViewportWidth(1600)).toBe('desktop');
+    expect(getLayoutProfileForViewportWidth(1280, 'fine')).toBe('desktop');
+    expect(getLayoutProfileForViewportWidth(1280, 'coarse')).toBe('desktop');
+    expect(getLayoutProfileForViewportWidth(1600, 'fine')).toBe('desktop');
+    expect(getLayoutProfileForViewportWidth(1600, 'coarse')).toBe('desktop');
 
-    const layout = resolveBoardLayout(1280);
+    const layout = resolveBoardLayout(1280, 'fine');
     expect(layout.profile).toBe('desktop');
     expect(layout.sidePanelWidth).toBe(220);
     expect(layout.topPanelWidth).toBe(188);
@@ -37,23 +39,32 @@ describe('gameBoardLayout', () => {
     expect(layout.boardShellColumns).toBe('188px 1080px 220px');
   });
 
-  it('uses tablet profile only for widths between 900px and 1279px', () => {
-    expect(getLayoutProfileForViewportWidth(900)).toBe('tablet');
-    expect(getLayoutProfileForViewportWidth(1024)).toBe('tablet');
-    expect(getLayoutProfileForViewportWidth(1279)).toBe('tablet');
+  it('uses tablet profile in 900-1279px only when input profile is coarse', () => {
+    expect(getLayoutProfileForViewportWidth(900, 'coarse')).toBe('tablet');
+    expect(getLayoutProfileForViewportWidth(1024, 'coarse')).toBe('tablet');
+    expect(getLayoutProfileForViewportWidth(1279, 'coarse')).toBe('tablet');
 
-    expect(getLayoutProfileForViewportWidth(899)).toBe('desktop');
-    expect(getLayoutProfileForViewportWidth(1280)).toBe('desktop');
+    expect(getLayoutProfileForViewportWidth(900, 'fine')).toBe('desktop');
+    expect(getLayoutProfileForViewportWidth(1024, 'fine')).toBe('desktop');
+    expect(getLayoutProfileForViewportWidth(1279, 'fine')).toBe('desktop');
+    expect(getLayoutProfileForViewportWidth(899, 'coarse')).toBe('desktop');
+    expect(getLayoutProfileForViewportWidth(1280, 'coarse')).toBe('desktop');
   });
 
   it('fits tablet board shell within the viewport budget', () => {
     const viewportWidth = 1024;
-    const layout = resolveBoardLayout(viewportWidth);
+    const layout = resolveBoardLayout(viewportWidth, 'coarse');
 
     expect(layout.profile).toBe('tablet');
     expect(layout.boardShellColumns).toBe('132px 629px 151px');
 
     const boardShellWidth = layout.topPanelWidth + layout.boardContentWidth + layout.sidePanelWidth + (16 * 2);
     expect(boardShellWidth).toBeLessThanOrEqual(944);
+  });
+
+  it('keeps desktop board shell at 1024px when input profile is fine', () => {
+    const layout = resolveBoardLayout(1024, 'fine');
+    expect(layout.profile).toBe('desktop');
+    expect(layout.boardShellColumns).toBe('188px 1080px 220px');
   });
 });

--- a/src/pages/gameBoardLayout.ts
+++ b/src/pages/gameBoardLayout.ts
@@ -1,6 +1,7 @@
 import type { CSSProperties } from 'react';
 
 export type GameBoardLayoutProfile = 'desktop' | 'tablet';
+export type GameBoardLayoutInputProfile = 'fine' | 'coarse';
 
 export type GameBoardLayout = {
   profile: GameBoardLayoutProfile;
@@ -88,16 +89,26 @@ const resolveTabletLayout = (viewportWidth: number): GameBoardLayout => {
   });
 };
 
-export const getLayoutProfileForViewportWidth = (viewportWidth: number): GameBoardLayoutProfile => {
-  if (viewportWidth >= TABLET_MIN_WIDTH && viewportWidth < DESKTOP_MIN_WIDTH) {
-    return 'tablet';
+export const isTabletViewportWidth = (viewportWidth: number): boolean => (
+  viewportWidth >= TABLET_MIN_WIDTH && viewportWidth < DESKTOP_MIN_WIDTH
+);
+
+export const getLayoutProfileForViewportWidth = (
+  viewportWidth: number,
+  inputProfile: GameBoardLayoutInputProfile = 'coarse'
+): GameBoardLayoutProfile => {
+  if (!isTabletViewportWidth(viewportWidth)) {
+    return 'desktop';
   }
 
-  return 'desktop';
+  return inputProfile === 'coarse' ? 'tablet' : 'desktop';
 };
 
-export const resolveBoardLayout = (viewportWidth: number): GameBoardLayout => {
-  const profile = getLayoutProfileForViewportWidth(viewportWidth);
+export const resolveBoardLayout = (
+  viewportWidth: number,
+  inputProfile: GameBoardLayoutInputProfile = 'coarse'
+): GameBoardLayout => {
+  const profile = getLayoutProfileForViewportWidth(viewportWidth, inputProfile);
   return profile === 'tablet' ? resolveTabletLayout(viewportWidth) : desktopGameBoardLayout;
 };
 

--- a/src/pages/gameBoardLayout.ts
+++ b/src/pages/gameBoardLayout.ts
@@ -15,6 +15,14 @@ export type GameBoardLayout = {
 
 const TABLET_MIN_WIDTH = 900;
 const DESKTOP_MIN_WIDTH = 1280;
+const BOARD_SHELL_COLUMN_GAP = 16;
+const TABLET_VIEWPORT_HORIZONTAL_RESERVED = 80;
+const TABLET_MIN_SHELL_WIDTH = 860;
+const TABLET_MAX_SHELL_WIDTH = 1120;
+
+const clamp = (value: number, min: number, max: number): number => (
+  Math.min(Math.max(value, min), max)
+);
 
 const buildLayout = (
   profile: GameBoardLayoutProfile,
@@ -53,6 +61,33 @@ export const tabletGameBoardLayout = buildLayout('tablet', {
   centerZoneWidth: 640,
 });
 
+const resolveTabletLayout = (viewportWidth: number): GameBoardLayout => {
+  const boardShellWidth = clamp(
+    Math.round(viewportWidth - TABLET_VIEWPORT_HORIZONTAL_RESERVED),
+    TABLET_MIN_SHELL_WIDTH,
+    TABLET_MAX_SHELL_WIDTH
+  );
+
+  const topPanelWidth = clamp(Math.round(boardShellWidth * 0.14), 112, 148);
+  const sidePanelWidth = clamp(Math.round(boardShellWidth * 0.16), 128, 180);
+  const boardContentWidth = boardShellWidth - topPanelWidth - sidePanelWidth - (BOARD_SHELL_COLUMN_GAP * 2);
+
+  let sideZoneWidth = clamp(Math.round(boardContentWidth * 0.18), 100, 120);
+  let centerZoneWidth = boardContentWidth - (sideZoneWidth * 2);
+
+  if (centerZoneWidth < 360) {
+    sideZoneWidth = Math.max(90, Math.floor((boardContentWidth - 360) / 2));
+    centerZoneWidth = boardContentWidth - (sideZoneWidth * 2);
+  }
+
+  return buildLayout('tablet', {
+    sidePanelWidth,
+    topPanelWidth,
+    sideZoneWidth,
+    centerZoneWidth,
+  });
+};
+
 export const getLayoutProfileForViewportWidth = (viewportWidth: number): GameBoardLayoutProfile => {
   if (viewportWidth >= TABLET_MIN_WIDTH && viewportWidth < DESKTOP_MIN_WIDTH) {
     return 'tablet';
@@ -63,7 +98,7 @@ export const getLayoutProfileForViewportWidth = (viewportWidth: number): GameBoa
 
 export const resolveBoardLayout = (viewportWidth: number): GameBoardLayout => {
   const profile = getLayoutProfileForViewportWidth(viewportWidth);
-  return profile === 'tablet' ? tabletGameBoardLayout : desktopGameBoardLayout;
+  return profile === 'tablet' ? resolveTabletLayout(viewportWidth) : desktopGameBoardLayout;
 };
 
 // Keep legacy exports as desktop defaults to avoid changing the existing PC path.

--- a/src/pages/gameBoardLayout.ts
+++ b/src/pages/gameBoardLayout.ts
@@ -72,7 +72,7 @@ const resolveTabletLayout = (viewportWidth: number): GameBoardLayout => {
   const sidePanelWidth = clamp(Math.round(boardShellWidth * 0.16), 128, 180);
   const boardContentWidth = boardShellWidth - topPanelWidth - sidePanelWidth - (BOARD_SHELL_COLUMN_GAP * 2);
 
-  let sideZoneWidth = clamp(Math.round(boardContentWidth * 0.18), 100, 120);
+  let sideZoneWidth = clamp(Math.round(boardContentWidth * 0.125), 80, 104);
   let centerZoneWidth = boardContentWidth - (sideZoneWidth * 2);
 
   if (centerZoneWidth < 360) {

--- a/src/pages/gameBoardLayout.ts
+++ b/src/pages/gameBoardLayout.ts
@@ -1,12 +1,79 @@
 import type { CSSProperties } from 'react';
 
-export const sidePanelWidth = 220;
-export const topPanelWidth = 188;
-export const sideZoneWidth = 140;
-export const centerZoneWidth = 800;
-export const boardContentWidth = sideZoneWidth * 2 + centerZoneWidth;
-export const boardColumns = `${sideZoneWidth}px ${centerZoneWidth}px ${sideZoneWidth}px`;
-export const boardShellColumns = `${topPanelWidth}px ${boardContentWidth}px ${sidePanelWidth}px`;
+export type GameBoardLayoutProfile = 'desktop' | 'tablet';
+
+export type GameBoardLayout = {
+  profile: GameBoardLayoutProfile;
+  sidePanelWidth: number;
+  topPanelWidth: number;
+  sideZoneWidth: number;
+  centerZoneWidth: number;
+  boardContentWidth: number;
+  boardColumns: string;
+  boardShellColumns: string;
+};
+
+const TABLET_MIN_WIDTH = 900;
+const DESKTOP_MIN_WIDTH = 1280;
+
+const buildLayout = (
+  profile: GameBoardLayoutProfile,
+  {
+    sidePanelWidth,
+    topPanelWidth,
+    sideZoneWidth,
+    centerZoneWidth,
+  }: Pick<GameBoardLayout, 'sidePanelWidth' | 'topPanelWidth' | 'sideZoneWidth' | 'centerZoneWidth'>
+): GameBoardLayout => {
+  const boardContentWidth = sideZoneWidth * 2 + centerZoneWidth;
+
+  return {
+    profile,
+    sidePanelWidth,
+    topPanelWidth,
+    sideZoneWidth,
+    centerZoneWidth,
+    boardContentWidth,
+    boardColumns: `${sideZoneWidth}px ${centerZoneWidth}px ${sideZoneWidth}px`,
+    boardShellColumns: `${topPanelWidth}px ${boardContentWidth}px ${sidePanelWidth}px`,
+  };
+};
+
+export const desktopGameBoardLayout = buildLayout('desktop', {
+  sidePanelWidth: 220,
+  topPanelWidth: 188,
+  sideZoneWidth: 140,
+  centerZoneWidth: 800,
+});
+
+export const tabletGameBoardLayout = buildLayout('tablet', {
+  sidePanelWidth: 180,
+  topPanelWidth: 148,
+  sideZoneWidth: 120,
+  centerZoneWidth: 640,
+});
+
+export const getLayoutProfileForViewportWidth = (viewportWidth: number): GameBoardLayoutProfile => {
+  if (viewportWidth >= TABLET_MIN_WIDTH && viewportWidth < DESKTOP_MIN_WIDTH) {
+    return 'tablet';
+  }
+
+  return 'desktop';
+};
+
+export const resolveBoardLayout = (viewportWidth: number): GameBoardLayout => {
+  const profile = getLayoutProfileForViewportWidth(viewportWidth);
+  return profile === 'tablet' ? tabletGameBoardLayout : desktopGameBoardLayout;
+};
+
+// Keep legacy exports as desktop defaults to avoid changing the existing PC path.
+export const sidePanelWidth = desktopGameBoardLayout.sidePanelWidth;
+export const topPanelWidth = desktopGameBoardLayout.topPanelWidth;
+export const sideZoneWidth = desktopGameBoardLayout.sideZoneWidth;
+export const centerZoneWidth = desktopGameBoardLayout.centerZoneWidth;
+export const boardContentWidth = desktopGameBoardLayout.boardContentWidth;
+export const boardColumns = desktopGameBoardLayout.boardColumns;
+export const boardShellColumns = desktopGameBoardLayout.boardShellColumns;
 
 export const soloMulliganButtonStyle: CSSProperties = {
   position: 'absolute',

--- a/src/utils/gameBoardCardLayout.test.ts
+++ b/src/utils/gameBoardCardLayout.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  coarseCardSize,
+  desktopCardSize,
+  getCardSizeForInputProfile,
+  getExZoneGapForInputProfile,
+  getFieldZoneGapForInputProfile,
+  getRequiredFieldWidthForCardCount,
+} from './gameBoardCardLayout';
+import { resolveBoardLayout } from '../pages/gameBoardLayout';
+
+describe('gameBoardCardLayout', () => {
+  it('keeps desktop card size unchanged for fine input', () => {
+    expect(desktopCardSize).toEqual({ width: 100, height: 140 });
+    expect(getCardSizeForInputProfile('fine')).toEqual(desktopCardSize);
+    expect(getFieldZoneGapForInputProfile('fine')).toBe('1.9rem');
+    expect(getExZoneGapForInputProfile('fine')).toBe('1rem');
+  });
+
+  it('uses a compact card size and tighter zone gaps for coarse input', () => {
+    expect(coarseCardSize).toEqual({ width: 82, height: 115 });
+    expect(getCardSizeForInputProfile('coarse')).toEqual(coarseCardSize);
+    expect(getFieldZoneGapForInputProfile('coarse')).toBe('0.5rem');
+    expect(getExZoneGapForInputProfile('coarse')).toBe('0.5rem');
+  });
+
+  it('fits five field cards within tablet center zone width at 1024px', () => {
+    const tabletLayout = resolveBoardLayout(1024);
+    expect(tabletLayout.profile).toBe('tablet');
+
+    const requiredWidth = getRequiredFieldWidthForCardCount(5, 'coarse', 16);
+    expect(requiredWidth).toBeLessThanOrEqual(tabletLayout.centerZoneWidth);
+  });
+});

--- a/src/utils/gameBoardCardLayout.test.ts
+++ b/src/utils/gameBoardCardLayout.test.ts
@@ -18,10 +18,10 @@ describe('gameBoardCardLayout', () => {
   });
 
   it('uses a compact card size and tighter zone gaps for coarse input', () => {
-    expect(coarseCardSize).toEqual({ width: 82, height: 115 });
+    expect(coarseCardSize).toEqual({ width: 76, height: 106 });
     expect(getCardSizeForInputProfile('coarse')).toEqual(coarseCardSize);
-    expect(getFieldZoneGapForInputProfile('coarse')).toBe('0.5rem');
-    expect(getExZoneGapForInputProfile('coarse')).toBe('0.5rem');
+    expect(getFieldZoneGapForInputProfile('coarse')).toBe('0.36rem');
+    expect(getExZoneGapForInputProfile('coarse')).toBe('0.36rem');
   });
 
   it('fits five field cards within tablet center zone width at 1024px', () => {

--- a/src/utils/gameBoardCardLayout.test.ts
+++ b/src/utils/gameBoardCardLayout.test.ts
@@ -25,7 +25,7 @@ describe('gameBoardCardLayout', () => {
   });
 
   it('fits five field cards within tablet center zone width at 1024px', () => {
-    const tabletLayout = resolveBoardLayout(1024);
+    const tabletLayout = resolveBoardLayout(1024, 'coarse');
     expect(tabletLayout.profile).toBe('tablet');
 
     const requiredWidth = getRequiredFieldWidthForCardCount(5, 'coarse', 16);

--- a/src/utils/gameBoardCardLayout.ts
+++ b/src/utils/gameBoardCardLayout.ts
@@ -1,0 +1,58 @@
+import type { GameBoardInputProfile } from './gameBoardInputProfile';
+
+export type GameBoardCardSize = {
+  width: number;
+  height: number;
+};
+
+export const desktopCardSize: GameBoardCardSize = {
+  width: 100,
+  height: 140,
+};
+
+export const coarseCardSize: GameBoardCardSize = {
+  width: 82,
+  height: 115,
+};
+
+export const getCardSizeForInputProfile = (inputProfile: GameBoardInputProfile): GameBoardCardSize => (
+  inputProfile === 'coarse' ? coarseCardSize : desktopCardSize
+);
+
+export const getFieldZoneGapForInputProfile = (inputProfile: GameBoardInputProfile): string => (
+  inputProfile === 'coarse' ? '0.5rem' : '1.9rem'
+);
+
+export const getExZoneGapForInputProfile = (inputProfile: GameBoardInputProfile): string => (
+  inputProfile === 'coarse' ? '0.5rem' : '1rem'
+);
+
+export const getStackAttachmentOffsetForInputProfile = (inputProfile: GameBoardInputProfile): { top: number; left: number } => (
+  inputProfile === 'coarse'
+    ? { top: 16, left: 12 }
+    : { top: 20, left: 15 }
+);
+
+export const getLinkedCardOffsetForInputProfile = (inputProfile: GameBoardInputProfile): { top: number; left: number; paddingBottom: number } => (
+  inputProfile === 'coarse'
+    ? { top: 16, left: 12, paddingBottom: 20 }
+    : { top: 20, left: 15, paddingBottom: 24 }
+);
+
+export const getRequiredFieldWidthForCardCount = (
+  cardCount: number,
+  inputProfile: GameBoardInputProfile,
+  rootFontSizePx = 16
+): number => {
+  const normalizedCardCount = Math.max(0, cardCount);
+  if (normalizedCardCount <= 0) return 0;
+
+  const cardSize = getCardSizeForInputProfile(inputProfile);
+  const gapRem = inputProfile === 'coarse' ? 0.5 : 1.9;
+  const gapPx = gapRem * rootFontSizePx;
+  const horizontalPaddingPx = 16;
+
+  return (cardSize.width * normalizedCardCount)
+    + (gapPx * Math.max(0, normalizedCardCount - 1))
+    + horizontalPaddingPx;
+};

--- a/src/utils/gameBoardCardLayout.ts
+++ b/src/utils/gameBoardCardLayout.ts
@@ -11,8 +11,8 @@ export const desktopCardSize: GameBoardCardSize = {
 };
 
 export const coarseCardSize: GameBoardCardSize = {
-  width: 82,
-  height: 115,
+  width: 76,
+  height: 106,
 };
 
 export const getCardSizeForInputProfile = (inputProfile: GameBoardInputProfile): GameBoardCardSize => (
@@ -20,22 +20,22 @@ export const getCardSizeForInputProfile = (inputProfile: GameBoardInputProfile):
 );
 
 export const getFieldZoneGapForInputProfile = (inputProfile: GameBoardInputProfile): string => (
-  inputProfile === 'coarse' ? '0.5rem' : '1.9rem'
+  inputProfile === 'coarse' ? '0.36rem' : '1.9rem'
 );
 
 export const getExZoneGapForInputProfile = (inputProfile: GameBoardInputProfile): string => (
-  inputProfile === 'coarse' ? '0.5rem' : '1rem'
+  inputProfile === 'coarse' ? '0.36rem' : '1rem'
 );
 
 export const getStackAttachmentOffsetForInputProfile = (inputProfile: GameBoardInputProfile): { top: number; left: number } => (
   inputProfile === 'coarse'
-    ? { top: 16, left: 12 }
+    ? { top: 14, left: 10 }
     : { top: 20, left: 15 }
 );
 
 export const getLinkedCardOffsetForInputProfile = (inputProfile: GameBoardInputProfile): { top: number; left: number; paddingBottom: number } => (
   inputProfile === 'coarse'
-    ? { top: 16, left: 12, paddingBottom: 20 }
+    ? { top: 14, left: 10, paddingBottom: 16 }
     : { top: 20, left: 15, paddingBottom: 24 }
 );
 
@@ -48,7 +48,7 @@ export const getRequiredFieldWidthForCardCount = (
   if (normalizedCardCount <= 0) return 0;
 
   const cardSize = getCardSizeForInputProfile(inputProfile);
-  const gapRem = inputProfile === 'coarse' ? 0.5 : 1.9;
+  const gapRem = inputProfile === 'coarse' ? 0.36 : 1.9;
   const gapPx = gapRem * rootFontSizePx;
   const horizontalPaddingPx = 16;
 

--- a/src/utils/gameBoardInputProfile.test.ts
+++ b/src/utils/gameBoardInputProfile.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { getInputProfileForViewportWidth } from './gameBoardInputProfile';
+
+describe('gameBoardInputProfile', () => {
+  it('returns coarse only when viewport is tablet and pointer is coarse', () => {
+    const coarseMatchMedia = () => ({ matches: true });
+    const fineMatchMedia = () => ({ matches: false });
+
+    expect(getInputProfileForViewportWidth(1024, coarseMatchMedia)).toBe('coarse');
+    expect(getInputProfileForViewportWidth(1024, fineMatchMedia)).toBe('fine');
+  });
+
+  it('keeps desktop and sub-tablet widths on fine even with coarse pointer', () => {
+    const coarseMatchMedia = () => ({ matches: true });
+
+    expect(getInputProfileForViewportWidth(1280, coarseMatchMedia)).toBe('fine');
+    expect(getInputProfileForViewportWidth(899, coarseMatchMedia)).toBe('fine');
+  });
+
+  it('falls back to fine when matchMedia is unavailable', () => {
+    expect(getInputProfileForViewportWidth(1024)).toBe('fine');
+  });
+});

--- a/src/utils/gameBoardInputProfile.ts
+++ b/src/utils/gameBoardInputProfile.ts
@@ -1,4 +1,4 @@
-import { getLayoutProfileForViewportWidth } from '../pages/gameBoardLayout';
+import { isTabletViewportWidth } from '../pages/gameBoardLayout';
 
 export type GameBoardInputProfile = 'fine' | 'coarse';
 
@@ -14,7 +14,7 @@ export const getInputProfileForViewportWidth = (
   viewportWidth: number,
   matchMediaFn?: MatchMediaFn
 ): GameBoardInputProfile => {
-  if (getLayoutProfileForViewportWidth(viewportWidth) !== 'tablet') {
+  if (!isTabletViewportWidth(viewportWidth)) {
     return 'fine';
   }
 

--- a/src/utils/gameBoardInputProfile.ts
+++ b/src/utils/gameBoardInputProfile.ts
@@ -1,0 +1,34 @@
+import { getLayoutProfileForViewportWidth } from '../pages/gameBoardLayout';
+
+export type GameBoardInputProfile = 'fine' | 'coarse';
+
+type MatchMediaResult = {
+  matches: boolean;
+};
+
+type MatchMediaFn = (query: string) => MatchMediaResult;
+
+const POINTER_COARSE_QUERY = '(pointer: coarse)';
+
+export const getInputProfileForViewportWidth = (
+  viewportWidth: number,
+  matchMediaFn?: MatchMediaFn
+): GameBoardInputProfile => {
+  if (getLayoutProfileForViewportWidth(viewportWidth) !== 'tablet') {
+    return 'fine';
+  }
+
+  if (!matchMediaFn) {
+    return 'fine';
+  }
+
+  return matchMediaFn(POINTER_COARSE_QUERY).matches ? 'coarse' : 'fine';
+};
+
+export const resolveInputProfile = (viewportWidth: number): GameBoardInputProfile => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return getInputProfileForViewportWidth(viewportWidth);
+  }
+
+  return getInputProfileForViewportWidth(viewportWidth, window.matchMedia.bind(window));
+};


### PR DESCRIPTION
※ タブレット版は beta release
不具合やデグレなど検出リスクあり

## 概要
タブレット（横画面・タッチ操作）向けの GameBoard UI を段階的に最適化しました。  
既存PC版への影響を最小化するため、`inputProfile (fine/coarse)` と `layoutProfile (desktop/tablet)` で分岐しています。

## 背景
- 以前は固定幅・マウス前提のUIで、タブレット実機で以下の課題がありました
  - 盤面見切れ/スクロール過多
  - カード操作シートの見切れ
  - タッチ操作（ドラッグ/押下）のしづらさ
  - 情報密度不足（文字・カード・ボタンが大きく縦に伸びる）

## 変更内容

### 1) 入力/レイアウトプロファイル導入
- `GameBoardInputProfileProvider` / `useGameBoardInputProfile` を導入
- `pointer: coarse` かつタブレット幅（900〜1279px）で `coarse + tablet` に切替
- それ以外は `fine + desktop`（PC既存挙動を維持）
- 追加:
  - `src/contexts/GameBoardInputProfileProvider.tsx`
  - `src/contexts/gameBoardInputProfileContext.ts`
  - `src/utils/gameBoardInputProfile.ts`
  - `src/pages/gameBoardLayout.ts` を拡張（desktop/tablet 解決ロジック）

### 2) タブレット向け密度最適化
- カードサイズ/間隔/スタックオフセットを `coarse` 用に最適化
- 各ゾーン、ヘッダー、ターンパネル、コントロールパネル、Recent Events を compact 化
- 手札/各ゾーンの最小高さやパディング/ギャップを調整し、スクロール量を削減
- 追加:
  - `src/utils/gameBoardCardLayout.ts`

### 3) カードアクションシート改善（タッチ）
- coarse時はカードタップで外部アクションシート表示
- シートを「選択カード付近」にアンカー表示し、ビューポート内にクランプ
- `visualViewport` ベースで再計算し、見切れを抑制
- EXゾーンは上方向優先 + さらに小さめ幅で表示（見切れ対策）

### 4) 手札アクション（例: 手札を公開）の欠損対策
- タブレット時は手札アクションメニューを領域内配置に変更
- 展開方向を `up` に切替して表示欠けを回避

### 5) タブレット実機向け細部調整
- ボタン配色/可読性改善
- 長文ラベルの折返し/省略改善
- 検索モーダルの coarse 操作性改善

## 影響範囲
### 主対象
- `GameBoard` 系UI（表示・操作性）

### PC版への影響方針
- レイアウト判定は `fine` 時 desktop を維持（1024pxでも fine なら desktop）
- 既存PC機能は維持

### 既知の差分（PC）
- コントロールパネルの見た目/並びは一部変化あり（機能は維持）
- `board-playmat` が `overflowX: auto` になり、狭幅時に横スクロールバーが出る可能性あり（実害は現時点で未確認）

## テスト/検証
### 自動テスト
- `vitest`（関連11ファイル）: **207 passed**
- 主要ユニット/統合テスト追加・更新
  - `gameBoardLayout.test.ts`
  - `gameBoardInputProfile.test.ts`
  - `gameBoardCardLayout.test.ts`
  - `GameBoardPlayerControlsPanel.test.tsx`
  - `GameBoardPlayerTracker.test.tsx`
  - `Card.test.tsx`
  - `Zone.test.tsx`
  - `GameBoard.test.tsx`（desktop/fine vs tablet/coarseの判定含む）

### 品質ゲート
- `npm run lint` : pass
- `npx tsc --noEmit -p tsconfig.app.json` : pass
- `npm run build` : pass

## 非対象
- スマートフォン向け専用UI最適化（今回はタブレットスコープ）
- 文言短縮の全面適用（必要なら別PRで実施）

## レビュー観点
- [ ] 1024px前後（fine/desktop）で従来PC操作感に問題がないか
- [ ] タブレット実機でカードアクションシートが見切れないか（特にEX）
- [ ] 手札アクション（手札公開含む）が安定表示/操作できるか
- [ ] コントロールパネルの並び変更が許容か

## 補足
- `main` との差分はタブレット最適化が中心で、PC機能退行は未検出です。
- 実機確認で追加調整が必要な場合は、`EX` アクションシートを「常時上固定」にする軽微追従が可能です。
