### PR TITLE
タブレット版 UI 調整

### DIFF
--- a/e2e/helpers/gameBoard.ts
+++ b/e2e/helpers/gameBoard.ts
@@ -108,9 +108,24 @@ export const spawnDefaultToken = async (
 
 export const openMainDeckActions = async (page: Page, role: 'host' | 'guest') => {
   const mainDeckSection = zone(page, `mainDeck-${role}`).locator('..');
+  const actionsButton = mainDeckSection.getByRole('button', { name: 'Actions' });
 
   await zone(page, `mainDeck-${role}`).scrollIntoViewIfNeeded();
-  await mainDeckSection.getByRole('button', { name: 'Actions' }).click();
+  if (await actionsButton.count()) {
+    await actionsButton.click();
+    return mainDeckSection;
+  }
 
-  return mainDeckSection;
+  const mainDeckCard = zoneCards(page, `mainDeck-${role}`).first();
+  if (await mainDeckCard.count()) {
+    await expect(mainDeckCard).toBeVisible();
+    await mainDeckCard.click();
+  } else {
+    await zone(page, `mainDeck-${role}`).click();
+  }
+
+  const touchSheet = page.getByTestId('gameboard-touch-action-sheet');
+  await expect(touchSheet).toBeVisible();
+
+  return touchSheet;
 };

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -38,6 +38,11 @@ export interface CardInspectAnchor {
   height: number;
 }
 
+export interface CardTapAnchor {
+  x: number;
+  y: number;
+}
+
 interface Props {
   card: CardInstance;
   baseStats?: BaseCardStats;
@@ -55,6 +60,7 @@ interface Props {
   onReturnEvolve?: (id: string) => void;
   onCemetery?: (id: string) => void;
   onPlayToField?: (id: string) => void;
+  onCardTapAction?: (card: CardInstance, anchor: CardTapAnchor) => boolean | void;
   isHidden?: boolean; // if true, STRICTLY render card back only
   isLocked?: boolean; // if true, prevent dragging and operating (opponent's hand/deck/ex)
   quickActionsDisabled?: boolean;
@@ -62,7 +68,7 @@ interface Props {
   debugIndex?: number;
 }
 
-const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideCurrentStats, highlightTone, onInspect, onAttack, onTap, onModifyCounter, onModifyGenericCounter, onSendToBottom, onBanish, onReturnEvolve, onCemetery, onPlayToField, isHidden, isLocked, quickActionsDisabled, disableCombatAndCounterControls, debugIndex }) => {
+const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideCurrentStats, highlightTone, onInspect, onAttack, onTap, onModifyCounter, onModifyGenericCounter, onSendToBottom, onBanish, onReturnEvolve, onCemetery, onPlayToField, onCardTapAction, isHidden, isLocked, quickActionsDisabled, disableCombatAndCounterControls, debugIndex }) => {
   const { t } = useTranslation();
   const inspectPointerStartRef = React.useRef<{ x: number; y: number } | null>(null);
   const cardElementRef = React.useRef<HTMLElement | null>(null);
@@ -347,11 +353,17 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
 
         if (!pointerStart) return;
         if ((event.target as HTMLElement).closest('button')) return;
-        if (isHidden || card.isFlipped) return;
 
         const deltaX = Math.abs(event.clientX - pointerStart.x);
         const deltaY = Math.abs(event.clientY - pointerStart.y);
         if (deltaX > 6 || deltaY > 6) return;
+
+        const tapActionHandled = onCardTapAction?.(card, {
+          x: event.clientX,
+          y: event.clientY,
+        });
+        if (tapActionHandled) return;
+        if (isHidden || card.isFlipped) return;
 
         if (canToggleQuickActions) {
           setIsQuickActionsOpen(prev => {

--- a/src/components/GameBoardLeaderZone.tsx
+++ b/src/components/GameBoardLeaderZone.tsx
@@ -11,6 +11,7 @@ type GameBoardLeaderZoneProps = {
   leaderCards: CardInstance[];
   side: 'left' | 'right';
   sideZoneWidth: number;
+  zoneMinHeight?: string;
   extraOffset?: number;
   cardDetailLookup: CardDetailLookup;
   getHighlightTone?: (card: CardInstance) => 'attack-source' | 'attack-target' | undefined;
@@ -29,6 +30,7 @@ const GameBoardLeaderZone: React.FC<GameBoardLeaderZoneProps> = ({
   leaderCards,
   side,
   sideZoneWidth,
+  zoneMinHeight = '150px',
   extraOffset = 0,
   cardDetailLookup,
   getHighlightTone,
@@ -62,7 +64,7 @@ const GameBoardLeaderZone: React.FC<GameBoardLeaderZoneProps> = ({
       viewerRole={viewerRole}
       containerStyle={{
         minWidth: `${sideZoneWidth}px`,
-        minHeight: '150px',
+        minHeight: zoneMinHeight,
         border: isAttackTargetLeader ? '2px solid rgba(250, 204, 21, 0.65)' : undefined,
         boxShadow: isAttackTargetLeader ? '0 0 18px rgba(250, 204, 21, 0.18)' : undefined,
       }}

--- a/src/components/GameBoardLeaderZoneSection.tsx
+++ b/src/components/GameBoardLeaderZoneSection.tsx
@@ -10,6 +10,7 @@ type GameBoardLeaderZoneSectionProps = {
   zoneLabel: string;
   side: 'left' | 'right';
   extraOffset?: number;
+  zoneMinHeight?: string;
   leaderCards: CardInstance[];
   sideZoneWidth: number;
   cardDetailLookup: CardDetailLookup;
@@ -28,6 +29,7 @@ const GameBoardLeaderZoneSection: React.FC<GameBoardLeaderZoneSectionProps> = ({
   zoneLabel,
   side,
   extraOffset = 0,
+  zoneMinHeight = '150px',
   leaderCards,
   sideZoneWidth,
   cardDetailLookup,
@@ -52,6 +54,7 @@ const GameBoardLeaderZoneSection: React.FC<GameBoardLeaderZoneSectionProps> = ({
       leaderCards={leaderCards}
       side={side}
       sideZoneWidth={sideZoneWidth}
+      zoneMinHeight={zoneMinHeight}
       extraOffset={extraOffset}
       cardDetailLookup={cardDetailLookup}
       getHighlightTone={getHighlightTone}

--- a/src/components/GameBoardMainDeckSection.tsx
+++ b/src/components/GameBoardMainDeckSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import GameBoardTouchActionSheet from './GameBoardTouchActionSheet';
 import Zone from './Zone';
 import GameBoardZoneActionsSection from './GameBoardZoneActionsSection';
 
@@ -16,6 +17,7 @@ type GameBoardMainDeckSectionProps = {
   actions?: ZoneAction[];
   direction?: 'down' | 'up';
   onActiveMenuChange: (menuId: string | null) => void;
+  useTapToOpenActions?: boolean;
 };
 
 const GameBoardMainDeckSection: React.FC<GameBoardMainDeckSectionProps> = ({
@@ -26,20 +28,63 @@ const GameBoardMainDeckSection: React.FC<GameBoardMainDeckSectionProps> = ({
   actions,
   direction,
   onActiveMenuChange,
-}) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-    <Zone {...zoneProps} />
-    {actions && actions.length > 0 ? (
-      <GameBoardZoneActionsSection
-        menuId={menuId}
-        activeMenuId={activeMenuId}
-        actionsLabel={actionsLabel}
-        actions={actions}
-        direction={direction}
-        onActiveMenuChange={onActiveMenuChange}
+  useTapToOpenActions = false,
+}) => {
+  const [isTouchSheetOpen, setIsTouchSheetOpen] = React.useState(false);
+  const [touchSheetAnchor, setTouchSheetAnchor] = React.useState<{ x: number; y: number } | null>(null);
+  const hasActions = Boolean(actions && actions.length > 0);
+  const shouldUseTapToOpenActions = useTapToOpenActions && hasActions;
+
+  React.useEffect(() => {
+    if (!shouldUseTapToOpenActions) {
+      setIsTouchSheetOpen(false);
+      setTouchSheetAnchor(null);
+    }
+  }, [shouldUseTapToOpenActions]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+      <Zone
+        {...zoneProps}
+        onCardTapAction={(_, anchor) => {
+          if (!shouldUseTapToOpenActions) return false;
+          onActiveMenuChange(null);
+          setTouchSheetAnchor(anchor);
+          setIsTouchSheetOpen(true);
+          return true;
+        }}
+        onZoneTapAction={(anchor) => {
+          if (!shouldUseTapToOpenActions) return;
+          onActiveMenuChange(null);
+          setTouchSheetAnchor(anchor);
+          setIsTouchSheetOpen(true);
+        }}
       />
-    ) : null}
-  </div>
-);
+      {!shouldUseTapToOpenActions && hasActions ? (
+        <GameBoardZoneActionsSection
+          menuId={menuId}
+          activeMenuId={activeMenuId}
+          actionsLabel={actionsLabel}
+          actions={actions as ZoneAction[]}
+          direction={direction}
+          onActiveMenuChange={onActiveMenuChange}
+        />
+      ) : null}
+      <GameBoardTouchActionSheet
+        isOpen={isTouchSheetOpen}
+        actions={(actions ?? []).map((action) => ({
+          label: action.label,
+          onClick: action.onClick,
+          tone: action.tone,
+        }))}
+        anchor={touchSheetAnchor}
+        onClose={() => {
+          setIsTouchSheetOpen(false);
+          setTouchSheetAnchor(null);
+        }}
+      />
+    </div>
+  );
+};
 
 export default GameBoardMainDeckSection;

--- a/src/components/GameBoardSearchableStackSection.tsx
+++ b/src/components/GameBoardSearchableStackSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import GameBoardSearchableZoneStack from './GameBoardSearchableZoneStack';
+import GameBoardTouchActionSheet from './GameBoardTouchActionSheet';
+import GameBoardZoneSearchButton from './GameBoardZoneSearchButton';
 import Zone from './Zone';
 
 type GameBoardSearchableStackSectionProps = {
@@ -8,6 +9,7 @@ type GameBoardSearchableStackSectionProps = {
   onSearch: () => void;
   searchTitle?: string;
   isSearchInteractive?: boolean;
+  useTapToOpenActions?: boolean;
 };
 
 const GameBoardSearchableStackSection: React.FC<GameBoardSearchableStackSectionProps> = ({
@@ -16,14 +18,54 @@ const GameBoardSearchableStackSection: React.FC<GameBoardSearchableStackSectionP
   onSearch,
   searchTitle,
   isSearchInteractive,
-}) => (
-  <GameBoardSearchableZoneStack
-    zone={<Zone {...zoneProps} />}
-    searchLabel={searchLabel}
-    onSearch={onSearch}
-    searchTitle={searchTitle}
-    isSearchInteractive={isSearchInteractive}
-  />
-);
+  useTapToOpenActions = false,
+}) => {
+  const [isTouchSheetOpen, setIsTouchSheetOpen] = React.useState(false);
+  const [touchSheetAnchor, setTouchSheetAnchor] = React.useState<{ x: number; y: number } | null>(null);
+  const shouldUseTapToOpenActions = useTapToOpenActions;
+
+  React.useEffect(() => {
+    if (!shouldUseTapToOpenActions) {
+      setIsTouchSheetOpen(false);
+      setTouchSheetAnchor(null);
+    }
+  }, [shouldUseTapToOpenActions]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+      <Zone
+        {...zoneProps}
+        onCardTapAction={(_, anchor) => {
+          if (!shouldUseTapToOpenActions) return false;
+          setTouchSheetAnchor(anchor);
+          setIsTouchSheetOpen(true);
+          return true;
+        }}
+        onZoneTapAction={(anchor) => {
+          if (!shouldUseTapToOpenActions) return;
+          setTouchSheetAnchor(anchor);
+          setIsTouchSheetOpen(true);
+        }}
+      />
+      {!shouldUseTapToOpenActions ? (
+        <GameBoardZoneSearchButton
+          label={searchLabel}
+          onClick={onSearch}
+          title={searchTitle}
+          isInteractive={isSearchInteractive}
+        />
+      ) : null}
+      <GameBoardTouchActionSheet
+        isOpen={isTouchSheetOpen}
+        actions={[{ label: searchLabel, onClick: onSearch, tone: 'accent' }]}
+        anchor={touchSheetAnchor}
+        onClose={() => {
+          setIsTouchSheetOpen(false);
+          setTouchSheetAnchor(null);
+        }}
+      />
+    </div>
+  );
+};
 
 export default GameBoardSearchableStackSection;

--- a/src/components/GameBoardTouchActionSheet.tsx
+++ b/src/components/GameBoardTouchActionSheet.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+
+type TouchAction = {
+  label: string;
+  onClick: () => void;
+  tone?: 'default' | 'accent';
+};
+
+type GameBoardTouchActionSheetProps = {
+  isOpen: boolean;
+  actions: TouchAction[];
+  anchor?: { x: number; y: number } | null;
+  onClose: () => void;
+};
+
+const GameBoardTouchActionSheet: React.FC<GameBoardTouchActionSheetProps> = ({
+  isOpen,
+  actions,
+  anchor = null,
+  onClose,
+}) => {
+  const panelRef = React.useRef<HTMLDivElement | null>(null);
+  const isMultiActionLayout = actions.length >= 2;
+  const useTwoColumnLayout = actions.length >= 3;
+  const [placement, setPlacement] = React.useState<{ top: number; left: number; width: number } | null>(null);
+
+  React.useEffect(() => {
+    if (!isOpen || typeof window === 'undefined') {
+      setPlacement(null);
+      return undefined;
+    }
+    const visualViewport = window.visualViewport;
+
+    const computePlacement = () => {
+      const viewportLeft = visualViewport?.offsetLeft ?? 0;
+      const viewportTop = visualViewport?.offsetTop ?? 0;
+      const viewportWidth = visualViewport?.width ?? window.innerWidth;
+      const viewportHeight = visualViewport?.height ?? window.innerHeight;
+      const viewportRight = viewportLeft + viewportWidth;
+      const viewportBottom = viewportTop + viewportHeight;
+      const margin = 8;
+      const longestLabelLength = Math.max(1, ...actions.map((action) => action.label.length));
+      const singleColumnWidth = Math.max(148, Math.min(268, Math.round(longestLabelLength * 11 + 74)));
+      const twoColumnCellWidth = Math.max(112, Math.min(178, Math.round(longestLabelLength * 9.5 + 40)));
+      const contentWidth = useTwoColumnLayout
+        ? twoColumnCellWidth * 2 + 4 + 12
+        : singleColumnWidth;
+      const width = Math.min(Math.round(viewportWidth * 0.9), contentWidth);
+
+      const rowCount = useTwoColumnLayout ? Math.ceil(actions.length / 2) : actions.length;
+      const estimatedHeight = 12 + (rowCount * 34) + ((rowCount - 1) * 4);
+
+      const targetX = anchor?.x ?? (viewportLeft + viewportWidth / 2);
+      const targetY = anchor?.y ?? (viewportBottom - estimatedHeight - margin);
+
+      const desiredLeft = targetX - (width / 2);
+      const minLeft = viewportLeft + margin;
+      const maxLeft = Math.max(minLeft, viewportRight - width - margin);
+      const left = Math.min(Math.max(desiredLeft, minLeft), maxLeft);
+
+      const belowSpace = viewportBottom - (targetY + 8) - margin;
+      const aboveSpace = targetY - viewportTop - margin - 8;
+      const placeBelow = !anchor || belowSpace >= estimatedHeight || belowSpace >= aboveSpace;
+      const desiredTop = placeBelow ? targetY + 8 : targetY - 8 - estimatedHeight;
+      const minTop = viewportTop + margin;
+      const maxTop = Math.max(minTop, viewportBottom - estimatedHeight - margin);
+      const top = Math.min(Math.max(desiredTop, minTop), maxTop);
+
+      setPlacement({
+        top: Math.round(top),
+        left: Math.round(left),
+        width,
+      });
+    };
+
+    computePlacement();
+    const rafId = window.requestAnimationFrame(computePlacement);
+    window.addEventListener('resize', computePlacement);
+    window.addEventListener('scroll', computePlacement, true);
+    visualViewport?.addEventListener('resize', computePlacement);
+    visualViewport?.addEventListener('scroll', computePlacement);
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      window.removeEventListener('resize', computePlacement);
+      window.removeEventListener('scroll', computePlacement, true);
+      visualViewport?.removeEventListener('resize', computePlacement);
+      visualViewport?.removeEventListener('scroll', computePlacement);
+    };
+  }, [actions, anchor, isOpen, useTwoColumnLayout]);
+
+  React.useEffect(() => {
+    if (!isOpen) return undefined;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!panelRef.current) return;
+      if (panelRef.current.contains(event.target as Node)) return;
+      onClose();
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('pointerdown', handlePointerDown, true);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('pointerdown', handlePointerDown, true);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen || typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      data-testid="gameboard-touch-action-sheet"
+      style={{
+        position: 'fixed',
+        top: placement ? `${placement.top}px` : '8px',
+        left: placement ? `${placement.left}px` : '8px',
+        display: 'flex',
+        zIndex: 1300,
+        pointerEvents: placement ? 'auto' : 'none',
+        visibility: placement ? 'visible' : 'hidden',
+      }}
+    >
+      <div
+        ref={panelRef}
+        style={{
+          pointerEvents: 'auto',
+          width: placement ? `${placement.width}px` : 'min(420px, 90vw)',
+          display: 'grid',
+          gridTemplateColumns: useTwoColumnLayout ? '1fr 1fr' : '1fr',
+          gap: '0.28rem',
+          background: 'rgba(2, 6, 23, 0.97)',
+          border: '1px solid rgba(148, 163, 184, 0.35)',
+          borderRadius: '8px',
+          padding: '0.34rem',
+          boxShadow: '0 12px 20px rgba(0,0,0,0.4)',
+        }}
+      >
+        {actions.map((action, index) => {
+          const shouldSpanLastOddButton = useTwoColumnLayout && actions.length % 2 === 1 && index === actions.length - 1;
+          return (
+          <button
+            key={action.label}
+            type="button"
+            onClick={() => {
+              action.onClick();
+              onClose();
+            }}
+            style={{
+              minHeight: '30px',
+              width: '100%',
+              gridColumn: shouldSpanLastOddButton ? '1 / -1' : undefined,
+              borderRadius: '6px',
+              fontSize: isMultiActionLayout ? '0.72rem' : '0.74rem',
+              fontWeight: 700,
+              border: action.tone === 'accent' ? '1px solid #2563eb' : '1px solid rgba(255,255,255,0.25)',
+              background: action.tone === 'accent' ? '#3b82f6' : 'var(--bg-surface-elevated)',
+              color: 'white',
+              padding: '0.2rem 0.32rem',
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              lineHeight: 1.1,
+              whiteSpace: 'nowrap',
+              textAlign: 'center',
+            }}
+          >
+            {action.label}
+          </button>
+          );
+        })}
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default GameBoardTouchActionSheet;

--- a/src/components/GameBoardZoneUi.test.tsx
+++ b/src/components/GameBoardZoneUi.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import GameBoardEndTurnButton from './GameBoardEndTurnButton';
 import GameBoardEndTurnSection from './GameBoardEndTurnSection';
@@ -8,6 +8,8 @@ import GameBoardPlayerTracker from './GameBoardPlayerTracker';
 import GameBoardPlayerTrackerSection from './GameBoardPlayerTrackerSection';
 import GameBoardReadOnlyStatusPanel from './GameBoardReadOnlyStatusPanel';
 import GameBoardReadOnlyStatusSection from './GameBoardReadOnlyStatusSection';
+import GameBoardMainDeckSection from './GameBoardMainDeckSection';
+import GameBoardSearchableStackSection from './GameBoardSearchableStackSection';
 import GameBoardSearchableZoneStack from './GameBoardSearchableZoneStack';
 import GameBoardTurnPanel from './GameBoardTurnPanel';
 import GameBoardZoneActionsMenu from './GameBoardZoneActionsMenu';
@@ -24,15 +26,29 @@ vi.mock('./Zone', () => ({
     label,
     cards,
     containerStyle,
+    onCardTapAction,
+    onZoneTapAction,
   }: {
     id: string;
     label: string;
     cards: Array<{ id: string }>;
     containerStyle?: React.CSSProperties;
+    onCardTapAction?: (card: { id: string }, anchor: { x: number; y: number }) => boolean | void;
+    onZoneTapAction?: (anchor: { x: number; y: number }) => void;
   }) => (
-    <section data-testid={`zone-${id}`} data-border={containerStyle?.border ?? ''}>
+    <section data-testid={`zone-${id}`} data-border={containerStyle?.border ?? ''} data-min-height={containerStyle?.minHeight ?? ''}>
       <h3>{label}</h3>
       <span>{cards.length} cards</span>
+      {onCardTapAction ? (
+        <button type="button" onClick={() => onCardTapAction({ id: `${id}-card` }, { x: 320, y: 240 })}>
+          Tap zone card
+        </button>
+      ) : null}
+      {onZoneTapAction ? (
+        <button type="button" onClick={() => onZoneTapAction({ x: 180, y: 220 })}>
+          Tap zone
+        </button>
+      ) : null}
     </section>
   ),
 }));
@@ -122,6 +138,27 @@ describe('GameBoard extracted UI components - zones and controls', () => {
     expect(screen.getByTestId('zone-leader-host')).toHaveAttribute('data-border', '');
   });
 
+  it('passes custom leader zone min height', () => {
+    render(
+      <GameBoardLeaderZoneSection
+        playerRole="host"
+        label="Player 1"
+        zoneLabel="Player 1 Leader"
+        side="left"
+        zoneMinHeight="124px"
+        leaderCards={[]}
+        sideZoneWidth={120}
+        cardDetailLookup={{}}
+        viewerRole="host"
+        attackSourceController={null}
+        searchLabel="Search"
+        onSearch={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('zone-leader-host')).toHaveAttribute('data-min-height', '124px');
+  });
+
   it('renders zone search button and wires click action', () => {
     const onClick = vi.fn();
 
@@ -164,6 +201,52 @@ describe('GameBoard extracted UI components - zones and controls', () => {
 
     fireEvent.click(button);
 
+    expect(onSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses tap-to-open zone search actions when enabled and cards exist', () => {
+    const onSearch = vi.fn();
+
+    render(
+      <GameBoardSearchableStackSection
+        zoneProps={{
+          id: 'banish-host',
+          label: 'Banish',
+          cards: [{ id: 'card-1' } as never],
+        }}
+        searchLabel="Search"
+        onSearch={onSearch}
+        useTapToOpenActions={true}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Search' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tap zone card' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides inline zone search button for empty zones and opens via zone tap when tap-to-open is enabled', () => {
+    const onSearch = vi.fn();
+
+    render(
+      <GameBoardSearchableStackSection
+        zoneProps={{
+          id: 'banish-host',
+          label: 'Banish',
+          cards: [],
+        }}
+        searchLabel="Search"
+        onSearch={onSearch}
+        useTapToOpenActions={true}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Search' })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Tap zone' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
     expect(onSearch).toHaveBeenCalledTimes(1);
   });
 
@@ -338,6 +421,121 @@ describe('GameBoard extracted UI components - zones and controls', () => {
 
     expect(searchAction).toHaveBeenCalledTimes(1);
     expect(onActiveMenuChange).toHaveBeenCalledWith(null);
+  });
+
+  it('uses tap-to-open main deck actions when enabled and cards exist', () => {
+    const onSearch = vi.fn();
+    const onActiveMenuChange = vi.fn();
+
+    render(
+      <GameBoardMainDeckSection
+        zoneProps={{
+          id: 'mainDeck-host',
+          label: 'Main Deck',
+          cards: [{ id: 'card-1' } as never],
+        }}
+        menuId="mainDeck-host"
+        activeMenuId={null}
+        actionsLabel="Actions"
+        actions={[{ label: 'Search', onClick: onSearch }]}
+        onActiveMenuChange={onActiveMenuChange}
+        useTapToOpenActions={true}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Actions' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tap zone card' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    expect(onActiveMenuChange).toHaveBeenCalledWith(null);
+    expect(onSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a compact two-column touch sheet layout for multiple main deck actions', () => {
+    render(
+      <GameBoardMainDeckSection
+        zoneProps={{
+          id: 'mainDeck-host',
+          label: 'Main Deck',
+          cards: [{ id: 'card-1' } as never],
+        }}
+        menuId="mainDeck-host"
+        activeMenuId={null}
+        actionsLabel="Actions"
+        actions={[
+          { label: 'Search', onClick: vi.fn() },
+          { label: 'Shuffle', onClick: vi.fn() },
+          { label: 'Look Top', onClick: vi.fn(), tone: 'accent' },
+        ]}
+        onActiveMenuChange={vi.fn()}
+        useTapToOpenActions={true}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tap zone card' }));
+
+    const touchSheet = screen.getByTestId('gameboard-touch-action-sheet').firstElementChild as HTMLElement;
+    expect(touchSheet).toHaveStyle({ gridTemplateColumns: '1fr 1fr', gap: '0.28rem' });
+    expect(screen.getByRole('button', { name: 'Search' })).toHaveStyle({ minHeight: '30px' });
+    const touchSheetWidth = parseInt(touchSheet.style.width, 10);
+    expect(touchSheetWidth).toBeGreaterThanOrEqual(220);
+    expect(touchSheetWidth).toBeLessThan(380);
+  });
+
+  it('positions touch sheet near tapped zone coordinates', async () => {
+    render(
+      <GameBoardMainDeckSection
+        zoneProps={{
+          id: 'mainDeck-host',
+          label: 'Main Deck',
+          cards: [{ id: 'card-1' } as never],
+        }}
+        menuId="mainDeck-host"
+        activeMenuId={null}
+        actionsLabel="Actions"
+        actions={[{ label: 'Search', onClick: vi.fn() }]}
+        onActiveMenuChange={vi.fn()}
+        useTapToOpenActions={true}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tap zone card' }));
+
+    await waitFor(() => {
+      const sheet = screen.getByTestId('gameboard-touch-action-sheet') as HTMLElement;
+      expect(sheet).toHaveStyle({ top: '248px' });
+      const left = parseInt(sheet.style.left, 10);
+      expect(left).toBeGreaterThanOrEqual(220);
+      expect(left).toBeLessThanOrEqual(280);
+    });
+  });
+
+  it('hides inline main deck actions for empty main deck and opens via zone tap when tap-to-open is enabled', () => {
+    const onSearch = vi.fn();
+    const onActiveMenuChange = vi.fn();
+
+    render(
+      <GameBoardMainDeckSection
+        zoneProps={{
+          id: 'mainDeck-host',
+          label: 'Main Deck',
+          cards: [],
+        }}
+        menuId="mainDeck-host"
+        activeMenuId={null}
+        actionsLabel="Actions"
+        actions={[{ label: 'Search', onClick: onSearch }]}
+        onActiveMenuChange={onActiveMenuChange}
+        useTapToOpenActions={true}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Actions' })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Tap zone' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    expect(onActiveMenuChange).toHaveBeenCalledWith(null);
+    expect(onSearch).toHaveBeenCalledTimes(1);
   });
 
   it('renders end turn section and delegates end turn for the active player', () => {

--- a/src/components/Zone.tsx
+++ b/src/components/Zone.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDroppable } from '@dnd-kit/core';
-import Card, { type CardInspectAnchor, type CardInstance } from './Card';
+import Card, { type CardInspectAnchor, type CardInstance, type CardTapAnchor } from './Card';
 import type { PlayerRole } from '../types/game';
 import type { CardStatLookup } from '../utils/cardStats';
 import type { CardDetailLookup } from '../utils/cardDetails';
@@ -29,6 +29,8 @@ interface Props {
   onReturnEvolve?: (id: string) => void;
   onCemetery?: (id: string) => void;
   onPlayToField?: (id: string) => void;
+  onCardTapAction?: (card: CardInstance, anchor: CardTapAnchor) => boolean | void;
+  onZoneTapAction?: (anchor: CardTapAnchor) => void;
   hideCards?: boolean; // e.g. opponent hand
   layout?: 'horizontal' | 'stack';
   isProtected?: boolean; // if true, opponent cannot operate cards in this zone
@@ -40,7 +42,8 @@ interface Props {
   isDebug?: boolean;
 }
 
-const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLookup, onInspectCard, onAttack, onTap, onModifyCounter, onModifyGenericCounter, onSendToBottom, onBanish, onReturnEvolve, onCemetery, onPlayToField, hideCards, layout = 'horizontal', isProtected, lockCards, disableQuickActionsForCard, getHighlightTone, viewerRole, containerStyle, isDebug }) => {
+const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLookup, onInspectCard, onAttack, onTap, onModifyCounter, onModifyGenericCounter, onSendToBottom, onBanish, onReturnEvolve, onCemetery, onPlayToField, onCardTapAction, onZoneTapAction, hideCards, layout = 'horizontal', isProtected, lockCards, disableQuickActionsForCard, getHighlightTone, viewerRole, containerStyle, isDebug }) => {
+  const zoneTapPointerStartRef = React.useRef<{ x: number; y: number } | null>(null);
   const inputProfile = useGameBoardInputProfile();
   const boardDensity = useGameBoardBoardDensity();
   const isCompactInput = inputProfile === 'coarse';
@@ -100,16 +103,42 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
           isLocked={lockCards || isReadOnlySpectator || (isProtected && viewerRole !== 'all' && linkedCard.owner !== viewerRole)}
           quickActionsDisabled={disableQuickActionsForCard?.(linkedCard)}
           disableCombatAndCounterControls={true}
+          onCardTapAction={onCardTapAction}
           debugIndex={isDebug ? index : undefined}
         />
       </div>
     ));
-  }, [attachmentLeftOffset, attachmentTopOffset, cardDetailLookup, cardStatLookup, disableQuickActionsForCard, getHighlightTone, hideCards, isDebug, isProtected, isReadOnlySpectator, linkedCardLeftOffset, linkedCardTopOffset, lockCards, onBanish, onCemetery, onInspectCard, onReturnEvolve, onSendToBottom, viewerRole]);
+  }, [attachmentLeftOffset, attachmentTopOffset, cardDetailLookup, cardStatLookup, disableQuickActionsForCard, getHighlightTone, hideCards, isDebug, isProtected, isReadOnlySpectator, linkedCardLeftOffset, linkedCardTopOffset, lockCards, onBanish, onCardTapAction, onCemetery, onInspectCard, onReturnEvolve, onSendToBottom, viewerRole]);
 
   return (
     <div
       ref={setNodeRef}
       data-testid={`zone-${id}`}
+      onPointerDownCapture={(event) => {
+        if (event.button !== 0) return;
+        if (!onZoneTapAction) return;
+        if ((event.target as HTMLElement).closest('button')) return;
+        zoneTapPointerStartRef.current = { x: event.clientX, y: event.clientY };
+      }}
+      onPointerUpCapture={(event) => {
+        const pointerStart = zoneTapPointerStartRef.current;
+        zoneTapPointerStartRef.current = null;
+        if (!onZoneTapAction || !pointerStart) return;
+        if ((event.target as HTMLElement).closest('button')) return;
+        if ((event.target as HTMLElement).closest('[data-card-id]')) return;
+
+        const deltaX = Math.abs(event.clientX - pointerStart.x);
+        const deltaY = Math.abs(event.clientY - pointerStart.y);
+        if (deltaX > 6 || deltaY > 6) return;
+
+        onZoneTapAction({
+          x: event.clientX,
+          y: event.clientY,
+        });
+      }}
+      onPointerCancel={() => {
+        zoneTapPointerStartRef.current = null;
+      }}
       style={{
         flex: 1,
         minHeight: '160px',
@@ -248,6 +277,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                       isLocked={lockCards || isReadOnlySpectator || (isProtected && viewerRole !== 'all' && card.owner !== viewerRole)}
                       quickActionsDisabled={disableQuickActionsForCard?.(card)}
                       disableCombatAndCounterControls={hasCardOnTop(card.id)}
+                      onCardTapAction={onCardTapAction}
                       debugIndex={isDebug ? index : undefined}
                     />
                     {renderLinkedCards(linkedCards, attachments.length)}
@@ -276,6 +306,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                           isLocked={lockCards || isReadOnlySpectator || (isProtected && viewerRole !== 'all' && attachedCard.owner !== viewerRole)}
                           quickActionsDisabled={disableQuickActionsForCard?.(attachedCard)}
                           disableCombatAndCounterControls={hasCardOnTop(attachedCard.id)}
+                          onCardTapAction={onCardTapAction}
                           debugIndex={isDebug ? i : undefined}
                         />
                       </div>
@@ -320,6 +351,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                 isLocked={lockCards || isReadOnlySpectator || (isProtected && viewerRole !== 'all' && card.owner !== viewerRole)}
                 quickActionsDisabled={disableQuickActionsForCard?.(card)}
                 disableCombatAndCounterControls={hasCardOnTop(card.id)}
+                onCardTapAction={onCardTapAction}
                 debugIndex={isDebug ? topLevelCards.indexOf(card) : undefined}
               />
               {renderLinkedCards(linkedCards, attachments.length)}
@@ -348,6 +380,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                     isLocked={lockCards || isReadOnlySpectator || (isProtected && viewerRole !== 'all' && attachedCard.owner !== viewerRole)}
                     quickActionsDisabled={disableQuickActionsForCard?.(attachedCard)}
                     disableCombatAndCounterControls={hasCardOnTop(attachedCard.id)}
+                    onCardTapAction={onCardTapAction}
                     debugIndex={isDebug ? i : undefined}
                   />
                 </div>

--- a/src/pages/GameBoard.test.tsx
+++ b/src/pages/GameBoard.test.tsx
@@ -3098,6 +3098,9 @@ describe('GameBoard', () => {
       expect(screen.getByTestId('zone-field-guest')).toHaveStyle({ minHeight: '120px' });
       expect(screen.getByTestId('zone-hand-guest')).toHaveStyle({ minHeight: '112px' });
       expect(screen.getByTestId('zone-hand-host')).toHaveStyle({ minHeight: '120px' });
+      expect(screen.getByTestId('zone-leader-guest')).toHaveStyle({ minHeight: '124px' });
+      expect(screen.getByTestId('zone-leader-host')).toHaveStyle({ minHeight: '124px' });
+      expect(screen.getByTestId('bottom-board-row-secondary-wrap')).toHaveStyle({ marginTop: '0.2rem' });
       const hostControlsPanel = screen.getByTestId('player-tracker-host').parentElement as HTMLElement;
       expect(hostControlsPanel).toHaveStyle({ marginLeft: '1.35rem' });
       const turnPanelWrapper = screen.getByTestId('gameboard-turn-panel').parentElement as HTMLElement;

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -108,11 +108,13 @@ const GameBoard: React.FC = () => {
       ? '1.5rem'
       : '1.25rem';
   const boardColumnStackGap = isCompactBoard ? '0.34rem' : isOverviewBoard ? '0.29rem' : '0.65rem';
+  const bottomBoardRowSecondaryMarginTop = isTabletCompactBoard ? '0.2rem' : '0';
   const boardSectionDividerMargin = isTabletCompactBoard ? '0.3rem 0' : isCompactBoard ? '0.4rem 0' : isOverviewBoard ? '0.28rem 0' : '1rem 0';
   const stackZoneMinHeight = isTabletCompactBoard ? '108px' : isCompactBoard ? '110px' : isOverviewBoard ? '98px' : '150px';
   const fieldZoneMinHeight = isTabletCompactBoard ? '120px' : isCompactBoard ? '124px' : isOverviewBoard ? '109px' : '160px';
   const handZoneMinHeight = isTabletCompactBoard ? '112px' : isCompactBoard ? '116px' : isOverviewBoard ? '102px' : '150px';
   const bottomHandZoneMinHeight = isTabletCompactBoard ? '120px' : isCompactBoard ? '124px' : isOverviewBoard ? '109px' : '160px';
+  const leaderZoneMinHeight = isTabletCompactBoard ? '124px' : '150px';
   const {
     sidePanelWidth,
     topPanelWidth,
@@ -738,6 +740,7 @@ const GameBoard: React.FC = () => {
                       onSearch={() => openSearchZone(`cemetery-${topRole}`, t('gameBoard.zones.cemetery', { label: topLabel }))}
                       searchTitle={interactionBlockedTitle}
                       isSearchInteractive={canView}
+                      useTapToOpenActions={isTabletCompactBoard}
                     />
                     <Zone
                       id={`ex-${topRole}`}
@@ -763,6 +766,7 @@ const GameBoard: React.FC = () => {
                       onSearch={() => openSearchZone(`banish-${topRole}`, t('gameBoard.zones.banish', { label: topLabel }))}
                       searchTitle={interactionBlockedTitle}
                       isSearchInteractive={canView}
+                      useTapToOpenActions={isTabletCompactBoard}
                     />
                   </GameBoardBoardRow>
 
@@ -776,6 +780,7 @@ const GameBoard: React.FC = () => {
                         zoneLabel={t('gameBoard.board.leaderLabel', { label: topLabel })}
                         side="right"
                         extraOffset={20}
+                        zoneMinHeight={leaderZoneMinHeight}
                         leaderCards={getCards(`leader-${topRole}`)}
                         sideZoneWidth={sideZoneWidth}
                         cardDetailLookup={cardDetailLookup}
@@ -797,6 +802,7 @@ const GameBoard: React.FC = () => {
                         actions={topMainDeckZoneActions.actions}
                         direction="up"
                         onActiveMenuChange={setActiveZoneActions}
+                        useTapToOpenActions={isTabletCompactBoard}
                       />
                       <Zone
                         id={`field-${topRole}`}
@@ -826,6 +832,7 @@ const GameBoard: React.FC = () => {
                         onSearch={() => openSearchZone(`evolveDeck-${topRole}`, t('gameBoard.zones.evolveDeck', { label: topLabel }))}
                         searchTitle={interactionBlockedTitle}
                         isSearchInteractive={canView}
+                        useTapToOpenActions={isTabletCompactBoard}
                       />
                   </GameBoardBoardRow>
                 </div>
@@ -848,6 +855,7 @@ const GameBoard: React.FC = () => {
                       zoneProps={{ id: `cemetery-${topRole}`, label: t('gameBoard.zones.cemetery', { label: topLabel }), cards: getCards(`cemetery-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                       searchLabel={t('gameBoard.zones.search')}
                       onSearch={() => openSearchZone(`cemetery-${topRole}`, t('gameBoard.zones.cemetery', { label: topLabel }))}
+                      useTapToOpenActions={isTabletCompactBoard}
                     />
                     <Zone
                       id={`ex-${topRole}`}
@@ -864,6 +872,7 @@ const GameBoard: React.FC = () => {
                       zoneProps={{ id: `banish-${topRole}`, label: t('gameBoard.zones.banish', { label: topLabel }), cards: getCards(`banish-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                       searchLabel={t('gameBoard.zones.search')}
                       onSearch={() => openSearchZone(`banish-${topRole}`, t('gameBoard.zones.banish', { label: topLabel }))}
+                      useTapToOpenActions={isTabletCompactBoard}
                     />
                   </GameBoardBoardRow>
 
@@ -877,6 +886,7 @@ const GameBoard: React.FC = () => {
                         zoneLabel={t('gameBoard.board.leaderLabel', { label: topLabel })}
                         side="right"
                         extraOffset={20}
+                        zoneMinHeight={leaderZoneMinHeight}
                         leaderCards={getCards(`leader-${topRole}`)}
                         sideZoneWidth={sideZoneWidth}
                         cardDetailLookup={cardDetailLookup}
@@ -898,6 +908,7 @@ const GameBoard: React.FC = () => {
                         actions={isSpectator ? topReadOnlyMainDeckZoneActions.actions : undefined}
                         direction="up"
                         onActiveMenuChange={setActiveZoneActions}
+                        useTapToOpenActions={isTabletCompactBoard}
                       />
                       <Zone
                         id={`field-${topRole}`}
@@ -919,6 +930,7 @@ const GameBoard: React.FC = () => {
                         zoneProps={{ id: `evolveDeck-${topRole}`, label: t('gameBoard.zones.evolveDeck', { label: topLabel }), cards: getCards(`evolveDeck-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, isProtected: true, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                         searchLabel={t('common.buttons.search')}
                         onSearch={() => openSearchZone(`evolveDeck-${topRole}`, t('gameBoard.zones.evolveDeck', { label: topLabel }))}
+                        useTapToOpenActions={isTabletCompactBoard}
                       />
                   </GameBoardBoardRow>
                 </div>
@@ -947,6 +959,7 @@ const GameBoard: React.FC = () => {
                         label={bottomLabel}
                         zoneLabel={t('gameBoard.board.leaderLabel', { label: bottomLabel })}
                         side="left"
+                        zoneMinHeight={leaderZoneMinHeight}
                         leaderCards={getCards(`leader-${bottomRole}`)}
                         sideZoneWidth={sideZoneWidth}
                         cardDetailLookup={cardDetailLookup}
@@ -966,6 +979,7 @@ const GameBoard: React.FC = () => {
                     onSearch={() => openSearchZone(`evolveDeck-${bottomRole}`, t('gameBoard.zones.evolveDeck', { label: bottomLabel }))}
                     searchTitle={interactionBlockedTitle}
                     isSearchInteractive={canView}
+                    useTapToOpenActions={isTabletCompactBoard}
                   />
                   <Zone id={`field-${bottomRole}`} label={t('gameBoard.zones.field', { label: bottomLabel })} cards={getCards(`field-${bottomRole}`)} cardStatLookup={cardStatLookup} cardDetailLookup={cardDetailLookup} getHighlightTone={getAttackHighlightTone} onInspectCard={handleInspectCard} onAttack={gameState.turnPlayer === bottomRole ? handleStartAttack : undefined} onTap={toggleTap} onModifyCounter={handleModifyCounter} onModifyGenericCounter={handleModifyGenericCounter} onSendToBottom={handleSendToBottom} onBanish={handleBanish} onReturnEvolve={handleReturnEvolve} onCemetery={handleSendToCemetery} onPlayToField={handlePlayToField} disableQuickActionsForCard={shouldDisableQuickActionsForAttackTarget} viewerRole={viewerRole} containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: fieldZoneMinHeight, width: `${centerZoneWidth}px`, flex: 'none' }} isDebug={isDebug} />
                   <GameBoardMainDeckSection
@@ -975,16 +989,22 @@ const GameBoard: React.FC = () => {
                     actionsLabel={bottomMainDeckZoneActions.actionsLabel}
                     actions={bottomMainDeckZoneActions.actions}
                     onActiveMenuChange={setActiveZoneActions}
+                    useTapToOpenActions={isTabletCompactBoard}
                   />
                   </GameBoardBoardRow>
 
-	                <GameBoardBoardRow columns={boardColumns} width={boardContentWidth}>
+	                <div
+                    data-testid="bottom-board-row-secondary-wrap"
+                    style={{ marginTop: bottomBoardRowSecondaryMarginTop }}
+                  >
+                  <GameBoardBoardRow columns={boardColumns} width={boardContentWidth}>
                   <GameBoardSearchableStackSection
                     zoneProps={{ id: `banish-${bottomRole}`, label: t('gameBoard.zones.banish', { label: bottomLabel }), cards: getCards(`banish-${bottomRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, onModifyCounter: handleModifyCounter, onSendToBottom: handleSendToBottom, onCemetery: handleSendToCemetery, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                     searchLabel={t('common.buttons.search')}
                     onSearch={() => openSearchZone(`banish-${bottomRole}`, t('gameBoard.zones.banish', { label: bottomLabel }))}
                     searchTitle={interactionBlockedTitle}
                     isSearchInteractive={canView}
+                    useTapToOpenActions={isTabletCompactBoard}
                   />
 		                  <Zone id={`ex-${bottomRole}`} label={t('gameBoard.zones.exArea', { label: bottomLabel })} cards={getCards(`ex-${bottomRole}`)} cardStatLookup={cardStatLookup} cardDetailLookup={cardDetailLookup} onInspectCard={handleInspectCard} onModifyCounter={handleModifyCounter} onModifyGenericCounter={handleModifyGenericCounter} onSendToBottom={handleSendToBottom} onBanish={handleBanish} onReturnEvolve={handleReturnEvolve} onCemetery={handleSendToCemetery} onPlayToField={handlePlayToField} viewerRole={viewerRole} containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: stackZoneMinHeight, flex: 'none', width: `${centerZoneWidth}px` }} isDebug={isDebug} />
                   <GameBoardSearchableStackSection
@@ -993,8 +1013,10 @@ const GameBoard: React.FC = () => {
                     onSearch={() => openSearchZone(`cemetery-${bottomRole}`, t('gameBoard.zones.cemetery', { label: bottomLabel }))}
                     searchTitle={interactionBlockedTitle}
                     isSearchInteractive={canView}
+                    useTapToOpenActions={isTabletCompactBoard}
                   />
 	                </GameBoardBoardRow>
+                  </div>
 
 	                <GameBoardBottomHandSection {...bottomHandSectionProps} />
               </div>


### PR DESCRIPTION
## 概要
tablet/coarse 表示で縦幅と操作導線を最適化するため、ゾーン下部の常設ボタンをタップ式アクションシートへ置き換えました。  
あわせて、下側ボード行間とリーダーゾーン高さを微調整し、視認性とスクロール量を改善しています。

## 変更内容

### 1) tablet/coarse のゾーン操作をタップ式に変更
- 対象: `mainDeck / evolveDeck / banish / cemetery`
- 変更:
  - 下部の `検索/アクション` 常設ボタンを非表示
  - カードタップ（空ゾーン時はゾーンタップ）でアクションシートを表示
  - ドラッグ操作は維持（タップ判定閾値あり）
- 実装:
  - `GameBoardTouchActionSheet` 新規追加
  - `Zone` / `Card` にタップ座標伝搬を追加
  - `GameBoardMainDeckSection`, `GameBoardSearchableStackSection` をタップ導線対応
  - `GameBoard.tsx` で `isTabletCompactBoard` 時のみ有効化

### 2) アクションシートのUI改善
- タップ位置近傍に表示（固定下部表示を廃止）
- 画面内クランプ（上下左右）
- 複数アクション時は2カラム
- 文言長に応じた可変幅に調整（不要な改行を抑制）

### 3) 細かなレイアウト調整
- 下側プレイヤーの1列目/2列目間隔を拡張
  - `bottomBoardRowSecondaryMarginTop` を tablet/coarse のみ適用
- タブレット版リーダーゾーン高さを調整
  - `150px -> 124px`（tablet/coarse のみ）

### 4) テスト/ヘルパー更新
- `GameBoardZoneUi.test.tsx`
  - タップ導線、空ゾーン導線、シート配置、幅・2カラムを検証
- `GameBoard.test.tsx`
  - tablet/coarse の spacing 契約に
    - `bottom-board-row-secondary-wrap` の余白
    - leader zone minHeight (`124px`) を追加
- `e2e/helpers/gameBoard.ts`
  - `openMainDeckActions` を旧UI/新UI両対応化

## 検証
- `npm run lint`
- `npx tsc --noEmit -p tsconfig.app.json`
- `npm run build`
- `npx vitest run`（112 files / 1127 tests）
- `npm run test:e2e`（16 passed）

## デグレリスク（既知）
- tablet/coarse のタップシート経路では、`isSearchInteractive/searchTitle` の見た目反映が現状未対応（機能ガードは維持）。
- 幅計算は文言長ヒューリスティックのため、将来の長文翻訳追加時に再調整の余地あり。
