### PR TITLE
Codex/uistatus

### DIFF
--- a/e2e/solo-tablet-touch.spec.ts
+++ b/e2e/solo-tablet-touch.spec.ts
@@ -46,7 +46,7 @@ test.describe('Solo Tablet Touch Controls', () => {
     expect(hostTrackerBox).not.toBeNull();
     if (hostMainDeckBox && hostTrackerBox) {
       const controlsGap = hostTrackerBox.x - (hostMainDeckBox.x + hostMainDeckBox.width);
-      expect(controlsGap).toBeGreaterThanOrEqual(14);
+      expect(controlsGap).toBeGreaterThanOrEqual(12);
     }
 
     await expect(zoneCards(page, 'mainDeck-host')).toHaveCount(2);

--- a/src/components/GameBoardHeader.tsx
+++ b/src/components/GameBoardHeader.tsx
@@ -68,6 +68,10 @@ const GameBoardHeader: React.FC<GameBoardHeaderProps> = ({
   const boardDensity = useGameBoardBoardDensity();
   const isCompactControls = inputProfile === 'coarse';
   const keepInlineCompactHeader = isCompactControls && isTabletLayout;
+  const compactHeaderColumnGap = keepInlineCompactHeader ? '0.42rem' : '0.5rem';
+  const compactHeaderRowGap = keepInlineCompactHeader ? '0.28rem' : '0.4rem';
+  const compactHeaderPadding = keepInlineCompactHeader ? '0.42rem 0.56rem' : '0.48rem 0.62rem';
+  const compactLeftBlockGap = keepInlineCompactHeader ? '0.42rem' : '0.5rem';
   const isOverviewControls = inputProfile === 'fine' && boardDensity === 'overview';
 
   return (
@@ -77,17 +81,17 @@ const GameBoardHeader: React.FC<GameBoardHeaderProps> = ({
         justifyContent: 'space-between',
         alignItems: keepInlineCompactHeader ? 'center' : isCompactControls ? 'stretch' : 'center',
         flexWrap: keepInlineCompactHeader ? 'nowrap' : isCompactControls ? 'wrap' : 'nowrap',
-        columnGap: isCompactControls ? '0.5rem' : isOverviewControls ? '0.8rem' : undefined,
-        rowGap: isCompactControls ? '0.4rem' : isOverviewControls ? '0.32rem' : undefined,
+        columnGap: isCompactControls ? compactHeaderColumnGap : isOverviewControls ? '0.8rem' : undefined,
+        rowGap: isCompactControls ? compactHeaderRowGap : isOverviewControls ? '0.32rem' : undefined,
         background: 'var(--bg-surface)',
-        padding: isCompactControls ? '0.48rem 0.62rem' : isOverviewControls ? '0.6rem 0.8rem' : '0.75rem 1rem',
+        padding: isCompactControls ? compactHeaderPadding : isOverviewControls ? '0.6rem 0.8rem' : '0.75rem 1rem',
         borderRadius: 'var(--radius-md)',
       }}
     >
       <div
         style={{
           display: 'flex',
-          gap: isCompactControls ? '0.5rem' : isOverviewControls ? '0.8rem' : '1rem',
+          gap: isCompactControls ? compactLeftBlockGap : isOverviewControls ? '0.8rem' : '1rem',
           alignItems: 'center',
           flexWrap: keepInlineCompactHeader ? 'nowrap' : isCompactControls ? 'wrap' : 'nowrap',
           minWidth: 0,

--- a/src/components/GameBoardPlayerControlsPanel.test.tsx
+++ b/src/components/GameBoardPlayerControlsPanel.test.tsx
@@ -215,6 +215,10 @@ describe('GameBoardPlayerControlsPanel', () => {
       />
     );
 
+    const panel = screen.getByText('Player 1 Controls').parentElement as HTMLElement;
+    expect(panel).toHaveStyle({ padding: '0.48rem', gap: '0.26rem' });
+    expect(screen.getByTestId('player-controls-primary-actions')).toHaveStyle({ gap: '0.24rem' });
+    expect(screen.getByRole('button', { name: 'Draw' })).toHaveStyle({ padding: '0.32rem' });
     expect(screen.getByTestId('player-tracker')).toHaveAttribute('data-compact', 'true');
   });
 

--- a/src/components/GameBoardPlayerControlsPanel.tsx
+++ b/src/components/GameBoardPlayerControlsPanel.tsx
@@ -72,12 +72,14 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
   const inputProfile = useGameBoardInputProfile();
   const boardDensity = useGameBoardBoardDensity();
   const isCompactControls = inputProfile === 'coarse';
+  const isNarrowCompactPanel = isCompactControls && panelWidth <= 160;
   const isOverviewControls = inputProfile === 'fine' && boardDensity === 'overview';
   const showSetupActions = gameStatus === 'preparing';
   const showPlayingActions = gameStatus === 'playing';
-  const compactPanelPadding = isCompactControls ? '0.55rem' : isOverviewControls ? '0.8rem' : '1rem';
-  const compactSectionGap = isCompactControls ? '0.3rem' : isOverviewControls ? '0.4rem' : '0.5rem';
-  const compactCellPadding = isCompactControls ? '0.36rem' : isOverviewControls ? '0.4rem' : '0.5rem';
+  const compactPanelPadding = isCompactControls ? (isNarrowCompactPanel ? '0.48rem' : '0.55rem') : isOverviewControls ? '0.8rem' : '1rem';
+  const compactPanelGap = isCompactControls ? (isNarrowCompactPanel ? '0.26rem' : '0.32rem') : isOverviewControls ? '0.4rem' : '0.5rem';
+  const compactSectionGap = isCompactControls ? (isNarrowCompactPanel ? '0.24rem' : '0.3rem') : isOverviewControls ? '0.4rem' : '0.5rem';
+  const compactCellPadding = isCompactControls ? (isNarrowCompactPanel ? '0.32rem' : '0.36rem') : isOverviewControls ? '0.4rem' : '0.5rem';
   const compactButtonBaseStyle: React.CSSProperties = isCompactControls || isOverviewControls
     ? {
         minHeight: isCompactControls ? '30px' : '24px',
@@ -105,14 +107,14 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
         boxSizing: 'border-box',
         display: 'flex',
         flexDirection: 'column',
-        gap: isCompactControls ? '0.32rem' : isOverviewControls ? '0.4rem' : '0.5rem',
+        gap: compactPanelGap,
         background: 'rgba(0,0,0,0.8)',
         padding: compactPanelPadding,
         borderRadius: 'var(--radius-md)',
         ...containerStyle,
       }}
     >
-      <div style={{ fontSize: isCompactControls ? '0.72rem' : isOverviewControls ? '0.64rem' : '0.8rem', fontWeight: 'bold', color: 'white', marginBottom: isCompactControls ? '0.16rem' : isOverviewControls ? '0.2rem' : '0.25rem' }}>
+      <div style={{ fontSize: isCompactControls ? (isNarrowCompactPanel ? '0.68rem' : '0.72rem') : isOverviewControls ? '0.64rem' : '0.8rem', fontWeight: 'bold', color: 'white', marginBottom: isCompactControls ? (isNarrowCompactPanel ? '0.12rem' : '0.16rem') : isOverviewControls ? '0.2rem' : '0.25rem' }}>
         {t('gameBoard.zones.controls', { label })}
       </div>
       <div
@@ -121,7 +123,7 @@ const GameBoardPlayerControlsPanel: React.FC<GameBoardPlayerControlsPanelProps> 
           display: isCompactControls ? 'grid' : 'flex',
           flexDirection: isCompactControls ? undefined : 'column',
           gridTemplateColumns: isCompactControls ? '1fr 1fr' : undefined,
-          gap: isCompactControls ? '0.28rem' : isOverviewControls ? '0.4rem' : '0.5rem',
+          gap: isCompactControls ? (isNarrowCompactPanel ? '0.24rem' : '0.28rem') : isOverviewControls ? '0.4rem' : '0.5rem',
         }}
       >
         {showSetupActions && (

--- a/src/components/GameBoardPlayerTracker.test.tsx
+++ b/src/components/GameBoardPlayerTracker.test.tsx
@@ -39,9 +39,9 @@ describe('GameBoardPlayerTracker', () => {
     );
 
     expect(screen.getByTestId('player-tracker-host')).toHaveStyle({
-      marginTop: '0.25rem',
-      padding: '0.36rem',
-      gap: '0.24rem',
+      marginTop: '0.18rem',
+      padding: '0.32rem',
+      gap: '0.2rem',
     });
     expect(screen.getByText('Player 2 Status')).toHaveStyle({
       fontSize: '0.66rem',
@@ -50,7 +50,7 @@ describe('GameBoardPlayerTracker', () => {
     });
     expect(screen.getByText('HP: 20').parentElement).toHaveStyle({
       flexWrap: 'nowrap',
-      gap: '0.16rem',
+      gap: '0.14rem',
     });
   });
 

--- a/src/components/GameBoardPlayerTracker.tsx
+++ b/src/components/GameBoardPlayerTracker.tsx
@@ -35,9 +35,9 @@ const GameBoardPlayerTracker: React.FC<GameBoardPlayerTrackerProps> = ({
   const trackerContainerStyle: React.CSSProperties = {
     display: 'flex',
     flexDirection: 'column',
-    gap: compact ? '0.24rem' : '0.4rem',
-    marginTop: compact ? '0.25rem' : '0.8rem',
-    padding: compact ? '0.36rem' : '0.6rem',
+    gap: compact ? '0.2rem' : '0.4rem',
+    marginTop: compact ? '0.18rem' : '0.8rem',
+    padding: compact ? '0.32rem' : '0.6rem',
     background: 'rgba(255,255,255,0.04)',
     borderRadius: 'var(--radius-md)',
     border: '1px solid var(--border-light)',
@@ -55,7 +55,7 @@ const GameBoardPlayerTracker: React.FC<GameBoardPlayerTrackerProps> = ({
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    gap: compact ? '0.16rem' : '0.35rem',
+    gap: compact ? '0.14rem' : '0.35rem',
     flexWrap: 'nowrap',
   };
   const trackerStatLabelBaseStyle: React.CSSProperties = {
@@ -94,8 +94,8 @@ const GameBoardPlayerTracker: React.FC<GameBoardPlayerTrackerProps> = ({
   const ppSectionStyle: React.CSSProperties = {
     display: 'flex',
     flexDirection: 'column',
-    gap: compact ? '0.22rem' : '0.4rem',
-    padding: compact ? '0.36rem' : '0.6rem',
+    gap: compact ? '0.18rem' : '0.4rem',
+    padding: compact ? '0.32rem' : '0.6rem',
     background: 'rgba(59, 130, 246, 0.15)',
     borderRadius: 'var(--radius-md)',
     border: '1px solid rgba(59, 130, 246, 0.3)',

--- a/src/components/Zone.test.tsx
+++ b/src/components/Zone.test.tsx
@@ -310,7 +310,7 @@ describe('Zone', () => {
   });
 
   it('uses compact zone label typography for coarse input', () => {
-    renderWithInputProfile(
+    const { container } = renderWithInputProfile(
       'coarse',
       <Zone
         id="field-host"
@@ -319,8 +319,9 @@ describe('Zone', () => {
       />
     );
 
+    expect(container.firstChild).toHaveStyle({ padding: '0.32rem' });
     const zoneLabel = screen.getByText('Cemetery');
-    expect(zoneLabel).toHaveStyle({ fontSize: '0.5rem' });
+    expect(zoneLabel).toHaveStyle({ fontSize: '0.48rem' });
     expect(zoneLabel).toHaveStyle({
       whiteSpace: 'normal',
       textOverflow: 'clip',

--- a/src/components/Zone.tsx
+++ b/src/components/Zone.tsx
@@ -116,7 +116,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
         border: `2px dashed ${isOver ? 'var(--vivid-green-cyan)' : 'var(--border-light)'}`,
         backgroundColor: isOver ? 'rgba(0, 208, 132, 0.1)' : 'rgba(26, 29, 36, 0.5)',
         borderRadius: 'var(--radius-md)',
-        padding: isCompactInput ? '0.36rem' : '0.5rem',
+        padding: isCompactInput ? '0.32rem' : '0.5rem',
         position: 'relative',
         display: 'flex',
         flexDirection: isStack ? 'column' : 'row',
@@ -136,15 +136,15 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
       <div
         style={{
           position: 'absolute',
-          top: isCompactInput ? -8 : -12,
-          left: isCompactInput ? 8 : 10,
+          top: isCompactInput ? -7 : -12,
+          left: isCompactInput ? 7 : 10,
           zIndex: 20,
           display: isCompactInput ? 'grid' : 'inline-flex',
           gridTemplateColumns: isCompactInput ? 'minmax(0, 1fr) auto' : undefined,
           alignItems: 'center',
-          gap: isCompactInput ? '3px' : isOverviewDesktop ? '4px' : '6px',
+          gap: isCompactInput ? '2px' : isOverviewDesktop ? '4px' : '6px',
           maxWidth: isOverviewDesktop ? 'calc(100% - 12px)' : 'calc(100% - 20px)',
-          padding: isCompactInput ? '1px 5px' : isOverviewDesktop ? '1px 6px' : '2px 8px',
+          padding: isCompactInput ? '1px 4px' : isOverviewDesktop ? '1px 6px' : '2px 8px',
           background: 'rgba(17, 24, 39, 0.92)',
           border: '1px solid rgba(255,255,255,0.16)',
           borderRadius: '999px',
@@ -173,7 +173,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
           style={{
             maxWidth: isCompactInput ? '100%' : undefined,
             minWidth: 0,
-            fontSize: isCompactInput ? '0.5rem' : isOverviewDesktop ? '0.64rem' : '0.72rem',
+            fontSize: isCompactInput ? '0.48rem' : isOverviewDesktop ? '0.64rem' : '0.72rem',
             fontWeight: 'bold',
             color: 'white',
             whiteSpace: isCompactInput ? 'normal' : 'nowrap',
@@ -181,7 +181,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
             textOverflow: isCompactInput || isOverviewDesktop ? 'clip' : 'ellipsis',
             overflowWrap: isCompactInput ? 'normal' : undefined,
             wordBreak: isCompactInput ? 'keep-all' : undefined,
-            lineHeight: isCompactInput ? 1.1 : undefined,
+            lineHeight: isCompactInput ? 1.05 : undefined,
           }}
         >
           {displayLabel}
@@ -189,12 +189,12 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
         <span
           style={{
             flex: '0 0 auto',
-            minWidth: isCompactInput ? '18px' : isOverviewDesktop ? '18px' : '22px',
-            padding: isCompactInput ? '0 4px' : isOverviewDesktop ? '0 4px' : '0 6px',
+            minWidth: isCompactInput ? '16px' : isOverviewDesktop ? '18px' : '22px',
+            padding: isCompactInput ? '0 3px' : isOverviewDesktop ? '0 4px' : '0 6px',
             borderRadius: '999px',
             background: 'rgba(59, 130, 246, 0.24)',
             color: '#bfdbfe',
-            fontSize: isCompactInput ? '0.48rem' : isOverviewDesktop ? '0.62rem' : '0.7rem',
+            fontSize: isCompactInput ? '0.44rem' : isOverviewDesktop ? '0.62rem' : '0.7rem',
             fontWeight: 'bold',
             textAlign: 'center'
           }}

--- a/src/pages/GameBoard.test.tsx
+++ b/src/pages/GameBoard.test.tsx
@@ -3094,6 +3094,10 @@ describe('GameBoard', () => {
       expect(playmat).toHaveStyle({ padding: '0.36rem', gap: '0.22rem' });
       expect(topSection).toHaveStyle({ padding: '0.24rem 0.28rem' });
       expect(topGrid).toHaveStyle({ columnGap: '0.5rem' });
+      expect(screen.getByTestId('zone-cemetery-guest')).toHaveStyle({ minHeight: '108px' });
+      expect(screen.getByTestId('zone-field-guest')).toHaveStyle({ minHeight: '120px' });
+      expect(screen.getByTestId('zone-hand-guest')).toHaveStyle({ minHeight: '112px' });
+      expect(screen.getByTestId('zone-hand-host')).toHaveStyle({ minHeight: '120px' });
       const hostControlsPanel = screen.getByTestId('player-tracker-host').parentElement as HTMLElement;
       expect(hostControlsPanel).toHaveStyle({ marginLeft: '1.35rem' });
       const turnPanelWrapper = screen.getByTestId('gameboard-turn-panel').parentElement as HTMLElement;

--- a/src/pages/GameBoard.test.tsx
+++ b/src/pages/GameBoard.test.tsx
@@ -3084,13 +3084,15 @@ describe('GameBoard', () => {
     try {
       const { container } = render(<GameBoard />);
       const shell = container.firstElementChild as HTMLElement;
+      const header = shell.firstElementChild as HTMLElement;
       const playmat = screen.getByTestId('board-playmat');
       const topSection = screen.getByTestId('board-section-top');
       const topGrid = topSection.firstElementChild as HTMLElement;
 
-      expect(shell).toHaveStyle({ padding: '0.52rem', gap: '0.48rem' });
-      expect(playmat).toHaveStyle({ padding: '0.42rem', gap: '0.24rem' });
-      expect(topSection).toHaveStyle({ padding: '0.28rem 0.32rem' });
+      expect(shell).toHaveStyle({ padding: '0.46rem', gap: '0.4rem' });
+      expect(header).toHaveStyle({ padding: '0.42rem 0.56rem', rowGap: '0.28rem' });
+      expect(playmat).toHaveStyle({ padding: '0.36rem', gap: '0.22rem' });
+      expect(topSection).toHaveStyle({ padding: '0.24rem 0.28rem' });
       expect(topGrid).toHaveStyle({ columnGap: '0.5rem' });
       const hostControlsPanel = screen.getByTestId('player-tracker-host').parentElement as HTMLElement;
       expect(hostControlsPanel).toHaveStyle({ marginLeft: '1.35rem' });

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -109,10 +109,10 @@ const GameBoard: React.FC = () => {
       : '1.25rem';
   const boardColumnStackGap = isCompactBoard ? '0.34rem' : isOverviewBoard ? '0.29rem' : '0.65rem';
   const boardSectionDividerMargin = isTabletCompactBoard ? '0.3rem 0' : isCompactBoard ? '0.4rem 0' : isOverviewBoard ? '0.28rem 0' : '1rem 0';
-  const stackZoneMinHeight = isCompactBoard ? '110px' : isOverviewBoard ? '98px' : '150px';
-  const fieldZoneMinHeight = isCompactBoard ? '124px' : isOverviewBoard ? '109px' : '160px';
-  const handZoneMinHeight = isCompactBoard ? '116px' : isOverviewBoard ? '102px' : '150px';
-  const bottomHandZoneMinHeight = isCompactBoard ? '124px' : isOverviewBoard ? '109px' : '160px';
+  const stackZoneMinHeight = isTabletCompactBoard ? '108px' : isCompactBoard ? '110px' : isOverviewBoard ? '98px' : '150px';
+  const fieldZoneMinHeight = isTabletCompactBoard ? '120px' : isCompactBoard ? '124px' : isOverviewBoard ? '109px' : '160px';
+  const handZoneMinHeight = isTabletCompactBoard ? '112px' : isCompactBoard ? '116px' : isOverviewBoard ? '102px' : '150px';
+  const bottomHandZoneMinHeight = isTabletCompactBoard ? '120px' : isCompactBoard ? '124px' : isOverviewBoard ? '109px' : '160px';
   const {
     sidePanelWidth,
     topPanelWidth,

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -93,13 +93,14 @@ const GameBoard: React.FC = () => {
   );
   const isCompactBoard = inputProfile === 'coarse';
   const isTabletLayout = layoutProfile === 'tablet';
+  const isTabletCompactBoard = isCompactBoard && isTabletLayout;
   const isOverviewBoard = boardDensity === 'overview';
-  const boardShellPadding = isCompactBoard ? '0.52rem' : isOverviewBoard ? '0.48rem' : '1rem';
-  const boardShellGap = isCompactBoard ? '0.48rem' : isOverviewBoard ? '0.44rem' : '1rem';
-  const playmatPadding = isCompactBoard ? '0.42rem' : isOverviewBoard ? '0.44rem' : '1rem';
-  const playmatGap = isCompactBoard ? '0.24rem' : isOverviewBoard ? '0.24rem' : '0.5rem';
-  const boardSectionPadding = isCompactBoard ? '0.28rem 0.32rem' : isOverviewBoard ? '0.26rem 0.29rem' : '0.55rem 0.6rem';
-  const boardSectionGap = isCompactBoard ? '0.22rem' : isOverviewBoard ? '0.21rem' : '0.5rem';
+  const boardShellPadding = isTabletCompactBoard ? '0.46rem' : isCompactBoard ? '0.52rem' : isOverviewBoard ? '0.48rem' : '1rem';
+  const boardShellGap = isTabletCompactBoard ? '0.4rem' : isCompactBoard ? '0.48rem' : isOverviewBoard ? '0.44rem' : '1rem';
+  const playmatPadding = isTabletCompactBoard ? '0.36rem' : isCompactBoard ? '0.42rem' : isOverviewBoard ? '0.44rem' : '1rem';
+  const playmatGap = isTabletCompactBoard ? '0.22rem' : isCompactBoard ? '0.24rem' : isOverviewBoard ? '0.24rem' : '0.5rem';
+  const boardSectionPadding = isTabletCompactBoard ? '0.24rem 0.28rem' : isCompactBoard ? '0.28rem 0.32rem' : isOverviewBoard ? '0.26rem 0.29rem' : '0.55rem 0.6rem';
+  const boardSectionGap = isTabletCompactBoard ? '0.18rem' : isCompactBoard ? '0.22rem' : isOverviewBoard ? '0.21rem' : '0.5rem';
   const boardShellColumnGap = isCompactBoard ? '0.5rem' : isOverviewBoard ? '0.56rem' : '1rem';
   const bottomPanelMarginLeft = isCompactBoard
     ? (isTabletLayout ? '1.35rem' : '1.1rem')
@@ -107,7 +108,7 @@ const GameBoard: React.FC = () => {
       ? '1.5rem'
       : '1.25rem';
   const boardColumnStackGap = isCompactBoard ? '0.34rem' : isOverviewBoard ? '0.29rem' : '0.65rem';
-  const boardSectionDividerMargin = isCompactBoard ? '0.4rem 0' : isOverviewBoard ? '0.28rem 0' : '1rem 0';
+  const boardSectionDividerMargin = isTabletCompactBoard ? '0.3rem 0' : isCompactBoard ? '0.4rem 0' : isOverviewBoard ? '0.28rem 0' : '1rem 0';
   const stackZoneMinHeight = isCompactBoard ? '110px' : isOverviewBoard ? '98px' : '150px';
   const fieldZoneMinHeight = isCompactBoard ? '124px' : isOverviewBoard ? '109px' : '160px';
   const handZoneMinHeight = isCompactBoard ? '116px' : isOverviewBoard ? '102px' : '150px';


### PR DESCRIPTION
## 概要
tablet/compact 表示時の縦方向の密度を上げ、スクロール量を減らすための UI 調整を行いました。  
あわせて、狭幅コントロールパネル時の余白バランスを最適化し、表示崩れを起こしにくい値へ調整しています。

## 変更内容
- `GameBoard` の tablet+compact 専用 spacing/min-height を追加
  - shell / playmat / section の padding・gap を微調整
  - zone の min-height を段階的に圧縮
- `GameBoardHeader` の compact(tablet) 時の gap/padding を調整
  - ヘッダー要素の改行圧力を軽減
- `Zone` の compact ラベルピルを縮小
  - ラベル/カウントのフォント・padding・配置を調整
- `GameBoardPlayerControlsPanel` の狭幅(`panelWidth <= 160`)時に専用 spacing を適用
- `GameBoardPlayerTracker` の compact spacing を微調整
- tablet E2E のレイアウト許容値を現実的な閾値に更新（`>=14` → `>=12`）

## テスト（契約オーナー）
- `src/pages/GameBoard.test.tsx`
- `src/components/Zone.test.tsx`
- `src/components/GameBoardPlayerControlsPanel.test.tsx`
- `src/components/GameBoardPlayerTracker.test.tsx`
- `e2e/solo-tablet-touch.spec.ts`

## 検証結果
- lint: pass
- typecheck (`tsc --noEmit -p tsconfig.app.json`): pass
- unit/integration (`vitest`): pass (1120 tests)
- build: pass
- e2e (`playwright`): pass (16 tests)

## リスクと注意点
- ゲーム進行ロジックには変更なし（UIレイアウト中心）。
- compact 表示の余白を詰めたため、将来の文言増加時は再度折り返し確認が必要。
- tablet touch E2E の gap 閾値を下げているため、細かな見た目劣化の検知感度はやや低下。
