### PR TITLE
Codex/uistatus

### DIFF
--- a/e2e/solo-desktop-overview-layout.spec.ts
+++ b/e2e/solo-desktop-overview-layout.spec.ts
@@ -56,6 +56,15 @@ test.describe('Solo Desktop Overview Layout', () => {
     expect(firstHandCardBox?.height).toBeGreaterThanOrEqual(97);
     expect(firstHandCardBox?.height).toBeLessThanOrEqual(100);
 
+    const hostMainDeckBox = await zone(page, 'mainDeck-host').boundingBox();
+    const hostTrackerBox = await page.getByTestId('player-tracker-host').boundingBox();
+    expect(hostMainDeckBox).not.toBeNull();
+    expect(hostTrackerBox).not.toBeNull();
+    if (hostMainDeckBox && hostTrackerBox) {
+      const controlsGap = hostTrackerBox.x - (hostMainDeckBox.x + hostMainDeckBox.width);
+      expect(controlsGap).toBeGreaterThanOrEqual(16);
+    }
+
     await dragFirstZoneCard(page, 'hand-host', 'field-host');
     await expect(zoneCards(page, 'field-host')).toHaveCount(1);
     await expect(zoneCards(page, 'hand-host')).toHaveCount(3);

--- a/e2e/solo-tablet-touch.spec.ts
+++ b/e2e/solo-tablet-touch.spec.ts
@@ -40,6 +40,15 @@ test.describe('Solo Tablet Touch Controls', () => {
     await expect(boardRoot).toHaveAttribute('data-layout-profile', 'tablet');
     await expect(boardRoot).toHaveAttribute('data-input-profile', 'coarse');
 
+    const hostMainDeckBox = await page.getByTestId('zone-mainDeck-host').boundingBox();
+    const hostTrackerBox = await page.getByTestId('player-tracker-host').boundingBox();
+    expect(hostMainDeckBox).not.toBeNull();
+    expect(hostTrackerBox).not.toBeNull();
+    if (hostMainDeckBox && hostTrackerBox) {
+      const controlsGap = hostTrackerBox.x - (hostMainDeckBox.x + hostMainDeckBox.width);
+      expect(controlsGap).toBeGreaterThanOrEqual(14);
+    }
+
     await expect(zoneCards(page, 'mainDeck-host')).toHaveCount(2);
     await expect(zoneCards(page, 'hand-host')).toHaveCount(4);
 

--- a/src/components/GameBoardHeader.tsx
+++ b/src/components/GameBoardHeader.tsx
@@ -8,6 +8,7 @@ import type { ConnectionBadgeTone, GameBoardConnectionState } from '../utils/gam
 import { useGameBoardBoardDensity, useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type GameBoardHeaderProps = {
+  isTabletLayout: boolean;
   room: string;
   isSoloMode: boolean;
   isHost: boolean;
@@ -36,6 +37,7 @@ type GameBoardHeaderProps = {
 };
 
 const GameBoardHeader: React.FC<GameBoardHeaderProps> = ({
+  isTabletLayout,
   room,
   isSoloMode,
   isHost,
@@ -65,6 +67,7 @@ const GameBoardHeader: React.FC<GameBoardHeaderProps> = ({
   const inputProfile = useGameBoardInputProfile();
   const boardDensity = useGameBoardBoardDensity();
   const isCompactControls = inputProfile === 'coarse';
+  const keepInlineCompactHeader = isCompactControls && isTabletLayout;
   const isOverviewControls = inputProfile === 'fine' && boardDensity === 'overview';
 
   return (
@@ -72,8 +75,8 @@ const GameBoardHeader: React.FC<GameBoardHeaderProps> = ({
       style={{
         display: 'flex',
         justifyContent: 'space-between',
-        alignItems: isCompactControls ? 'stretch' : 'center',
-        flexWrap: isCompactControls ? 'wrap' : 'nowrap',
+        alignItems: keepInlineCompactHeader ? 'center' : isCompactControls ? 'stretch' : 'center',
+        flexWrap: keepInlineCompactHeader ? 'nowrap' : isCompactControls ? 'wrap' : 'nowrap',
         columnGap: isCompactControls ? '0.5rem' : isOverviewControls ? '0.8rem' : undefined,
         rowGap: isCompactControls ? '0.4rem' : isOverviewControls ? '0.32rem' : undefined,
         background: 'var(--bg-surface)',
@@ -86,7 +89,7 @@ const GameBoardHeader: React.FC<GameBoardHeaderProps> = ({
           display: 'flex',
           gap: isCompactControls ? '0.5rem' : isOverviewControls ? '0.8rem' : '1rem',
           alignItems: 'center',
-          flexWrap: isCompactControls ? 'wrap' : 'nowrap',
+          flexWrap: keepInlineCompactHeader ? 'nowrap' : isCompactControls ? 'wrap' : 'nowrap',
           minWidth: 0,
           flex: '1 1 auto',
         }}
@@ -133,7 +136,14 @@ const GameBoardHeader: React.FC<GameBoardHeaderProps> = ({
       </div>
 
       {gameState.gameStatus === 'playing' && (
-        <div style={{ display: 'flex', flex: isCompactControls ? '1 1 100%' : undefined, justifyContent: isCompactControls ? 'flex-start' : 'flex-end', minWidth: 0 }}>
+        <div
+          style={{
+            display: 'flex',
+            flex: keepInlineCompactHeader ? undefined : isCompactControls ? '1 1 100%' : undefined,
+            justifyContent: keepInlineCompactHeader ? 'flex-end' : isCompactControls ? 'flex-start' : 'flex-end',
+            minWidth: 0,
+          }}
+        >
           <GameBoardTurnPanel
             isSoloMode={isSoloMode || isSpectator}
             isCurrentPlayerTurn={gameState.turnPlayer === role}

--- a/src/pages/GameBoard.test.tsx
+++ b/src/pages/GameBoard.test.tsx
@@ -3077,6 +3077,9 @@ describe('GameBoard', () => {
       writable: true,
       value: vi.fn(() => ({ matches: true })),
     });
+    mockUseGameBoardLogic.mockReturnValue(buildMockGameBoardLogic({
+      gameState: createGameState([], { gameStatus: 'playing' }),
+    }));
 
     try {
       const { container } = render(<GameBoard />);
@@ -3091,6 +3094,9 @@ describe('GameBoard', () => {
       expect(topGrid).toHaveStyle({ columnGap: '0.5rem' });
       const hostControlsPanel = screen.getByTestId('player-tracker-host').parentElement as HTMLElement;
       expect(hostControlsPanel).toHaveStyle({ marginLeft: '1.35rem' });
+      const turnPanelWrapper = screen.getByTestId('gameboard-turn-panel').parentElement as HTMLElement;
+      expect(turnPanelWrapper).toHaveStyle({ justifyContent: 'flex-end' });
+      expect(turnPanelWrapper.style.flex).toBe('');
     } finally {
       Object.defineProperty(window, 'innerWidth', {
         configurable: true,

--- a/src/pages/GameBoard.test.tsx
+++ b/src/pages/GameBoard.test.tsx
@@ -2891,6 +2891,8 @@ describe('GameBoard', () => {
       expect(screen.getByTestId('zone-field-guest')).toHaveStyle({ minHeight: '109px' });
       expect(screen.getByTestId('zone-hand-guest')).toHaveStyle({ minHeight: '102px' });
       expect(screen.getByTestId('zone-hand-host')).toHaveStyle({ minHeight: '109px' });
+      const hostControlsPanel = screen.getByTestId('player-tracker-host').parentElement as HTMLElement;
+      expect(hostControlsPanel).toHaveStyle({ marginLeft: '1.5rem' });
 
       [
         'hand-guest',
@@ -3087,6 +3089,8 @@ describe('GameBoard', () => {
       expect(playmat).toHaveStyle({ padding: '0.42rem', gap: '0.24rem' });
       expect(topSection).toHaveStyle({ padding: '0.28rem 0.32rem' });
       expect(topGrid).toHaveStyle({ columnGap: '0.5rem' });
+      const hostControlsPanel = screen.getByTestId('player-tracker-host').parentElement as HTMLElement;
+      expect(hostControlsPanel).toHaveStyle({ marginLeft: '1.35rem' });
     } finally {
       Object.defineProperty(window, 'innerWidth', {
         configurable: true,

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -636,6 +636,7 @@ const GameBoard: React.FC = () => {
         >
 
         <GameBoardHeader
+          isTabletLayout={isTabletLayout}
           room={room}
           isSoloMode={isSoloMode}
           isHost={isHost}

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -92,6 +92,7 @@ const GameBoard: React.FC = () => {
     [viewportWidth, viewportHeight]
   );
   const isCompactBoard = inputProfile === 'coarse';
+  const isTabletLayout = layoutProfile === 'tablet';
   const isOverviewBoard = boardDensity === 'overview';
   const boardShellPadding = isCompactBoard ? '0.52rem' : isOverviewBoard ? '0.48rem' : '1rem';
   const boardShellGap = isCompactBoard ? '0.48rem' : isOverviewBoard ? '0.44rem' : '1rem';
@@ -99,7 +100,12 @@ const GameBoard: React.FC = () => {
   const playmatGap = isCompactBoard ? '0.24rem' : isOverviewBoard ? '0.24rem' : '0.5rem';
   const boardSectionPadding = isCompactBoard ? '0.28rem 0.32rem' : isOverviewBoard ? '0.26rem 0.29rem' : '0.55rem 0.6rem';
   const boardSectionGap = isCompactBoard ? '0.22rem' : isOverviewBoard ? '0.21rem' : '0.5rem';
-  const boardShellColumnGap = isCompactBoard ? '0.5rem' : isOverviewBoard ? '0.44rem' : '1rem';
+  const boardShellColumnGap = isCompactBoard ? '0.5rem' : isOverviewBoard ? '0.56rem' : '1rem';
+  const bottomPanelMarginLeft = isCompactBoard
+    ? (isTabletLayout ? '1.35rem' : '1.1rem')
+    : isOverviewBoard
+      ? '1.5rem'
+      : '1.25rem';
   const boardColumnStackGap = isCompactBoard ? '0.34rem' : isOverviewBoard ? '0.29rem' : '0.65rem';
   const boardSectionDividerMargin = isCompactBoard ? '0.4rem 0' : isOverviewBoard ? '0.28rem 0' : '1rem 0';
   const stackZoneMinHeight = isCompactBoard ? '110px' : isOverviewBoard ? '98px' : '150px';
@@ -561,7 +567,7 @@ const GameBoard: React.FC = () => {
     playerState: gameState[bottomRole],
     onAdjustStat: (stat: 'hp' | 'pp' | 'maxPp' | 'ep' | 'sep' | 'combo', delta: number) => handleStatChange(bottomRole, stat, delta),
     forceExpandedTracker: false,
-    containerStyle: { marginLeft: '1.25rem' },
+    containerStyle: { marginLeft: bottomPanelMarginLeft },
   };
   const savedDeckPickerDialogProps = savedDeckImportTargetRole && savedDeckPickerTargetLabel
     ? {
@@ -992,7 +998,7 @@ const GameBoard: React.FC = () => {
               </div>
 
               {isSpectator ? (
-                <div style={{ width: `${sidePanelWidth}px`, boxSizing: 'border-box', marginLeft: '1.25rem' }}>
+                <div style={{ width: `${sidePanelWidth}px`, boxSizing: 'border-box', marginLeft: bottomPanelMarginLeft }}>
                   <GameBoardReadOnlyStatusSection
                     label={bottomLabel}
                     playerState={gameState[bottomRole]}


### PR DESCRIPTION
## Summary

`origin/main` との差分として、GameBoard のヘッダー/コントロール周りの密度を微調整しました。  
主目的は、PC/Tablet で「盤面と自身側コントロールパネルが近すぎる」見た目を改善し、tablet ではターン表示をヘッダー内で1行維持することです。

## Changes

- PC overview の 3カラム間隔を微調整
  - `boardShellColumnGap`: `0.44rem -> 0.56rem`
- 自身側コントロールパネルの左余白を条件付きで調整
  - coarse+tablet: `1.35rem`
  - coarse+non-tablet: `1.1rem`
  - overview desktop: `1.5rem`
  - standard desktop: `1.25rem`
- `GameBoardHeader` に `isTabletLayout` を追加し、tablet+coarse のときだけヘッダーを折り返さず1行維持
  - ターン表示を右寄せで同一行に固定
- テスト追加/更新
  - `GameBoard.test.tsx`: PC overview / tablet coarse の余白・ヘッダーレイアウト契約を追加
  - `solo-desktop-overview-layout.spec.ts`: 盤面と自身側ステータス間の水平ギャップを検証
  - `solo-tablet-touch.spec.ts`: tablet coarse で同様の水平ギャップを検証

## Why

- 盤面とコントロールパネルが密接して見える問題を緩和するため
- tablet 環境でターン表記が2行化して縦方向を消費する問題を抑えるため
- 次段の縦幅最適化に進む前に、見た目の詰まりとレイアウト安定性を先に改善するため

## Test

- `npm run lint`
- `npx tsc --noEmit -p tsconfig.app.json`
- `npm run build`
- `npx vitest run`
- `npm run test:e2e`

## Risk / Notes

- tablet の極端に狭い幅では、room status 周辺が詰まる可能性がある
- E2E の距離閾値（14px/16px）はレイアウト回帰検知として機能する一方、将来の密度変更時には更新が必要
