### PR TITLE
UI調整

### DIFF
--- a/e2e/solo-combat-inspector.spec.ts
+++ b/e2e/solo-combat-inspector.spec.ts
@@ -32,13 +32,31 @@ test.describe('Solo Combat and Inspector Flows', () => {
     await attacker.hover();
     await attacker.getByRole('button', { name: 'Attack' }).click({ force: true });
 
-    await expect(page.getByText('ATTACK MODE')).toBeVisible();
-    await expect(page.getByText('Select an enemy follower or leader for Token.')).toBeVisible();
+    await expect(page.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'true');
 
     await zoneCards(page, 'field-guest').first().click();
 
-    await expect(page.getByText('ATTACK MODE')).toBeHidden();
+    await expect(page.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'false');
     await expect(page.getByTestId('card-inspector')).toBeHidden();
     await expect(page.getByText(/attacks/).first()).toBeVisible();
+  });
+
+  test('can stand a rested follower even when adjacent field cards are present', async ({ page }) => {
+    await startSoloGame(page);
+    await spawnDefaultToken(page, 'bottom', 'field');
+    await spawnDefaultToken(page, 'bottom', 'field');
+
+    const secondFollower = zoneCards(page, 'field-host').nth(1);
+
+    await secondFollower.hover();
+    await secondFollower.getByRole('button', { name: 'REST' }).click();
+    await secondFollower.hover();
+    await expect(secondFollower.getByRole('button', { name: 'STAND' })).toBeVisible();
+    await expect(secondFollower.getByRole('button', { name: 'Attack' })).toHaveCount(0);
+
+    await secondFollower.getByRole('button', { name: 'STAND' }).click();
+    await secondFollower.hover();
+    await expect(secondFollower.getByRole('button', { name: 'REST' })).toBeVisible();
+    await expect(secondFollower.getByRole('button', { name: 'Attack' })).toBeVisible();
   });
 });

--- a/e2e/solo-desktop-overview-layout.spec.ts
+++ b/e2e/solo-desktop-overview-layout.spec.ts
@@ -21,6 +21,16 @@ test.describe('Solo Desktop Overview Layout', () => {
     await expect(page.getByTestId('player-controls-tracker-disclosure')).toHaveCount(0);
     await expect(page.getByTestId('player-tracker-host')).toBeVisible();
 
+    const playmatBox = await page.getByTestId('board-playmat').boundingBox();
+    const bottomSectionBox = await page.getByTestId('board-section-bottom').boundingBox();
+    expect(playmatBox).not.toBeNull();
+    expect(bottomSectionBox).not.toBeNull();
+    if (playmatBox && bottomSectionBox) {
+      const leftGutter = bottomSectionBox.x - playmatBox.x;
+      const rightGutter = (playmatBox.x + playmatBox.width) - (bottomSectionBox.x + bottomSectionBox.width);
+      expect(Math.abs(leftGutter - rightGutter)).toBeLessThanOrEqual(24);
+    }
+
     for (const zoneId of [
       'hand-guest',
       'cemetery-guest',
@@ -41,10 +51,10 @@ test.describe('Solo Desktop Overview Layout', () => {
     }
 
     const firstHandCardBox = await zoneCards(page, 'hand-host').first().boundingBox();
-    expect(firstHandCardBox?.width).toBeGreaterThanOrEqual(86);
-    expect(firstHandCardBox?.width).toBeLessThanOrEqual(90);
-    expect(firstHandCardBox?.height).toBeGreaterThanOrEqual(121);
-    expect(firstHandCardBox?.height).toBeLessThanOrEqual(125);
+    expect(firstHandCardBox?.width).toBeGreaterThanOrEqual(69);
+    expect(firstHandCardBox?.width).toBeLessThanOrEqual(72);
+    expect(firstHandCardBox?.height).toBeGreaterThanOrEqual(97);
+    expect(firstHandCardBox?.height).toBeLessThanOrEqual(100);
 
     await dragFirstZoneCard(page, 'hand-host', 'field-host');
     await expect(zoneCards(page, 'field-host')).toHaveCount(1);

--- a/e2e/solo-preparation.spec.ts
+++ b/e2e/solo-preparation.spec.ts
@@ -52,7 +52,7 @@ test.describe('Solo Preparation Flow', () => {
     await preparationControls.getByRole('button', { name: /START GAME/ }).click();
 
     await expect(preparationControls).toBeHidden();
-    await expect(deckInput(page, 'bottom')).toBeDisabled();
-    await expect(deckInput(page, 'top')).toBeDisabled();
+    await expect(deckInput(page, 'bottom')).toHaveCount(0);
+    await expect(deckInput(page, 'top')).toHaveCount(0);
   });
 });

--- a/src/components/Card.test.tsx
+++ b/src/components/Card.test.tsx
@@ -36,9 +36,10 @@ const createCard = (overrides: Partial<CardInstance> = {}): CardInstance => ({
 
 const renderWithInputProfile = (
   profile: 'fine' | 'coarse',
-  ui: React.ReactElement
+  ui: React.ReactElement,
+  boardDensity: 'standard' | 'overview' = 'standard'
 ) => render(
-  <GameBoardInputProfileProvider value={profile}>
+  <GameBoardInputProfileProvider value={profile} boardDensity={boardDensity}>
     {ui}
   </GameBoardInputProfileProvider>
 );
@@ -124,8 +125,8 @@ describe('Card', () => {
     const atkIncreaseButton = screen.getByText('+A');
     expect(atkIncreaseButton).toHaveStyle({
       minWidth: '24px',
-      minHeight: '24px',
-      padding: '4px 4px',
+      minHeight: '22px',
+      padding: '3px 4px',
     });
 
     fireEvent.pointerDown(atkIncreaseButton, { clientX: 10, clientY: 20, button: 0 });
@@ -151,6 +152,48 @@ describe('Card', () => {
     expect(screen.getByText('Cem')).toHaveAttribute('aria-label', 'Send to cemetery');
     expect(screen.getByText('Ban')).toHaveAttribute('title', 'Banish this card');
     expect(screen.getByText('Evolve')).toHaveAttribute('aria-label', 'Return to evolve deck');
+  });
+
+  it('scales fine-input hover quick actions down in overview density', () => {
+    renderWithInputProfile(
+      'fine',
+      <Card
+        card={createCard({ isEvolveCard: true })}
+        onModifyCounter={vi.fn()}
+        onModifyGenericCounter={vi.fn()}
+        onSendToBottom={vi.fn()}
+        onBanish={vi.fn()}
+        onReturnEvolve={vi.fn()}
+        onCemetery={vi.fn()}
+        onTap={vi.fn()}
+      />,
+      'overview'
+    );
+
+    expect(screen.getByTestId('card-controls')).toHaveStyle({
+      padding: '3px',
+      gap: '1px',
+    });
+    expect(screen.getByText('Bot')).toHaveStyle({
+      fontSize: '9px',
+      minWidth: '28px',
+      padding: '1px 3px',
+    });
+    expect(screen.getByText('+A')).toHaveStyle({
+      minWidth: '20px',
+      minHeight: '18px',
+      fontSize: '10px',
+    });
+    expect(screen.getByText('+C')).toHaveStyle({
+      minHeight: '16px',
+      fontSize: '9px',
+    });
+    expect(screen.getByText('REST')).toHaveStyle({
+      minHeight: '18px',
+      minWidth: '30px',
+      fontSize: '8px',
+      display: 'flex',
+    });
   });
 
   it('fires generic counter quick actions for field cards', () => {
@@ -736,6 +779,25 @@ describe('Card', () => {
       lineHeight: '1',
       borderRadius: '3px',
     });
+  });
+
+  it('raises hovered fine-input quick actions above neighboring cards', () => {
+    render(
+      <Card
+        card={createCard({ zone: 'field-host', isTapped: true })}
+        baseStats={{ atk: 3, hp: 4 }}
+        onTap={vi.fn()}
+      />
+    );
+
+    const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
+    expect(cardElement).toHaveStyle({ zIndex: '1' });
+
+    fireEvent.pointerEnter(cardElement);
+    expect(cardElement).toHaveStyle({ zIndex: '140' });
+
+    fireEvent.pointerLeave(cardElement);
+    expect(cardElement).toHaveStyle({ zIndex: '1' });
   });
 
 });

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -71,7 +71,9 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
   const boardDensity = useGameBoardBoardDensity();
   const [isQuickActionsOpen, setIsQuickActionsOpen] = React.useState(false);
   const [coarseSheetPlacement, setCoarseSheetPlacement] = React.useState<{ top: number; left: number; width: number; maxHeight: number } | null>(null);
+  const [isDesktopQuickActionsHovered, setIsDesktopQuickActionsHovered] = React.useState(false);
   const isCoarseInput = inputProfile === 'coarse';
+  const isOverviewQuickActions = !isCoarseInput && boardDensity === 'overview';
   const cardSize = getCardSizeForInputProfile(inputProfile, boardDensity);
   const isInteractionLocked = isLocked || card.isLeaderCard || card.zone.startsWith('leader-');
   const canShowQuickActionOverlay = !isHidden && !isInteractionLocked;
@@ -212,7 +214,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
   const style: React.CSSProperties = {
     // Translate x/y for the drag
     transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
-    zIndex: transform ? 999 : 1,
+    zIndex: transform ? 999 : isDesktopQuickActionsHovered ? 140 : 1,
     cursor: isInteractionLocked ? 'default' : 'grab',
     touchAction: isCoarseInput ? 'none' : undefined,
     position: 'relative',
@@ -249,33 +251,47 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
     toEvolveDeck: t('gameBoard.card.quickActionDescriptions.toEvolveDeck'),
   };
   const compactQuickActionButtonStyle: React.CSSProperties = {
-    padding: '2px 4px',
-    fontSize: '10px',
+    padding: isOverviewQuickActions ? '1px 3px' : '2px 4px',
+    fontSize: isOverviewQuickActions ? '9px' : '10px',
     borderRadius: '2px',
-    minWidth: '32px',
+    minWidth: isOverviewQuickActions ? '28px' : '32px',
     whiteSpace: 'nowrap',
     lineHeight: 1.2,
   };
   const counterAdjustButtonStyle: React.CSSProperties = {
-    padding: '4px 4px',
-    fontSize: '11px',
+    padding: isOverviewQuickActions ? '2px 3px' : '3px 4px',
+    fontSize: isOverviewQuickActions ? '10px' : '11px',
     borderRadius: '4px',
-    minWidth: '24px',
-    minHeight: '24px',
+    minWidth: isOverviewQuickActions ? '20px' : '24px',
+    minHeight: isOverviewQuickActions ? '18px' : '22px',
     border: '1px solid rgba(255,255,255,0.55)',
     fontWeight: 'bold',
     lineHeight: 1,
   };
+  const genericCounterButtonStyle: React.CSSProperties = {
+    padding: isOverviewQuickActions ? '1px 3px' : '1px 4px',
+    fontSize: isOverviewQuickActions ? '9px' : '10px',
+    borderRadius: '2px',
+    width: '100%',
+    minHeight: isOverviewQuickActions ? '16px' : '18px',
+    lineHeight: 1.05,
+  };
   const combatActionButtonStyle: React.CSSProperties = {
-    padding: '2px 5px',
-    minHeight: '22px',
-    fontSize: '10px',
-    lineHeight: 1,
+    padding: isOverviewQuickActions ? '1px 3px' : '2px 5px',
+    minHeight: isOverviewQuickActions ? '18px' : '22px',
+    fontSize: isOverviewQuickActions ? '8px' : '10px',
+    lineHeight: isOverviewQuickActions ? 1.05 : 1,
     borderRadius: '3px',
     flex: '1 1 0',
-    minWidth: 0,
+    minWidth: isOverviewQuickActions ? '30px' : 0,
     fontWeight: 'bold',
     whiteSpace: 'nowrap',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+    textOverflow: 'clip',
+    wordBreak: 'keep-all',
   };
   const coarseSheetButtonStyle: React.CSSProperties = {
     minHeight: '34px',
@@ -360,6 +376,14 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
       }}
       onPointerCancel={() => {
         inspectPointerStartRef.current = null;
+      }}
+      onPointerEnter={() => {
+        if (!isCoarseInput && canShowQuickActionOverlay) {
+          setIsDesktopQuickActionsHovered(true);
+        }
+      }}
+      onPointerLeave={() => {
+        setIsDesktopQuickActionsHovered(false);
       }}
       onContextMenu={(e) => {
         e.preventDefault();
@@ -482,17 +506,30 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
               data-quick-actions-open={String(isQuickActionsOpen)}
               style={{
                 position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
-                display: 'flex', flexDirection: 'column', gap: '2px', padding: '4px',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: isOverviewQuickActions ? '1px' : '2px',
+                padding: isOverviewQuickActions ? '3px' : '4px',
                 background: 'rgba(0,0,0,0.6)', opacity: isCoarseInput ? (isQuickActionsOpen ? 1 : 0) : 0, transition: 'opacity 0.2s ease',
                 borderRadius: '4px',
                 pointerEvents: quickActionsDisabled ? 'none' : isCoarseInput ? (isQuickActionsOpen ? 'auto' : 'none') : undefined
               }}>
               {onPlayToField && (card.zone.startsWith('hand') || card.zone.startsWith('ex-')) && (
-                <div style={{ display: 'flex', justifyContent: 'center', gap: '4px', marginBottom: '2px' }}>
+                <div style={{ display: 'flex', justifyContent: 'center', gap: isOverviewQuickActions ? '2px' : '4px', marginBottom: isOverviewQuickActions ? '1px' : '2px' }}>
                   <button
                     onPointerDown={(e) => e.stopPropagation()}
                     onClick={(e) => { e.stopPropagation(); onPlayToField(card.id); }}
-                    style={{ background: '#3b82f6', color: 'white', border: '1px solid #fff', padding: '4px 4px', fontSize: '11px', borderRadius: '4px', width: '100%', fontWeight: 'bold' }}
+                    style={{
+                      background: '#3b82f6',
+                      color: 'white',
+                      border: '1px solid #fff',
+                      padding: isOverviewQuickActions ? '3px 3px' : '4px 4px',
+                      fontSize: isOverviewQuickActions ? '10px' : '11px',
+                      borderRadius: '4px',
+                      width: '100%',
+                      fontWeight: 'bold',
+                      minHeight: isOverviewQuickActions ? '20px' : undefined,
+                    }}
                   >
                     {playActionLabel}
                   </button>
@@ -500,23 +537,23 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
               )}
               {onModifyCounter && isStatDisplayZone && !disableCombatAndCounterControls && (
                 <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: '3px' }}>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: isOverviewQuickActions ? '2px' : '3px' }}>
                     <button onPointerDown={(e) => e.stopPropagation()} onClick={(e) => { e.stopPropagation(); onModifyCounter(card.id, 'atk', 1); }} style={{ ...counterAdjustButtonStyle, background: '#3b82f6', color: '#fff' }}>+A</button>
                     <button onPointerDown={(e) => e.stopPropagation()} onClick={(e) => { e.stopPropagation(); onModifyCounter(card.id, 'atk', -1); }} style={{ ...counterAdjustButtonStyle, background: '#1a1d24', color: '#fff' }}>-A</button>
                   </div>
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: '3px' }}>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: isOverviewQuickActions ? '2px' : '3px' }}>
                     <button onPointerDown={(e) => e.stopPropagation()} onClick={(e) => { e.stopPropagation(); onModifyCounter(card.id, 'hp', 1); }} style={{ ...counterAdjustButtonStyle, background: '#ef4444', color: '#fff' }}>+H</button>
                     <button onPointerDown={(e) => e.stopPropagation()} onClick={(e) => { e.stopPropagation(); onModifyCounter(card.id, 'hp', -1); }} style={{ ...counterAdjustButtonStyle, background: '#1a1d24', color: '#fff' }}>-H</button>
                   </div>
                 </div>
               )}
               {onModifyGenericCounter && isStatDisplayZone && !disableCombatAndCounterControls && (
-                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '4px', width: '100%' }}>
-                  <button onPointerDown={(e) => e.stopPropagation()} onClick={(e) => { e.stopPropagation(); onModifyGenericCounter(card.id, 1); }} style={{ background: '#0f766e', color: '#fff', padding: '2px 4px', fontSize: '10px', borderRadius: '2px', width: '100%' }}>+C</button>
-                  <button onPointerDown={(e) => e.stopPropagation()} onClick={(e) => { e.stopPropagation(); onModifyGenericCounter(card.id, -1); }} style={{ background: '#7f1d1d', color: '#fff', padding: '2px 4px', fontSize: '10px', borderRadius: '2px', width: '100%' }}>-C</button>
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: isOverviewQuickActions ? '2px' : '4px', width: '100%' }}>
+                  <button onPointerDown={(e) => e.stopPropagation()} onClick={(e) => { e.stopPropagation(); onModifyGenericCounter(card.id, 1); }} style={{ ...genericCounterButtonStyle, background: '#0f766e', color: '#fff' }}>+C</button>
+                  <button onPointerDown={(e) => e.stopPropagation()} onClick={(e) => { e.stopPropagation(); onModifyGenericCounter(card.id, -1); }} style={{ ...genericCounterButtonStyle, background: '#7f1d1d', color: '#fff' }}>-C</button>
                 </div>
               )}
-              <div style={{ display: 'flex', justifyContent: 'center', gap: '4px', marginTop: 'auto' }}>
+              <div style={{ display: 'flex', justifyContent: 'center', gap: isOverviewQuickActions ? '2px' : '4px', marginTop: 'auto' }}>
                 {onSendToBottom && (
                   <button
                     onPointerDown={(e) => e.stopPropagation()}
@@ -552,7 +589,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
                 )}
               </div>
               {onReturnEvolve && card.isEvolveCard && (
-                <div style={{ display: 'flex', justifyContent: 'center', gap: '4px', marginTop: '2px' }}>
+                <div style={{ display: 'flex', justifyContent: 'center', gap: isOverviewQuickActions ? '2px' : '4px', marginTop: isOverviewQuickActions ? '1px' : '2px' }}>
                   <button
                     onPointerDown={(e) => e.stopPropagation()}
                     onClick={(e) => { e.stopPropagation(); onReturnEvolve(card.id); }}
@@ -565,7 +602,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
                 </div>
               )}
               {onTap && !disableCombatAndCounterControls && (
-                <div style={{ display: 'flex', justifyContent: 'center', gap: '3px', marginTop: '2px' }}>
+                <div style={{ display: 'flex', justifyContent: 'center', gap: isOverviewQuickActions ? '2px' : '3px', marginTop: isOverviewQuickActions ? '1px' : '2px' }}>
                   <button
                     onPointerDown={(e) => e.stopPropagation()}
                     onClick={(e) => { e.stopPropagation(); onTap(card.id); }}

--- a/src/components/GameBoardHeader.tsx
+++ b/src/components/GameBoardHeader.tsx
@@ -5,7 +5,7 @@ import GameBoardRoomStatus from './GameBoardRoomStatus';
 import GameBoardTurnPanel from './GameBoardTurnPanel';
 import type { PlayerRole, SyncState } from '../types/game';
 import type { ConnectionBadgeTone, GameBoardConnectionState } from '../utils/gameBoardPresentation';
-import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
+import { useGameBoardBoardDensity, useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type GameBoardHeaderProps = {
   room: string;
@@ -63,7 +63,9 @@ const GameBoardHeader: React.FC<GameBoardHeaderProps> = ({
   onPhaseChange,
 }) => {
   const inputProfile = useGameBoardInputProfile();
+  const boardDensity = useGameBoardBoardDensity();
   const isCompactControls = inputProfile === 'coarse';
+  const isOverviewControls = inputProfile === 'fine' && boardDensity === 'overview';
 
   return (
     <div
@@ -72,17 +74,17 @@ const GameBoardHeader: React.FC<GameBoardHeaderProps> = ({
         justifyContent: 'space-between',
         alignItems: isCompactControls ? 'stretch' : 'center',
         flexWrap: isCompactControls ? 'wrap' : 'nowrap',
-        columnGap: isCompactControls ? '0.5rem' : undefined,
-        rowGap: isCompactControls ? '0.4rem' : undefined,
+        columnGap: isCompactControls ? '0.5rem' : isOverviewControls ? '0.8rem' : undefined,
+        rowGap: isCompactControls ? '0.4rem' : isOverviewControls ? '0.32rem' : undefined,
         background: 'var(--bg-surface)',
-        padding: isCompactControls ? '0.48rem 0.62rem' : '0.75rem 1rem',
+        padding: isCompactControls ? '0.48rem 0.62rem' : isOverviewControls ? '0.6rem 0.8rem' : '0.75rem 1rem',
         borderRadius: 'var(--radius-md)',
       }}
     >
       <div
         style={{
           display: 'flex',
-          gap: isCompactControls ? '0.5rem' : '1rem',
+          gap: isCompactControls ? '0.5rem' : isOverviewControls ? '0.8rem' : '1rem',
           alignItems: 'center',
           flexWrap: isCompactControls ? 'wrap' : 'nowrap',
           minWidth: 0,

--- a/src/components/GameBoardPlayerControlsPanel.test.tsx
+++ b/src/components/GameBoardPlayerControlsPanel.test.tsx
@@ -198,8 +198,8 @@ describe('GameBoardPlayerControlsPanel', () => {
       display: 'flex',
       flexDirection: 'column',
     });
-    expect(screen.getByText('Player 1 Controls')).toHaveStyle({ fontSize: '0.8rem' });
-    expect(screen.getByRole('button', { name: 'Draw' })).toHaveStyle({ padding: '0.5rem' });
+    expect(screen.getByText('Player 1 Controls')).toHaveStyle({ fontSize: '0.64rem' });
+    expect(screen.getByRole('button', { name: 'Draw' })).toHaveStyle({ padding: '0.4rem' });
     expect(screen.queryByRole('button', { name: 'Load from My Decks' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Spawn Token' })).toBeInTheDocument();
     expect(screen.getByTestId('player-tracker')).toHaveAttribute('data-compact', 'false');
@@ -230,6 +230,19 @@ describe('GameBoardPlayerControlsPanel', () => {
     expect(screen.queryByTestId('player-controls-tracker-disclosure')).not.toBeInTheDocument();
     expect(screen.queryByTestId('player-controls-tracker-summary')).not.toBeInTheDocument();
     expect(screen.getByTestId('player-tracker')).toHaveAttribute('data-compact', 'true');
+  });
+
+  it('keeps the tracker expanded when compact mode is explicitly disabled', () => {
+    renderWithInputProfile(
+      'coarse',
+      <GameBoardPlayerControlsPanel
+        {...createBaseProps()}
+        panelWidth={132}
+        forceExpandedTracker={true}
+      />
+    );
+
+    expect(screen.getByTestId('player-tracker')).toHaveAttribute('data-compact', 'false');
   });
 
   it('keeps tracker in regular mode on desktop width panels', () => {

--- a/src/components/GameBoardPlayerControlsPanel.tsx
+++ b/src/components/GameBoardPlayerControlsPanel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import GameBoardPlayerTrackerSection from './GameBoardPlayerTrackerSection';
 import type { SyncState } from '../types/game';
-import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
+import { useGameBoardBoardDensity, useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type GameBoardPlayerControlsPanelProps = {
   label: string;
@@ -34,6 +34,7 @@ type GameBoardPlayerControlsPanelProps = {
     delta: number
   ) => void;
   readOnlyTracker?: boolean;
+  forceExpandedTracker?: boolean;
   containerStyle?: React.CSSProperties;
 };
 
@@ -64,30 +65,33 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
   playerState,
   onAdjustStat,
   readOnlyTracker = false,
+  forceExpandedTracker = false,
   containerStyle,
 }) => {
   const { t } = useTranslation();
   const inputProfile = useGameBoardInputProfile();
+  const boardDensity = useGameBoardBoardDensity();
   const isCompactControls = inputProfile === 'coarse';
+  const isOverviewControls = inputProfile === 'fine' && boardDensity === 'overview';
   const showSetupActions = gameStatus === 'preparing';
   const showPlayingActions = gameStatus === 'playing';
-  const compactPanelPadding = isCompactControls ? '0.55rem' : '1rem';
-  const compactSectionGap = isCompactControls ? '0.3rem' : '0.5rem';
-  const compactCellPadding = isCompactControls ? '0.36rem' : '0.5rem';
-  const compactButtonBaseStyle: React.CSSProperties = isCompactControls
+  const compactPanelPadding = isCompactControls ? '0.55rem' : isOverviewControls ? '0.8rem' : '1rem';
+  const compactSectionGap = isCompactControls ? '0.3rem' : isOverviewControls ? '0.4rem' : '0.5rem';
+  const compactCellPadding = isCompactControls ? '0.36rem' : isOverviewControls ? '0.4rem' : '0.5rem';
+  const compactButtonBaseStyle: React.CSSProperties = isCompactControls || isOverviewControls
     ? {
-        minHeight: '30px',
-        fontSize: '0.64rem',
+        minHeight: isCompactControls ? '30px' : '24px',
+        fontSize: isCompactControls ? '0.64rem' : '0.7rem',
         lineHeight: 1.1,
         whiteSpace: 'normal',
         overflowWrap: 'anywhere',
         wordBreak: 'break-word',
       }
     : {};
-  const compactPrimaryActionLabelStyle: React.CSSProperties = isCompactControls
+  const compactPrimaryActionLabelStyle: React.CSSProperties = isCompactControls || isOverviewControls
     ? {
-        minHeight: '30px',
-        fontSize: '0.66rem',
+        minHeight: isCompactControls ? '30px' : '24px',
+        fontSize: isCompactControls ? '0.66rem' : '0.7rem',
         lineHeight: 1.1,
         whiteSpace: 'normal',
         overflowWrap: 'anywhere',
@@ -101,14 +105,14 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
         boxSizing: 'border-box',
         display: 'flex',
         flexDirection: 'column',
-        gap: isCompactControls ? '0.32rem' : '0.5rem',
+        gap: isCompactControls ? '0.32rem' : isOverviewControls ? '0.4rem' : '0.5rem',
         background: 'rgba(0,0,0,0.8)',
         padding: compactPanelPadding,
         borderRadius: 'var(--radius-md)',
         ...containerStyle,
       }}
     >
-      <div style={{ fontSize: isCompactControls ? '0.72rem' : '0.8rem', fontWeight: 'bold', color: 'white', marginBottom: isCompactControls ? '0.16rem' : '0.25rem' }}>
+      <div style={{ fontSize: isCompactControls ? '0.72rem' : isOverviewControls ? '0.64rem' : '0.8rem', fontWeight: 'bold', color: 'white', marginBottom: isCompactControls ? '0.16rem' : isOverviewControls ? '0.2rem' : '0.25rem' }}>
         {t('gameBoard.zones.controls', { label })}
       </div>
       <div
@@ -117,7 +121,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
           display: isCompactControls ? 'grid' : 'flex',
           flexDirection: isCompactControls ? undefined : 'column',
           gridTemplateColumns: isCompactControls ? '1fr 1fr' : undefined,
-          gap: isCompactControls ? '0.28rem' : '0.5rem',
+          gap: isCompactControls ? '0.28rem' : isOverviewControls ? '0.4rem' : '0.5rem',
         }}
       >
         {showSetupActions && (
@@ -133,7 +137,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
                 textAlign: 'center',
                 gridColumn: isCompactControls ? '1 / -1' : undefined,
                 cursor: canImportDeck ? 'pointer' : 'not-allowed',
-                fontSize: isCompactControls ? '0.72rem' : '0.875rem',
+                fontSize: isCompactControls ? '0.72rem' : isOverviewControls ? '0.7rem' : '0.875rem',
                 opacity: canImportDeck ? 1 : 0.5,
                 ...compactPrimaryActionLabelStyle,
               }}
@@ -166,7 +170,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
                 textAlign: 'center',
                 gridColumn: isCompactControls ? '1 / -1' : undefined,
                 cursor: canImportDeck && canOpenSavedDeckPicker ? 'pointer' : 'not-allowed',
-                fontSize: isCompactControls ? '0.72rem' : '0.875rem',
+                fontSize: isCompactControls ? '0.72rem' : isOverviewControls ? '0.7rem' : '0.875rem',
                 boxShadow: canImportDeck && canOpenSavedDeckPicker
                   ? '0 8px 18px rgba(5, 150, 105, 0.28)'
                   : 'none',
@@ -261,7 +265,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
         label={label}
         playerState={playerState}
         onAdjustStat={onAdjustStat}
-        compact={isCompactControls && panelWidth <= 180}
+        compact={!forceExpandedTracker && (isCompactControls || isOverviewControls) && panelWidth <= 180}
         readOnly={readOnlyTracker}
       />
     </div>

--- a/src/components/GameBoardPlayerTracker.tsx
+++ b/src/components/GameBoardPlayerTracker.tsx
@@ -102,7 +102,7 @@ const GameBoardPlayerTracker: React.FC<GameBoardPlayerTrackerProps> = ({
   };
 
   return (
-    <div data-testid={testId} style={trackerContainerStyle}>
+    <div data-testid={testId} data-compact={String(compact)} style={trackerContainerStyle}>
       <div title={t('gameBoard.board.statusLabel', { label })} style={trackerHeaderStyle}>{t('gameBoard.board.statusLabel', { label })}</div>
       <div style={trackerStatRowStyle}>
         <span style={{ ...trackerStatLabelBaseStyle, color: '#ef4444' }}>{t('gameBoard.board.stats.hp')}: {hp}</span>

--- a/src/components/GameBoardPlayingControls.tsx
+++ b/src/components/GameBoardPlayingControls.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
+import { useGameBoardBoardDensity, useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type GameBoardPlayingControlsProps = {
   canShowUndoTurn: boolean;
@@ -17,15 +17,19 @@ const GameBoardPlayingControls: React.FC<GameBoardPlayingControlsProps> = ({
 }) => {
   const { t } = useTranslation();
   const inputProfile = useGameBoardInputProfile();
+  const boardDensity = useGameBoardBoardDensity();
   const isCompactControls = inputProfile === 'coarse';
+  const isOverviewControls = inputProfile === 'fine' && boardDensity === 'overview';
   const compactButtonStyle: React.CSSProperties = isCompactControls
     ? { padding: '0.23rem 0.4rem', fontSize: '0.68rem', minHeight: '30px', lineHeight: 1.15 }
-    : { padding: '0.3rem 0.6rem', fontSize: '0.875rem' };
+    : isOverviewControls
+      ? { padding: '0.24rem 0.48rem', fontSize: '0.7rem' }
+      : { padding: '0.3rem 0.6rem', fontSize: '0.875rem' };
 
   return (
     <div
       data-testid="gameboard-playing-controls"
-      style={{ display: 'flex', gap: isCompactControls ? '0.35rem' : '0.4rem', flexWrap: isCompactControls ? 'wrap' : 'nowrap' }}
+      style={{ display: 'flex', gap: isCompactControls ? '0.35rem' : isOverviewControls ? '0.32rem' : '0.4rem', flexWrap: isCompactControls ? 'wrap' : 'nowrap' }}
     >
       <button
         onClick={onTossCoin}

--- a/src/components/GameBoardPreparationControls.tsx
+++ b/src/components/GameBoardPreparationControls.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import type { PlayerRole } from '../types/game';
 import GameBoardPreparationReadyStatus from './GameBoardPreparationReadyStatus';
-import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
+import { useGameBoardBoardDensity, useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type GameBoardPreparationControlsProps = {
   isSoloMode: boolean;
@@ -43,14 +43,17 @@ const GameBoardPreparationControls: React.FC<GameBoardPreparationControlsProps> 
 }) => {
   const { t } = useTranslation();
   const inputProfile = useGameBoardInputProfile();
+  const boardDensity = useGameBoardBoardDensity();
   const isCompactControls = inputProfile === 'coarse';
+  const isOverviewControls = inputProfile === 'fine' && boardDensity === 'overview';
   const canConfigureTurnOrder = isHost || isSoloMode;
   const canStartGame = canConfigureTurnOrder && hostReady && guestReady;
-  const compactButtonPadding = isCompactControls ? '0.2rem 0.36rem' : '0.3rem 0.5rem';
-  const compactButtonFontSize = isCompactControls ? '0.66rem' : '0.75rem';
+  const compactButtonPadding = isCompactControls ? '0.2rem 0.36rem' : isOverviewControls ? '0.24rem 0.4rem' : '0.3rem 0.5rem';
+  const compactButtonFontSize = isCompactControls ? '0.66rem' : isOverviewControls ? '0.6rem' : '0.75rem';
+  const primaryActionPadding = isCompactControls ? '0.24rem 0.5rem' : isOverviewControls ? '0.24rem 0.48rem' : '0.3rem 0.6rem';
 
   return (
-    <div data-testid="preparation-controls" style={{ display: 'flex', gap: isCompactControls ? '0.3rem' : '0.4rem', flexWrap: isCompactControls ? 'wrap' : 'nowrap' }}>
+    <div data-testid="preparation-controls" style={{ display: 'flex', gap: isCompactControls ? '0.3rem' : isOverviewControls ? '0.32rem' : '0.4rem', flexWrap: isCompactControls ? 'wrap' : 'nowrap' }}>
       <button
         onClick={() => onSetInitialTurnOrder()}
         disabled={!canConfigureTurnOrder}
@@ -76,7 +79,7 @@ const GameBoardPreparationControls: React.FC<GameBoardPreparationControlsProps> 
       {!bottomInitialHandDrawn && (
         <button
           onClick={() => onDrawInitialHand(bottomRole)}
-          style={{ padding: isCompactControls ? '0.24rem 0.5rem' : '0.3rem 0.6rem', background: '#3b82f6', color: 'white', fontWeight: 'bold', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: compactButtonFontSize }}
+          style={{ padding: primaryActionPadding, background: '#3b82f6', color: 'white', fontWeight: 'bold', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: compactButtonFontSize }}
         >
           {t('gameBoard.controls.drawHand')}
         </button>
@@ -86,7 +89,7 @@ const GameBoardPreparationControls: React.FC<GameBoardPreparationControlsProps> 
         <button
           onClick={() => onToggleReady(bottomRole)}
           style={{
-            padding: isCompactControls ? '0.24rem 0.5rem' : '0.3rem 0.6rem',
+            padding: primaryActionPadding,
             background: bottomReady ? '#ef4444' : 'var(--vivid-green-cyan)',
             color: bottomReady ? 'white' : 'black',
             fontWeight: 'bold',
@@ -103,7 +106,7 @@ const GameBoardPreparationControls: React.FC<GameBoardPreparationControlsProps> 
       {isSoloMode && !topInitialHandDrawn && (
         <button
           onClick={() => onDrawInitialHand(topRole)}
-          style={{ padding: isCompactControls ? '0.24rem 0.5rem' : '0.3rem 0.6rem', background: '#6366f1', color: 'white', fontWeight: 'bold', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: compactButtonFontSize }}
+          style={{ padding: primaryActionPadding, background: '#6366f1', color: 'white', fontWeight: 'bold', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: compactButtonFontSize }}
         >
           {t('gameBoard.controls.drawP2Hand')}
         </button>
@@ -113,7 +116,7 @@ const GameBoardPreparationControls: React.FC<GameBoardPreparationControlsProps> 
         <button
           onClick={() => onToggleReady(topRole)}
           style={{
-            padding: isCompactControls ? '0.24rem 0.5rem' : '0.3rem 0.6rem',
+            padding: primaryActionPadding,
             background: topReady ? '#ef4444' : '#6366f1',
             color: 'white',
             fontWeight: 'bold',
@@ -131,7 +134,7 @@ const GameBoardPreparationControls: React.FC<GameBoardPreparationControlsProps> 
         onClick={onStartGame}
         disabled={!canStartGame}
         style={{
-          padding: isCompactControls ? '0.24rem 0.5rem' : '0.3rem 0.6rem',
+          padding: primaryActionPadding,
           background: 'var(--vivid-green-cyan)',
           color: 'black',
           fontWeight: 'bold',

--- a/src/components/GameBoardRoomStatus.tsx
+++ b/src/components/GameBoardRoomStatus.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
+import { useGameBoardBoardDensity, useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type ConnectionBadgeTone = {
   background: string;
@@ -36,10 +36,12 @@ const GameBoardRoomStatus: React.FC<GameBoardRoomStatusProps> = ({
 }) => {
   const { t } = useTranslation();
   const inputProfile = useGameBoardInputProfile();
+  const boardDensity = useGameBoardBoardDensity();
   const isCompactControls = inputProfile === 'coarse';
-  const pillFontSize = isCompactControls ? '0.62rem' : '0.72rem';
-  const statusFontSize = isCompactControls ? '0.66rem' : undefined;
-  const buttonPadding = isCompactControls ? '0.2rem 0.4rem' : '0.28rem 0.55rem';
+  const isOverviewControls = inputProfile === 'fine' && boardDensity === 'overview';
+  const pillFontSize = isCompactControls ? '0.62rem' : isOverviewControls ? '0.58rem' : '0.72rem';
+  const statusFontSize = isCompactControls ? '0.66rem' : isOverviewControls ? '0.8rem' : undefined;
+  const buttonPadding = isCompactControls ? '0.2rem 0.4rem' : isOverviewControls ? '0.22rem 0.44rem' : '0.28rem 0.55rem';
 
   return (
     <div
@@ -47,12 +49,12 @@ const GameBoardRoomStatus: React.FC<GameBoardRoomStatusProps> = ({
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: isCompactControls ? '0.4rem' : '0.6rem',
+        gap: isCompactControls ? '0.4rem' : isOverviewControls ? '0.48rem' : '0.6rem',
         flexWrap: isCompactControls ? 'wrap' : 'nowrap',
         minWidth: 0,
       }}
     >
-      <span style={{ fontSize: isCompactControls ? '0.68rem' : undefined, lineHeight: 1.2 }}>
+      <span style={{ fontSize: isCompactControls ? '0.68rem' : isOverviewControls ? '0.8rem' : undefined, lineHeight: 1.2 }}>
         {isSoloMode ? t('gameBoard.header.mode') : t('gameBoard.header.room')}:{' '}
         <strong>{isSoloMode ? t('gameBoard.header.soloPlayBeta') : room}</strong>
       </span>
@@ -79,11 +81,11 @@ const GameBoardRoomStatus: React.FC<GameBoardRoomStatusProps> = ({
       {isSoloMode && (
         <span
           style={{
-            fontSize: isCompactControls ? '0.68rem' : '0.75rem',
+            fontSize: isCompactControls ? '0.68rem' : isOverviewControls ? '0.6rem' : '0.75rem',
             fontWeight: 'bold',
             color: '#111827',
             background: '#f59e0b',
-            padding: '0.2rem 0.45rem',
+            padding: isOverviewControls ? '0.16rem 0.36rem' : '0.2rem 0.45rem',
             borderRadius: '999px',
             whiteSpace: 'nowrap',
           }}
@@ -94,7 +96,7 @@ const GameBoardRoomStatus: React.FC<GameBoardRoomStatusProps> = ({
       {!isSoloMode && (
         <span
           style={{
-            padding: '0.22rem 0.55rem',
+            padding: isOverviewControls ? '0.18rem 0.44rem' : '0.22rem 0.55rem',
             borderRadius: '999px',
             border: `1px solid ${connectionBadgeTone.border}`,
             background: connectionBadgeTone.background,
@@ -126,13 +128,13 @@ const GameBoardRoomStatus: React.FC<GameBoardRoomStatusProps> = ({
           disabled={connectionState === 'connecting'}
           title={connectionState === 'connecting' ? t('gameBoard.header.reconnectMessageConnecting') : t('gameBoard.header.reconnectMessageRetry')}
           style={{
-            padding: isCompactControls ? '0.25rem 0.5rem' : '0.3rem 0.6rem',
+            padding: isCompactControls ? '0.25rem 0.5rem' : isOverviewControls ? '0.24rem 0.48rem' : '0.3rem 0.6rem',
             background: '#334155',
             color: 'white',
             border: '1px solid rgba(255,255,255,0.14)',
             borderRadius: '4px',
             cursor: connectionState === 'connecting' ? 'not-allowed' : 'pointer',
-            fontSize: isCompactControls ? '0.68rem' : '0.75rem',
+            fontSize: isCompactControls ? '0.68rem' : isOverviewControls ? '0.6rem' : '0.75rem',
             opacity: connectionState === 'connecting' ? 0.6 : 1,
             whiteSpace: 'nowrap',
           }}

--- a/src/components/GameBoardTurnPanel.tsx
+++ b/src/components/GameBoardTurnPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
+import { useGameBoardBoardDensity, useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type GamePhase = 'Start' | 'Main' | 'End';
 
@@ -27,20 +27,22 @@ const GameBoardTurnPanel: React.FC<GameBoardTurnPanelProps> = ({
 }) => {
   const { t } = useTranslation();
   const inputProfile = useGameBoardInputProfile();
+  const boardDensity = useGameBoardBoardDensity();
   const isCompactControls = inputProfile === 'coarse';
+  const isOverviewControls = inputProfile === 'fine' && boardDensity === 'overview';
 
   return (
     <div
       data-testid="gameboard-turn-panel"
       style={{
         display: 'flex',
-        gap: isCompactControls ? '0.5rem' : '1rem',
+        gap: isCompactControls ? '0.5rem' : isOverviewControls ? '0.8rem' : '1rem',
         flexWrap: isCompactControls ? 'wrap' : 'nowrap',
         alignItems: 'center',
         background: isBottomTurnActive
           ? 'linear-gradient(90deg, rgba(0, 208, 132, 0.18), rgba(17, 24, 39, 0.92))'
           : 'var(--bg-overlay)',
-        padding: isCompactControls ? '0.36rem 0.55rem' : '0.55rem 1rem',
+        padding: isCompactControls ? '0.36rem 0.55rem' : isOverviewControls ? '0.44rem 0.8rem' : '0.55rem 1rem',
         borderRadius: '10px',
         border: isBottomTurnActive ? '1px solid rgba(0, 208, 132, 0.28)' : '1px solid transparent',
         boxShadow: isBottomTurnActive ? '0 0 18px rgba(0, 208, 132, 0.16)' : 'none',
@@ -52,6 +54,8 @@ const GameBoardTurnPanel: React.FC<GameBoardTurnPanelProps> = ({
           color: isSoloMode || isCurrentPlayerTurn ? 'var(--vivid-green-cyan)' : 'var(--vivid-red)',
           fontSize: isCompactControls
             ? (isBottomTurnActive ? '0.78rem' : '0.74rem')
+            : isOverviewControls
+              ? (isBottomTurnActive ? '0.8rem' : '0.74rem')
             : (isBottomTurnActive ? '1rem' : '0.92rem'),
           fontWeight: 900,
           letterSpacing: '0.06em',
@@ -62,7 +66,7 @@ const GameBoardTurnPanel: React.FC<GameBoardTurnPanelProps> = ({
           ? t('gameBoard.turn.p1', { label: currentTurnLabel.toUpperCase() })
           : isCurrentPlayerTurn ? t('gameBoard.turn.your') : t('gameBoard.turn.opponent')}
       </span>
-      <span className="Garamond" style={{ fontSize: isCompactControls ? (isBottomTurnActive ? '0.84rem' : '0.78rem') : (isBottomTurnActive ? '1.08rem' : undefined) }}>
+      <span className="Garamond" style={{ fontSize: isCompactControls ? (isBottomTurnActive ? '0.84rem' : '0.78rem') : isOverviewControls ? (isBottomTurnActive ? '0.86rem' : '0.8rem') : (isBottomTurnActive ? '1.08rem' : undefined) }}>
         {t('gameBoard.turn.count', { count: turnCount })}
       </span>
       <select
@@ -71,11 +75,11 @@ const GameBoardTurnPanel: React.FC<GameBoardTurnPanelProps> = ({
         onChange={(event) => onPhaseChange(event.target.value as GamePhase)}
         disabled={!canChangePhase}
         style={{
-          padding: isCompactControls ? '0.14rem 0.24rem' : '0.2rem',
+          padding: isCompactControls ? '0.14rem 0.24rem' : isOverviewControls ? '0.16rem' : '0.2rem',
           borderRadius: '4px',
           background: 'black',
           color: 'white',
-          fontSize: isCompactControls ? '0.66rem' : undefined,
+          fontSize: isCompactControls ? '0.66rem' : isOverviewControls ? '0.8rem' : undefined,
           minHeight: isCompactControls ? '28px' : undefined,
           border: isBottomTurnActive ? '1px solid rgba(0, 208, 132, 0.35)' : undefined,
         }}

--- a/src/components/Zone.test.tsx
+++ b/src/components/Zone.test.tsx
@@ -292,10 +292,10 @@ describe('Zone', () => {
       />
     );
 
-    expect(container.firstChild).toHaveStyle({ gap: '0.36rem' });
+    expect(container.firstChild).toHaveStyle({ gap: '1.14rem' });
   });
 
-  it('keeps more breathing room between field cards in desktop overview mode', () => {
+  it('uses scaled field spacing in desktop overview mode without switching to coarse input', () => {
     const { container } = renderWithInputProfile(
       'fine',
       <Zone
@@ -306,7 +306,7 @@ describe('Zone', () => {
       'overview'
     );
 
-    expect(container.firstChild).toHaveStyle({ gap: '1.05rem' });
+    expect(container.firstChild).toHaveStyle({ gap: '1.9rem' });
   });
 
   it('uses compact zone label typography for coarse input', () => {
@@ -344,6 +344,25 @@ describe('Zone', () => {
     expect(zoneLabel).toHaveStyle({
       overflowWrap: 'normal',
       wordBreak: 'keep-all',
+    });
+  });
+
+  it('uses tighter zone label chrome in desktop overview so evolve labels fit more naturally', () => {
+    renderWithInputProfile(
+      'fine',
+      <Zone
+        id="evolveDeck-host"
+        label="エボルヴ"
+        cards={[createCard('host-card', { zone: 'evolveDeck-host' })]}
+      />,
+      'overview'
+    );
+
+    const zoneLabel = screen.getByText('エボルヴ');
+    expect(zoneLabel).toHaveStyle({
+      fontSize: '0.64rem',
+      textOverflow: 'clip',
+      whiteSpace: 'nowrap',
     });
   });
 });

--- a/src/components/Zone.tsx
+++ b/src/components/Zone.tsx
@@ -44,6 +44,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
   const inputProfile = useGameBoardInputProfile();
   const boardDensity = useGameBoardBoardDensity();
   const isCompactInput = inputProfile === 'coarse';
+  const isOverviewDesktop = inputProfile === 'fine' && boardDensity === 'overview';
   const { isOver, setNodeRef } = useDroppable({ id });
   const cardSize = getCardSizeForInputProfile(inputProfile, boardDensity);
   const stackAttachmentOffset = getStackAttachmentOffsetForInputProfile(inputProfile, boardDensity);
@@ -141,9 +142,9 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
           display: isCompactInput ? 'grid' : 'inline-flex',
           gridTemplateColumns: isCompactInput ? 'minmax(0, 1fr) auto' : undefined,
           alignItems: 'center',
-          gap: isCompactInput ? '3px' : '6px',
-          maxWidth: 'calc(100% - 20px)',
-          padding: isCompactInput ? '1px 5px' : '2px 8px',
+          gap: isCompactInput ? '3px' : isOverviewDesktop ? '4px' : '6px',
+          maxWidth: isOverviewDesktop ? 'calc(100% - 12px)' : 'calc(100% - 20px)',
+          padding: isCompactInput ? '1px 5px' : isOverviewDesktop ? '1px 6px' : '2px 8px',
           background: 'rgba(17, 24, 39, 0.92)',
           border: '1px solid rgba(255,255,255,0.16)',
           borderRadius: '999px',
@@ -172,12 +173,12 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
           style={{
             maxWidth: isCompactInput ? '100%' : undefined,
             minWidth: 0,
-            fontSize: isCompactInput ? '0.5rem' : '0.72rem',
+            fontSize: isCompactInput ? '0.5rem' : isOverviewDesktop ? '0.64rem' : '0.72rem',
             fontWeight: 'bold',
             color: 'white',
             whiteSpace: isCompactInput ? 'normal' : 'nowrap',
             overflow: isCompactInput ? 'visible' : 'hidden',
-            textOverflow: isCompactInput ? 'clip' : 'ellipsis',
+            textOverflow: isCompactInput || isOverviewDesktop ? 'clip' : 'ellipsis',
             overflowWrap: isCompactInput ? 'normal' : undefined,
             wordBreak: isCompactInput ? 'keep-all' : undefined,
             lineHeight: isCompactInput ? 1.1 : undefined,
@@ -188,12 +189,12 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
         <span
           style={{
             flex: '0 0 auto',
-            minWidth: isCompactInput ? '18px' : '22px',
-            padding: isCompactInput ? '0 4px' : '0 6px',
+            minWidth: isCompactInput ? '18px' : isOverviewDesktop ? '18px' : '22px',
+            padding: isCompactInput ? '0 4px' : isOverviewDesktop ? '0 4px' : '0 6px',
             borderRadius: '999px',
             background: 'rgba(59, 130, 246, 0.24)',
             color: '#bfdbfe',
-            fontSize: isCompactInput ? '0.48rem' : '0.7rem',
+            fontSize: isCompactInput ? '0.48rem' : isOverviewDesktop ? '0.62rem' : '0.7rem',
             fontWeight: 'bold',
             textAlign: 'center'
           }}

--- a/src/pages/GameBoard.test.tsx
+++ b/src/pages/GameBoard.test.tsx
@@ -28,6 +28,7 @@ vi.mock('../components/Zone', () => ({
     onAttack,
     hideCards,
     viewerRole,
+    containerStyle,
   }: {
     id: string;
     label: string;
@@ -36,8 +37,14 @@ vi.mock('../components/Zone', () => ({
     onAttack?: (id: string) => void;
     hideCards?: boolean;
     viewerRole?: string;
+    containerStyle?: React.CSSProperties;
   }) => (
-    <section data-testid={`zone-${id}`} data-hide-cards={String(Boolean(hideCards))} data-viewer-role={viewerRole ?? ''}>
+    <section
+      data-testid={`zone-${id}`}
+      data-hide-cards={String(Boolean(hideCards))}
+      data-viewer-role={viewerRole ?? ''}
+      style={containerStyle}
+    >
       <h3>{label}</h3>
       {cards.map((card) => (
         <div key={card.id} className="game-card" data-card-id={card.id}>
@@ -2261,7 +2268,7 @@ describe('GameBoard', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Inspect Alpha Knight' }));
     expect(await screen.findByTestId('card-inspector')).toBeInTheDocument();
 
-    fireEvent.keyDown(window, { key: 'Escape' });
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 
     await waitFor(() => {
       expect(screen.queryByTestId('card-inspector')).not.toBeInTheDocument();
@@ -2431,16 +2438,13 @@ describe('GameBoard', () => {
     render(<GameBoard />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Attack Alpha Knight' }));
+    expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'true');
+    expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-source-card-id', 'card-1');
 
-    expect(await screen.findByText('ATTACK MODE')).toBeInTheDocument();
-    expect(screen.getByText((_, node) => (
-      node?.textContent === 'Select an enemy follower or leader for Alpha Knight.'
-    ))).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 
     await waitFor(() => {
-      expect(screen.queryByText('ATTACK MODE')).not.toBeInTheDocument();
+      expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'false');
     });
   });
 
@@ -2477,7 +2481,7 @@ describe('GameBoard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Attack Alpha Knight' }));
 
-    expect(await screen.findByText('ATTACK MODE')).toBeInTheDocument();
+    expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'true');
     expect(screen.queryByTestId('card-inspector')).not.toBeInTheDocument();
   });
 
@@ -2495,12 +2499,12 @@ describe('GameBoard', () => {
 
     const attackButton = screen.getByRole('button', { name: 'Attack Alpha Knight' });
     fireEvent.click(attackButton);
-    expect(await screen.findByText('ATTACK MODE')).toBeInTheDocument();
+    expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'true');
 
     fireEvent.click(attackButton);
 
     await waitFor(() => {
-      expect(screen.queryByText('ATTACK MODE')).not.toBeInTheDocument();
+      expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'false');
     });
   });
 
@@ -2526,15 +2530,11 @@ describe('GameBoard', () => {
     render(<GameBoard />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Attack Alpha Knight' }));
-    expect(await screen.findByText((_, node) => (
-      node?.textContent === 'Select an enemy follower or leader for Alpha Knight.'
-    ))).toBeInTheDocument();
+    expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-source-card-id', 'card-1');
 
     fireEvent.click(screen.getByRole('button', { name: 'Attack Beta Mage' }));
 
-    expect(await screen.findByText((_, node) => (
-      node?.textContent === 'Select an enemy follower or leader for Beta Mage.'
-    ))).toBeInTheDocument();
+    expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-source-card-id', 'card-2');
   });
 
   it('closes attack mode from an outside pointer down', async () => {
@@ -2550,14 +2550,14 @@ describe('GameBoard', () => {
     render(<GameBoard />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Attack Alpha Knight' }));
-    expect(await screen.findByText('ATTACK MODE')).toBeInTheDocument();
+    expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'true');
 
     const outsideTarget = document.createElement('div');
     document.body.appendChild(outsideTarget);
     fireEvent.pointerDown(outsideTarget);
 
     await waitFor(() => {
-      expect(screen.queryByText('ATTACK MODE')).not.toBeInTheDocument();
+      expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'false');
     });
     outsideTarget.remove();
   });
@@ -2623,7 +2623,7 @@ describe('GameBoard', () => {
     render(<GameBoard />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Attack Alpha Knight' }));
-    expect(await screen.findByText('ATTACK MODE')).toBeInTheDocument();
+    expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'true');
 
     fireEvent.click(screen.getByRole('button', { name: 'Inspect Beta Mage' }));
 
@@ -2636,7 +2636,7 @@ describe('GameBoard', () => {
       'host'
     );
     await waitFor(() => {
-      expect(screen.queryByText('ATTACK MODE')).not.toBeInTheDocument();
+      expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'false');
     });
     expect(screen.queryByTestId('card-inspector')).not.toBeInTheDocument();
   });
@@ -2654,12 +2654,12 @@ describe('GameBoard', () => {
     render(<GameBoard />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Attack Alpha Knight' }));
-    expect(await screen.findByText('ATTACK MODE')).toBeInTheDocument();
+    expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'true');
 
-    fireEvent.keyDown(window, { key: 'Escape' });
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 
     await waitFor(() => {
-      expect(screen.queryByText('ATTACK MODE')).not.toBeInTheDocument();
+      expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'false');
     });
   });
 
@@ -2677,7 +2677,7 @@ describe('GameBoard', () => {
     const { rerender } = render(<GameBoard />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Attack Alpha Knight' }));
-    expect(await screen.findByText('ATTACK MODE')).toBeInTheDocument();
+    expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'true');
 
     currentLogic = buildMockGameBoardLogic({
       connectionState: 'reconnecting',
@@ -2689,7 +2689,7 @@ describe('GameBoard', () => {
     rerender(<GameBoard />);
 
     await waitFor(() => {
-      expect(screen.queryByText('ATTACK MODE')).not.toBeInTheDocument();
+      expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'false');
     });
   });
 
@@ -2709,7 +2709,7 @@ describe('GameBoard', () => {
     const { rerender } = render(<GameBoard />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Attack Alpha Knight' }));
-    expect(await screen.findByText('ATTACK MODE')).toBeInTheDocument();
+    expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'true');
 
     currentLogic = buildMockGameBoardLogic({
       mode: 'solo',
@@ -2722,10 +2722,10 @@ describe('GameBoard', () => {
     });
     rerender(<GameBoard />);
 
-    expect(screen.getByText('ATTACK MODE')).toBeInTheDocument();
+    expect(screen.getByTestId('board-playmat')).toHaveAttribute('data-attack-mode-active', 'true');
   });
 
-  it('uses desktop board shell columns when viewport width is 1280px', () => {
+  it('uses compact overview desktop board shell columns when viewport width is 1280px', () => {
     const originalInnerWidth = window.innerWidth;
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
@@ -2739,7 +2739,7 @@ describe('GameBoard', () => {
       const topSection = screen.getByTestId('board-section-top');
       const topGrid = topSection.firstElementChild as HTMLElement;
 
-      expect(topGrid).toHaveStyle({ gridTemplateColumns: '188px 1080px 220px' });
+      expect(topGrid).toHaveStyle({ gridTemplateColumns: '150px 864px 176px' });
     } finally {
       Object.defineProperty(window, 'innerWidth', {
         configurable: true,
@@ -2882,10 +2882,15 @@ describe('GameBoard', () => {
       expect(shell).toHaveAttribute('data-layout-profile', 'desktop');
       expect(shell).toHaveAttribute('data-input-profile', 'fine');
       expect(shell).toHaveAttribute('data-board-density', 'overview');
-      expect(shell).toHaveStyle({ padding: '0.6rem', gap: '0.55rem' });
-      expect(playmat).toHaveStyle({ padding: '0.55rem', gap: '0.3rem' });
-      expect(topSection).toHaveStyle({ padding: '0.32rem 0.36rem' });
-      expect(topGrid).toHaveStyle({ gridTemplateColumns: '188px 1080px 220px' });
+      expect(shell).toHaveStyle({ padding: '0.48rem', gap: '0.44rem', width: '100%', height: '100%' });
+      expect(shell.style.zoom).toBe('');
+      expect(playmat).toHaveStyle({ padding: '0.44rem', gap: '0.24rem' });
+      expect(topSection).toHaveStyle({ padding: '0.26rem 0.29rem' });
+      expect(topGrid).toHaveStyle({ gridTemplateColumns: '150px 864px 176px' });
+      expect(screen.getByTestId('zone-cemetery-guest')).toHaveStyle({ minHeight: '98px' });
+      expect(screen.getByTestId('zone-field-guest')).toHaveStyle({ minHeight: '109px' });
+      expect(screen.getByTestId('zone-hand-guest')).toHaveStyle({ minHeight: '102px' });
+      expect(screen.getByTestId('zone-hand-host')).toHaveStyle({ minHeight: '109px' });
 
       [
         'hand-guest',
@@ -2954,8 +2959,9 @@ describe('GameBoard', () => {
       expect(shell).toHaveAttribute('data-layout-profile', 'desktop');
       expect(shell).toHaveAttribute('data-input-profile', 'fine');
       expect(shell).toHaveAttribute('data-board-density', 'overview');
-      expect(shell).toHaveStyle({ padding: '0.6rem', gap: '0.55rem' });
-      expect(playmat).toHaveStyle({ padding: '0.55rem', gap: '0.3rem' });
+      expect(shell).toHaveStyle({ padding: '0.48rem', gap: '0.44rem', width: '100%', height: '100%' });
+      expect(shell.style.zoom).toBe('');
+      expect(playmat).toHaveStyle({ padding: '0.44rem', gap: '0.24rem' });
     } finally {
       Object.defineProperty(window, 'innerWidth', {
         configurable: true,
@@ -3081,6 +3087,44 @@ describe('GameBoard', () => {
       expect(playmat).toHaveStyle({ padding: '0.42rem', gap: '0.24rem' });
       expect(topSection).toHaveStyle({ padding: '0.28rem 0.32rem' });
       expect(topGrid).toHaveStyle({ columnGap: '0.5rem' });
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        writable: true,
+        value: originalInnerWidth,
+      });
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
+      });
+    }
+  });
+
+  it('keeps solo tablet trackers at the same compact density on roomy tablet widths', () => {
+    const originalInnerWidth = window.innerWidth;
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1180,
+    });
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => ({ matches: true })),
+    });
+    mockUseGameBoardLogic.mockReturnValue(buildMockGameBoardLogic({
+      mode: 'solo',
+      isSoloMode: true,
+      gameState: createGameState([], { gameStatus: 'playing' }),
+    }));
+
+    try {
+      render(<GameBoard />);
+
+      expect(screen.getByTestId('player-tracker-guest')).toHaveAttribute('data-compact', 'true');
+      expect(screen.getByTestId('player-tracker-host')).toHaveAttribute('data-compact', 'true');
     } finally {
       Object.defineProperty(window, 'innerWidth', {
         configurable: true,

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import Zone from '../components/Zone';
 import type { CardInstance } from '../components/Card';
 import CardSearchModal from '../components/CardSearchModal';
-import GameBoardAttackModeBanner from '../components/GameBoardAttackModeBanner';
 import GameBoardBoardRow from '../components/GameBoardBoardRow';
 import GameBoardBottomHandSection from '../components/GameBoardBottomHandSection';
 import GameBoardCardInspectorSection from '../components/GameBoardCardInspectorSection';
@@ -94,19 +93,19 @@ const GameBoard: React.FC = () => {
   );
   const isCompactBoard = inputProfile === 'coarse';
   const isOverviewBoard = boardDensity === 'overview';
-  const boardShellPadding = isCompactBoard ? '0.52rem' : isOverviewBoard ? '0.6rem' : '1rem';
-  const boardShellGap = isCompactBoard ? '0.48rem' : isOverviewBoard ? '0.55rem' : '1rem';
-  const playmatPadding = isCompactBoard ? '0.42rem' : isOverviewBoard ? '0.55rem' : '1rem';
-  const playmatGap = isCompactBoard ? '0.24rem' : isOverviewBoard ? '0.3rem' : '0.5rem';
-  const boardSectionPadding = isCompactBoard ? '0.28rem 0.32rem' : isOverviewBoard ? '0.32rem 0.36rem' : '0.55rem 0.6rem';
-  const boardSectionGap = isCompactBoard ? '0.22rem' : isOverviewBoard ? '0.26rem' : '0.5rem';
-  const boardShellColumnGap = isCompactBoard ? '0.5rem' : isOverviewBoard ? '0.55rem' : '1rem';
-  const boardColumnStackGap = isCompactBoard ? '0.34rem' : isOverviewBoard ? '0.36rem' : '0.65rem';
-  const boardSectionDividerMargin = isCompactBoard ? '0.4rem 0' : isOverviewBoard ? '0.35rem 0' : '1rem 0';
-  const stackZoneMinHeight = isCompactBoard ? '110px' : isOverviewBoard ? '122px' : '150px';
-  const fieldZoneMinHeight = isCompactBoard ? '124px' : isOverviewBoard ? '136px' : '160px';
-  const handZoneMinHeight = isCompactBoard ? '116px' : isOverviewBoard ? '128px' : '150px';
-  const bottomHandZoneMinHeight = isCompactBoard ? '124px' : isOverviewBoard ? '136px' : '160px';
+  const boardShellPadding = isCompactBoard ? '0.52rem' : isOverviewBoard ? '0.48rem' : '1rem';
+  const boardShellGap = isCompactBoard ? '0.48rem' : isOverviewBoard ? '0.44rem' : '1rem';
+  const playmatPadding = isCompactBoard ? '0.42rem' : isOverviewBoard ? '0.44rem' : '1rem';
+  const playmatGap = isCompactBoard ? '0.24rem' : isOverviewBoard ? '0.24rem' : '0.5rem';
+  const boardSectionPadding = isCompactBoard ? '0.28rem 0.32rem' : isOverviewBoard ? '0.26rem 0.29rem' : '0.55rem 0.6rem';
+  const boardSectionGap = isCompactBoard ? '0.22rem' : isOverviewBoard ? '0.21rem' : '0.5rem';
+  const boardShellColumnGap = isCompactBoard ? '0.5rem' : isOverviewBoard ? '0.44rem' : '1rem';
+  const boardColumnStackGap = isCompactBoard ? '0.34rem' : isOverviewBoard ? '0.29rem' : '0.65rem';
+  const boardSectionDividerMargin = isCompactBoard ? '0.4rem 0' : isOverviewBoard ? '0.28rem 0' : '1rem 0';
+  const stackZoneMinHeight = isCompactBoard ? '110px' : isOverviewBoard ? '98px' : '150px';
+  const fieldZoneMinHeight = isCompactBoard ? '124px' : isOverviewBoard ? '109px' : '160px';
+  const handZoneMinHeight = isCompactBoard ? '116px' : isOverviewBoard ? '102px' : '150px';
+  const bottomHandZoneMinHeight = isCompactBoard ? '124px' : isOverviewBoard ? '109px' : '160px';
   const {
     sidePanelWidth,
     topPanelWidth,
@@ -116,8 +115,8 @@ const GameBoard: React.FC = () => {
     boardColumns,
     boardShellColumns,
   } = React.useMemo(
-    () => resolveBoardLayout(viewportWidth, inputProfile),
-    [viewportWidth, inputProfile]
+    () => resolveBoardLayout(viewportWidth, inputProfile, boardDensity),
+    [viewportWidth, inputProfile, boardDensity]
   );
   const { t } = useTranslation();
   const {
@@ -445,6 +444,7 @@ const GameBoard: React.FC = () => {
     playerState: gameState[topRole],
     onAdjustStat: (stat: 'hp' | 'pp' | 'maxPp' | 'ep' | 'sep' | 'combo', delta: number) => handleStatChange(topRole, stat, delta),
     readOnlyTracker: isSpectator,
+    forceExpandedTracker: false,
   };
   const topSoloHandSectionProps = {
     columns: boardColumns,
@@ -560,6 +560,7 @@ const GameBoard: React.FC = () => {
     trackerTestId: `player-tracker-${bottomRole}`,
     playerState: gameState[bottomRole],
     onAdjustStat: (stat: 'hp' | 'pp' | 'maxPp' | 'ep' | 'sep' | 'combo', delta: number) => handleStatChange(bottomRole, stat, delta),
+    forceExpandedTracker: false,
     containerStyle: { marginLeft: '1.25rem' },
   };
   const savedDeckPickerDialogProps = savedDeckImportTargetRole && savedDeckPickerTargetLabel
@@ -617,7 +618,15 @@ const GameBoard: React.FC = () => {
           data-layout-profile={layoutProfile}
           data-input-profile={inputProfile}
           data-board-density={boardDensity}
-          style={{ padding: boardShellPadding, display: 'flex', flexDirection: 'column', height: '100%', gap: boardShellGap, overflow: 'hidden' }}
+          style={{
+            padding: boardShellPadding,
+            display: 'flex',
+            flexDirection: 'column',
+            width: '100%',
+            height: '100%',
+            gap: boardShellGap,
+            overflow: 'hidden',
+          }}
         >
 
         <GameBoardHeader
@@ -660,13 +669,6 @@ const GameBoard: React.FC = () => {
           />
         )}
 
-        {attackSourceCard && (
-          <GameBoardAttackModeBanner
-            attackerName={attackSourceCard.name}
-            onCancel={clearAttackSource}
-          />
-        )}
-
         {gameState.gameStatus === 'preparing' && (
           <GameBoardPreparationPanel
             isSoloMode={isSoloMode}
@@ -687,6 +689,8 @@ const GameBoard: React.FC = () => {
         {/* Board Playmat */}
         <div
           data-testid="board-playmat"
+          data-attack-mode-active={String(Boolean(attackSourceCard))}
+          data-attack-source-card-id={attackSourceCard?.id ?? ''}
           style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: playmatGap, background: 'url("https://shadowverse-evolve.com/wordpress/wp-content/themes/shadowverse-evolve-release_v0/assets/images/common/bg.jpg")', backgroundSize: 'cover', backgroundPosition: 'center', borderRadius: 'var(--radius-lg)', padding: playmatPadding, overflowY: 'auto', overflowX: 'auto', alignItems: 'center' }}
         >
 

--- a/src/pages/gameBoardLayout.test.ts
+++ b/src/pages/gameBoardLayout.test.ts
@@ -40,6 +40,19 @@ describe('gameBoardLayout', () => {
     expect(layout.boardShellColumns).toBe('188px 1080px 220px');
   });
 
+  it('uses explicit compact desktop columns for overview density without CSS scaling', () => {
+    const layout = resolveBoardLayout(1440, 'fine', 'overview');
+
+    expect(layout.profile).toBe('desktop');
+    expect(layout.sidePanelWidth).toBe(176);
+    expect(layout.topPanelWidth).toBe(150);
+    expect(layout.sideZoneWidth).toBe(112);
+    expect(layout.centerZoneWidth).toBe(640);
+    expect(layout.boardContentWidth).toBe(864);
+    expect(layout.boardColumns).toBe('112px 640px 112px');
+    expect(layout.boardShellColumns).toBe('150px 864px 176px');
+  });
+
   it('uses tablet profile in 900-1279px only when input profile is coarse', () => {
     expect(getLayoutProfileForViewportWidth(900, 'coarse')).toBe('tablet');
     expect(getLayoutProfileForViewportWidth(1024, 'coarse')).toBe('tablet');

--- a/src/pages/gameBoardLayout.ts
+++ b/src/pages/gameBoardLayout.ts
@@ -56,6 +56,13 @@ export const desktopGameBoardLayout = buildLayout('desktop', {
   centerZoneWidth: 800,
 });
 
+export const overviewDesktopGameBoardLayout = buildLayout('desktop', {
+  sidePanelWidth: 176,
+  topPanelWidth: 150,
+  sideZoneWidth: 112,
+  centerZoneWidth: 640,
+});
+
 export const tabletGameBoardLayout = buildLayout('tablet', {
   sidePanelWidth: 180,
   topPanelWidth: 148,
@@ -107,10 +114,12 @@ export const getLayoutProfileForViewportWidth = (
 
 export const resolveBoardLayout = (
   viewportWidth: number,
-  inputProfile: GameBoardLayoutInputProfile = 'coarse'
+  inputProfile: GameBoardLayoutInputProfile = 'coarse',
+  boardDensity: GameBoardBoardDensity = 'standard'
 ): GameBoardLayout => {
   const profile = getLayoutProfileForViewportWidth(viewportWidth, inputProfile);
-  return profile === 'tablet' ? resolveTabletLayout(viewportWidth) : desktopGameBoardLayout;
+  if (profile === 'tablet') return resolveTabletLayout(viewportWidth);
+  return boardDensity === 'overview' ? overviewDesktopGameBoardLayout : desktopGameBoardLayout;
 };
 
 export const getBoardDensityForViewportWidth = (

--- a/src/utils/gameBoardCardLayout.test.ts
+++ b/src/utils/gameBoardCardLayout.test.ts
@@ -18,18 +18,18 @@ describe('gameBoardCardLayout', () => {
     expect(getExZoneGapForInputProfile('fine')).toBe('1rem');
   });
 
-  it('uses a compact card size and tighter zone gaps for coarse input', () => {
+  it('uses a compact card size with slightly wider field spacing for coarse input', () => {
     expect(coarseCardSize).toEqual({ width: 76, height: 106 });
     expect(getCardSizeForInputProfile('coarse')).toEqual(coarseCardSize);
-    expect(getFieldZoneGapForInputProfile('coarse')).toBe('0.36rem');
+    expect(getFieldZoneGapForInputProfile('coarse')).toBe('1.14rem');
     expect(getExZoneGapForInputProfile('coarse')).toBe('0.36rem');
   });
 
   it('uses overview desktop sizing without switching to coarse input behavior', () => {
-    expect(overviewDesktopCardSize).toEqual({ width: 88, height: 123 });
+    expect(overviewDesktopCardSize).toEqual({ width: 70, height: 98 });
     expect(getCardSizeForInputProfile('fine', 'overview')).toEqual(overviewDesktopCardSize);
-    expect(getFieldZoneGapForInputProfile('fine', 'overview')).toBe('1.05rem');
-    expect(getExZoneGapForInputProfile('fine', 'overview')).toBe('0.5rem');
+    expect(getFieldZoneGapForInputProfile('fine', 'overview')).toBe('1.9rem');
+    expect(getExZoneGapForInputProfile('fine', 'overview')).toBe('0.4rem');
   });
 
   it('fits five field cards within tablet center zone width at 1024px', () => {

--- a/src/utils/gameBoardCardLayout.ts
+++ b/src/utils/gameBoardCardLayout.ts
@@ -12,8 +12,8 @@ export const desktopCardSize: GameBoardCardSize = {
 };
 
 export const overviewDesktopCardSize: GameBoardCardSize = {
-  width: 88,
-  height: 123,
+  width: 70,
+  height: 98,
 };
 
 export const coarseCardSize: GameBoardCardSize = {
@@ -37,9 +37,9 @@ export const getFieldZoneGapForInputProfile = (
   boardDensity: GameBoardBoardDensity = 'standard'
 ): string => (
   inputProfile === 'coarse'
-    ? '0.36rem'
+    ? '1.14rem'
     : boardDensity === 'overview'
-      ? '1.05rem'
+      ? '1.9rem'
       : '1.9rem'
 );
 
@@ -50,7 +50,7 @@ export const getExZoneGapForInputProfile = (
   inputProfile === 'coarse'
     ? '0.36rem'
     : boardDensity === 'overview'
-      ? '0.5rem'
+      ? '0.4rem'
       : '1rem'
 );
 
@@ -61,7 +61,7 @@ export const getStackAttachmentOffsetForInputProfile = (
   inputProfile === 'coarse'
     ? { top: 14, left: 10 }
     : boardDensity === 'overview'
-      ? { top: 16, left: 12 }
+      ? { top: 13, left: 10 }
     : { top: 20, left: 15 }
 );
 
@@ -72,7 +72,7 @@ export const getLinkedCardOffsetForInputProfile = (
   inputProfile === 'coarse'
     ? { top: 14, left: 10, paddingBottom: 16 }
     : boardDensity === 'overview'
-      ? { top: 16, left: 12, paddingBottom: 18 }
+      ? { top: 13, left: 10, paddingBottom: 14 }
     : { top: 20, left: 15, paddingBottom: 24 }
 );
 
@@ -87,9 +87,9 @@ export const getRequiredFieldWidthForCardCount = (
 
   const cardSize = getCardSizeForInputProfile(inputProfile, boardDensity);
   const gapRem = inputProfile === 'coarse'
-    ? 0.36
+    ? 1.14
     : boardDensity === 'overview'
-      ? 1.05
+      ? 1.9
       : 1.9;
   const gapPx = gapRem * rootFontSizePx;
   const horizontalPaddingPx = 16;


### PR DESCRIPTION
## Summary

GameBoard の UI 密度と操作性を整理し、PC 版は compact な overview レイアウトをデフォルトとして統一しました。  
あわせて、tablet / solo の tracker 表示、カード hover 時の quick actions、コントロールパネルの文言と表示ロジック、攻撃モード時の表示を調整しています。

## Changes

- PC fine input の GameBoard を compact な overview desktop layout に統一
- `zoom` ではなく、実寸ベースのレイアウト・カードサイズ・zone サイズで密度を調整
- コントロールパネルで phase に応じて無効ボタンを非表示化
- `Spawn Token` は準備中/ゲーム中どちらでも表示維持
- 日本語のコントロール文言を短縮して、狭い panel でも折り返しにくく調整
- tablet / solo の status tracker を compact density に統一し、1P/2P のサイズ差を解消
- PC overview の hover quick actions を小型化
- `REST/STAND` ボタンの押下不能問題を z-index 調整で修正
- レスト時の見栄え改善のため、field card 間隔を拡張
- PC 版の `エボルヴ` zone ラベルが省略されにくいよう zone label pill を調整
- 攻撃モード時に画面上部へ表示していたバナーを削除し、画面レイアウトが押し下がらないよう改善

## Why

- ブラウザ倍率 80% 相当のプレイ感を、アプリ内レイアウトで安全に再現したかったため
- PC / tablet でのスクロール量と視認性を減らしつつ、操作の押しやすさを保つため
- コントロールパネルのノイズを減らし、今使える操作だけを見せるため
- 高解像度環境で攻撃開始のたびに上部バナーが出てレイアウトがずれる問題をなくすため

## Test

- `npm run lint`
- `npx tsc --noEmit -p tsconfig.app.json`
- `npx vitest run`
- `npm run build`
- `npm run test:e2e`

## Risk / Notes

- PC fine input は常時 overview density になるため、大画面環境でも compact な見え方になります
- hover quick actions は主要導線を自動テストで確認済みですが、最終的な触り心地は実機確認があると安心です
- tablet / solo tracker は 1P/2P の見た目差をなくすため、両方 compact density に統一しています
- 攻撃モードの上部バナーは削除していますが、攻撃状態そのものは維持され、対象選択やキャンセルも既存通り動作します
