### PR TITLE
Codex/uistatus

### DIFF
--- a/src/components/GameBoardBottomHandSection.tsx
+++ b/src/components/GameBoardBottomHandSection.tsx
@@ -52,8 +52,8 @@ const GameBoardBottomHandSection: React.FC<GameBoardBottomHandSectionProps> = ({
   const minHeight = zoneProps.containerStyle?.minHeight ?? '160px';
   const actionMenuWrapperStyle: React.CSSProperties = {
     position: 'absolute',
-    right: isCompactInput ? '8px' : '10px',
-    bottom: isCompactInput ? '8px' : '-32px',
+    right: '8px',
+    bottom: '8px',
     width: isCompactInput ? '164px' : '180px',
     zIndex: 30,
   };
@@ -69,7 +69,7 @@ const GameBoardBottomHandSection: React.FC<GameBoardBottomHandSectionProps> = ({
             activeMenuId={activeMenuId}
             actionsLabel={randomDiscardZoneActions.actionsLabel}
             actions={randomDiscardZoneActions.actions}
-            direction={isCompactInput ? 'up' : 'down'}
+            direction="up"
             onActiveMenuChange={onActiveMenuChange}
           />
         </div>
@@ -82,7 +82,7 @@ const GameBoardBottomHandSection: React.FC<GameBoardBottomHandSectionProps> = ({
             activeMenuId={activeMenuId}
             actionsLabel={revealHandZoneActions.actionsLabel}
             actions={revealHandZoneActions.actions}
-            direction={isCompactInput ? 'up' : 'down'}
+            direction="up"
             onActiveMenuChange={onActiveMenuChange}
           />
         </div>

--- a/src/components/GameBoardTopHandSection.tsx
+++ b/src/components/GameBoardTopHandSection.tsx
@@ -52,8 +52,8 @@ const GameBoardTopHandSection: React.FC<GameBoardTopHandSectionProps> = ({
   const isCompactInput = inputProfile === 'coarse';
   const actionMenuWrapperStyle: React.CSSProperties = {
     position: 'absolute',
-    right: isCompactInput ? '8px' : '10px',
-    bottom: isCompactInput ? '8px' : '-32px',
+    right: '8px',
+    bottom: '8px',
     width: isCompactInput ? '164px' : '180px',
     zIndex: 30,
   };
@@ -75,7 +75,7 @@ const GameBoardTopHandSection: React.FC<GameBoardTopHandSectionProps> = ({
             activeMenuId={activeMenuId}
             actionsLabel={actionMenu.actionsLabel}
             actions={actionMenu.actions}
-            direction={isCompactInput ? 'up' : 'down'}
+            direction="down"
             onActiveMenuChange={onActiveMenuChange}
           />
         </div>

--- a/src/components/GameBoardZoneActionsMenu.tsx
+++ b/src/components/GameBoardZoneActionsMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useGameBoardBoardDensity, useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type ZoneAction = {
   label: string;
@@ -22,64 +23,76 @@ const GameBoardZoneActionsMenu: React.FC<GameBoardZoneActionsMenuProps> = ({
   direction = 'down',
   onToggle,
   onActionClick,
-}) => (
-  <div style={{ position: 'relative', zIndex: isOpen ? 60 : 5 }}>
-    <button
-      onClick={onToggle}
-      style={{
-        width: '100%',
-        fontSize: '0.75rem',
-        padding: '4px',
-        background: 'var(--bg-surface-elevated)',
-        border: '1px solid var(--border-light)',
-        color: 'white',
-        borderRadius: '4px',
-        cursor: 'pointer',
-        position: 'relative',
-        zIndex: 61,
-      }}
-    >
-      {actionsLabel}
-    </button>
-    {isOpen && (
-      <div
+}) => {
+  const inputProfile = useGameBoardInputProfile();
+  const boardDensity = useGameBoardBoardDensity();
+  const isFineInput = inputProfile === 'fine';
+  const isOverviewDesktop = isFineInput && boardDensity === 'overview';
+  const triggerFontSize = isOverviewDesktop ? '0.66rem' : isFineInput ? '0.7rem' : '0.75rem';
+  const triggerPadding = isOverviewDesktop ? '2px 4px' : isFineInput ? '3px 5px' : '4px';
+  const triggerMinHeight = isOverviewDesktop ? '20px' : isFineInput ? '22px' : undefined;
+
+  return (
+    <div style={{ position: 'relative', zIndex: isOpen ? 60 : 5 }}>
+      <button
+        onClick={onToggle}
         style={{
-          position: 'absolute',
-          top: direction === 'down' ? 'calc(100% + 4px)' : 'auto',
-          bottom: direction === 'up' ? 'calc(100% + 4px)' : 'auto',
-          left: 0,
-          right: 0,
-          zIndex: 62,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '4px',
-          padding: '6px',
-          background: 'rgba(15, 23, 42, 0.96)',
+          width: '100%',
+          fontSize: triggerFontSize,
+          padding: triggerPadding,
+          minHeight: triggerMinHeight,
+          lineHeight: 1.1,
+          background: 'var(--bg-surface-elevated)',
           border: '1px solid var(--border-light)',
-          borderRadius: '6px',
-          boxShadow: '0 10px 20px rgba(0,0,0,0.35)',
+          color: 'white',
+          borderRadius: '4px',
+          cursor: 'pointer',
+          position: 'relative',
+          zIndex: 61,
         }}
       >
-        {actions.map((action) => (
-          <button
-            key={action.label}
-            onClick={() => onActionClick(action.onClick)}
-            style={{
-              fontSize: '0.75rem',
-              padding: '5px 6px',
-              background: action.tone === 'accent' ? '#3b82f6' : 'var(--bg-surface-elevated)',
-              border: `1px solid ${action.tone === 'accent' ? '#2563eb' : 'var(--border-light)'}`,
-              color: 'white',
-              borderRadius: '4px',
-              cursor: 'pointer',
-            }}
-          >
-            {action.label}
-          </button>
-        ))}
-      </div>
-    )}
-  </div>
-);
+        {actionsLabel}
+      </button>
+      {isOpen && (
+        <div
+          style={{
+            position: 'absolute',
+            top: direction === 'down' ? 'calc(100% + 4px)' : 'auto',
+            bottom: direction === 'up' ? 'calc(100% + 4px)' : 'auto',
+            left: 0,
+            right: 0,
+            zIndex: 62,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '4px',
+            padding: '6px',
+            background: 'rgba(15, 23, 42, 0.96)',
+            border: '1px solid var(--border-light)',
+            borderRadius: '6px',
+            boxShadow: '0 10px 20px rgba(0,0,0,0.35)',
+          }}
+        >
+          {actions.map((action) => (
+            <button
+              key={action.label}
+              onClick={() => onActionClick(action.onClick)}
+              style={{
+                fontSize: '0.75rem',
+                padding: '5px 6px',
+                background: action.tone === 'accent' ? '#3b82f6' : 'var(--bg-surface-elevated)',
+                border: `1px solid ${action.tone === 'accent' ? '#2563eb' : 'var(--border-light)'}`,
+                color: 'white',
+                borderRadius: '4px',
+                cursor: 'pointer',
+              }}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
 
 export default GameBoardZoneActionsMenu;

--- a/src/components/GameBoardZoneSearchButton.tsx
+++ b/src/components/GameBoardZoneSearchButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useGameBoardBoardDensity, useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
 type GameBoardZoneSearchButtonProps = {
   label: string;
@@ -12,23 +13,35 @@ const GameBoardZoneSearchButton: React.FC<GameBoardZoneSearchButtonProps> = ({
   onClick,
   title,
   isInteractive = true,
-}) => (
-  <button
-    type="button"
-    onClick={onClick}
-    title={title}
-    style={{
-      fontSize: '0.75rem',
-      padding: '4px',
-      background: 'var(--bg-surface-elevated)',
-      border: '1px solid var(--border-light)',
-      color: 'white',
-      borderRadius: '4px',
-      cursor: isInteractive ? 'pointer' : 'not-allowed',
-    }}
-  >
-    {label}
-  </button>
-);
+}) => {
+  const inputProfile = useGameBoardInputProfile();
+  const boardDensity = useGameBoardBoardDensity();
+  const isFineInput = inputProfile === 'fine';
+  const isOverviewDesktop = isFineInput && boardDensity === 'overview';
+  const buttonFontSize = isOverviewDesktop ? '0.66rem' : isFineInput ? '0.7rem' : '0.75rem';
+  const buttonPadding = isOverviewDesktop ? '2px 4px' : isFineInput ? '3px 5px' : '4px';
+  const buttonMinHeight = isOverviewDesktop ? '20px' : isFineInput ? '22px' : undefined;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      style={{
+        fontSize: buttonFontSize,
+        padding: buttonPadding,
+        minHeight: buttonMinHeight,
+        lineHeight: 1.1,
+        background: 'var(--bg-surface-elevated)',
+        border: '1px solid var(--border-light)',
+        color: 'white',
+        borderRadius: '4px',
+        cursor: isInteractive ? 'pointer' : 'not-allowed',
+      }}
+    >
+      {label}
+    </button>
+  );
+};
 
 export default GameBoardZoneSearchButton;

--- a/src/components/GameBoardZoneUi.test.tsx
+++ b/src/components/GameBoardZoneUi.test.tsx
@@ -175,6 +175,7 @@ describe('GameBoard extracted UI components - zones and controls', () => {
 
     expect(button).toHaveAttribute('title', 'Unavailable');
     expect(button).toHaveStyle({ cursor: 'not-allowed' });
+    expect(button).toHaveStyle({ fontSize: '0.7rem', minHeight: '22px', padding: '3px 5px' });
 
     fireEvent.click(button);
 
@@ -379,6 +380,16 @@ describe('GameBoard extracted UI components - zones and controls', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
     fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    expect(screen.getByRole('button', { name: 'Actions' })).toHaveStyle({
+      fontSize: '0.7rem',
+      minHeight: '22px',
+      padding: '3px 5px',
+    });
+    expect(screen.getByRole('button', { name: 'Search' })).toHaveStyle({
+      fontSize: '0.75rem',
+      padding: '5px 6px',
+    });
 
     expect(onToggle).toHaveBeenCalledTimes(1);
     expect(onActionClick).toHaveBeenCalledTimes(1);

--- a/src/components/Zone.test.tsx
+++ b/src/components/Zone.test.tsx
@@ -348,6 +348,39 @@ describe('Zone', () => {
     });
   });
 
+  it('uses compact but slightly larger zone label typography on desktop without ellipsis', () => {
+    renderWithInputProfile(
+      'fine',
+      <Zone
+        id="evolveDeck-host"
+        label="エボルヴデッキ"
+        cards={[createCard('host-card', { zone: 'evolveDeck-host' })]}
+      />
+    );
+
+    const zoneLabel = screen.getByText('エボルヴデッキ');
+    expect(zoneLabel).toHaveStyle({
+      fontSize: '0.52rem',
+      textOverflow: 'clip',
+      whiteSpace: 'nowrap',
+    });
+    expect(screen.getByText('1')).toHaveStyle({ fontSize: '0.46rem' });
+  });
+
+  it('lowers floating zone label chrome on desktop to reduce overlap with nearby buttons', () => {
+    renderWithInputProfile(
+      'fine',
+      <Zone
+        id="field-host"
+        label="Field"
+        cards={[createCard('host-card')]}
+      />
+    );
+
+    const zoneLabel = screen.getByText('Field');
+    expect(zoneLabel.parentElement).toHaveStyle({ top: '-6px' });
+  });
+
   it('uses tighter zone label chrome in desktop overview so evolve labels fit more naturally', () => {
     renderWithInputProfile(
       'fine',
@@ -361,9 +394,10 @@ describe('Zone', () => {
 
     const zoneLabel = screen.getByText('エボルヴ');
     expect(zoneLabel).toHaveStyle({
-      fontSize: '0.64rem',
+      fontSize: '0.52rem',
       textOverflow: 'clip',
       whiteSpace: 'nowrap',
     });
+    expect(screen.getByText('1')).toHaveStyle({ fontSize: '0.46rem' });
   });
 });

--- a/src/components/Zone.tsx
+++ b/src/components/Zone.tsx
@@ -47,6 +47,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
   const inputProfile = useGameBoardInputProfile();
   const boardDensity = useGameBoardBoardDensity();
   const isCompactInput = inputProfile === 'coarse';
+  const isFineInput = inputProfile === 'fine';
   const isOverviewDesktop = inputProfile === 'fine' && boardDensity === 'overview';
   const { isOver, setNodeRef } = useDroppable({ id });
   const cardSize = getCardSizeForInputProfile(inputProfile, boardDensity);
@@ -62,6 +63,12 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
   const isFieldZone = id.startsWith('field-');
   const isExZone = id.startsWith('ex-');
   const isReadOnlySpectator = viewerRole === 'spectator';
+  const zoneLabelChipGap = isCompactInput ? '2px' : isFineInput ? '3px' : isOverviewDesktop ? '4px' : '6px';
+  const zoneLabelChipPadding = isCompactInput ? '1px 4px' : isFineInput ? '1px 5px' : isOverviewDesktop ? '1px 6px' : '2px 8px';
+  const zoneLabelFontSize = isCompactInput ? '0.48rem' : isFineInput ? '0.52rem' : isOverviewDesktop ? '0.62rem' : '0.68rem';
+  const zoneCountMinWidth = isCompactInput ? '16px' : isFineInput ? '17px' : isOverviewDesktop ? '18px' : '22px';
+  const zoneCountPadding = isCompactInput ? '0 3px' : isFineInput ? '0 4px' : isOverviewDesktop ? '0 4px' : '0 6px';
+  const zoneCountFontSize = isCompactInput ? '0.44rem' : isFineInput ? '0.46rem' : isOverviewDesktop ? '0.62rem' : '0.7rem';
 
   const displayLabel = label.replace(/^(My|Opponent|Player 1|Player 2|自分|相手|1P|2P)\s+/, '');
   const hasCardOnTop = React.useCallback((cardId: string) => cards.some(card => card.attachedTo === cardId), [cards]);
@@ -165,15 +172,15 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
       <div
         style={{
           position: 'absolute',
-          top: isCompactInput ? -7 : -12,
+          top: -6,
           left: isCompactInput ? 7 : 10,
           zIndex: 20,
           display: isCompactInput ? 'grid' : 'inline-flex',
           gridTemplateColumns: isCompactInput ? 'minmax(0, 1fr) auto' : undefined,
           alignItems: 'center',
-          gap: isCompactInput ? '2px' : isOverviewDesktop ? '4px' : '6px',
+          gap: zoneLabelChipGap,
           maxWidth: isOverviewDesktop ? 'calc(100% - 12px)' : 'calc(100% - 20px)',
-          padding: isCompactInput ? '1px 4px' : isOverviewDesktop ? '1px 6px' : '2px 8px',
+          padding: zoneLabelChipPadding,
           background: 'rgba(17, 24, 39, 0.92)',
           border: '1px solid rgba(255,255,255,0.16)',
           borderRadius: '999px',
@@ -202,12 +209,12 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
           style={{
             maxWidth: isCompactInput ? '100%' : undefined,
             minWidth: 0,
-            fontSize: isCompactInput ? '0.48rem' : isOverviewDesktop ? '0.64rem' : '0.72rem',
+            fontSize: zoneLabelFontSize,
             fontWeight: 'bold',
             color: 'white',
             whiteSpace: isCompactInput ? 'normal' : 'nowrap',
             overflow: isCompactInput ? 'visible' : 'hidden',
-            textOverflow: isCompactInput || isOverviewDesktop ? 'clip' : 'ellipsis',
+            textOverflow: 'clip',
             overflowWrap: isCompactInput ? 'normal' : undefined,
             wordBreak: isCompactInput ? 'keep-all' : undefined,
             lineHeight: isCompactInput ? 1.05 : undefined,
@@ -218,12 +225,12 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
         <span
           style={{
             flex: '0 0 auto',
-            minWidth: isCompactInput ? '16px' : isOverviewDesktop ? '18px' : '22px',
-            padding: isCompactInput ? '0 3px' : isOverviewDesktop ? '0 4px' : '0 6px',
+            minWidth: zoneCountMinWidth,
+            padding: zoneCountPadding,
             borderRadius: '999px',
             background: 'rgba(59, 130, 246, 0.24)',
             color: '#bfdbfe',
-            fontSize: isCompactInput ? '0.44rem' : isOverviewDesktop ? '0.62rem' : '0.7rem',
+            fontSize: zoneCountFontSize,
             fontWeight: 'bold',
             textAlign: 'center'
           }}

--- a/src/pages/GameBoard.test.tsx
+++ b/src/pages/GameBoard.test.tsx
@@ -2970,6 +2970,7 @@ describe('GameBoard', () => {
       const playmat = screen.getByTestId('board-playmat');
       const topSection = screen.getByTestId('board-section-top');
       const topGrid = topSection.firstElementChild as HTMLElement;
+      const sectionDivider = container.querySelector('hr');
 
       expect(shell).toHaveAttribute('data-layout-profile', 'desktop');
       expect(shell).toHaveAttribute('data-input-profile', 'fine');
@@ -2979,6 +2980,8 @@ describe('GameBoard', () => {
       expect(playmat).toHaveStyle({ padding: '0.44rem', gap: '0.24rem' });
       expect(topSection).toHaveStyle({ padding: '0.26rem 0.29rem' });
       expect(topGrid).toHaveStyle({ gridTemplateColumns: '150px 864px 176px' });
+      expect(sectionDivider).not.toBeNull();
+      expect(sectionDivider as HTMLElement).toHaveStyle({ margin: '0.18rem 0' });
       expect(screen.getByTestId('zone-cemetery-guest')).toHaveStyle({ minHeight: '98px' });
       expect(screen.getByTestId('zone-field-guest')).toHaveStyle({ minHeight: '109px' });
       expect(screen.getByTestId('zone-hand-guest')).toHaveStyle({ minHeight: '102px' });

--- a/src/pages/GameBoard.test.tsx
+++ b/src/pages/GameBoard.test.tsx
@@ -1106,6 +1106,52 @@ describe('GameBoard', () => {
     expect(discardRandomHandCards).toHaveBeenCalledWith('guest', 2, 'host');
   });
 
+  it('renders opponent hand actions trigger inside the zone on desktop', () => {
+    const guestHandCard = makeCard({
+      id: 'hand-guest-1',
+      zone: 'hand-guest',
+      owner: 'guest',
+    });
+
+    mockUseGameBoardLogic.mockReturnValue(buildMockGameBoardLogic({
+      gameState: createGameState([guestHandCard], {
+        gameStatus: 'playing',
+      }),
+    }));
+
+    render(<GameBoard />);
+
+    const opponentHandPanel = screen.getByTestId('zone-hand-guest').parentElement;
+    expect(opponentHandPanel).not.toBeNull();
+
+    const actionsButton = within(opponentHandPanel as HTMLElement).getByRole('button', { name: 'Actions' });
+    expect(actionsButton.parentElement?.parentElement).toHaveStyle({ bottom: '8px' });
+  });
+
+  it('opens opponent hand actions downward in p2p mode', () => {
+    const guestHandCard = makeCard({
+      id: 'hand-guest-1',
+      zone: 'hand-guest',
+      owner: 'guest',
+    });
+
+    mockUseGameBoardLogic.mockReturnValue(buildMockGameBoardLogic({
+      gameState: createGameState([guestHandCard], {
+        gameStatus: 'playing',
+      }),
+    }));
+
+    render(<GameBoard />);
+
+    const opponentHandPanel = screen.getByTestId('zone-hand-guest').parentElement;
+    expect(opponentHandPanel).not.toBeNull();
+
+    fireEvent.click(within(opponentHandPanel as HTMLElement).getByRole('button', { name: 'Actions' }));
+
+    const randomDiscardButton = screen.getByRole('button', { name: 'Random Discard' });
+    expect(randomDiscardButton.parentElement).toHaveStyle({ top: 'calc(100% + 4px)' });
+  });
+
   it('reopens random discard with the default value after canceling', async () => {
     const discardRandomHandCards = vi.fn();
     const guestHandCard = makeCard({
@@ -1259,6 +1305,52 @@ describe('GameBoard', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Reveal Hand' }));
 
     expect(revealHand).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens local hand actions upward in p2p mode', () => {
+    const hostHandCard = makeCard({
+      id: 'hand-host-1',
+      zone: 'hand-host',
+      owner: 'host',
+    });
+
+    mockUseGameBoardLogic.mockReturnValue(buildMockGameBoardLogic({
+      gameState: createGameState([hostHandCard], {
+        gameStatus: 'playing',
+      }),
+    }));
+
+    render(<GameBoard />);
+
+    const localHandPanel = screen.getByTestId('zone-hand-host').parentElement;
+    expect(localHandPanel).not.toBeNull();
+
+    fireEvent.click(within(localHandPanel as HTMLElement).getByRole('button', { name: 'Actions' }));
+
+    const revealHandButton = screen.getByRole('button', { name: 'Reveal Hand' });
+    expect(revealHandButton.parentElement).toHaveStyle({ bottom: 'calc(100% + 4px)' });
+  });
+
+  it('renders local hand actions trigger inside the zone on desktop', () => {
+    const hostHandCard = makeCard({
+      id: 'hand-host-1',
+      zone: 'hand-host',
+      owner: 'host',
+    });
+
+    mockUseGameBoardLogic.mockReturnValue(buildMockGameBoardLogic({
+      gameState: createGameState([hostHandCard], {
+        gameStatus: 'playing',
+      }),
+    }));
+
+    render(<GameBoard />);
+
+    const localHandPanel = screen.getByTestId('zone-hand-host').parentElement;
+    expect(localHandPanel).not.toBeNull();
+
+    const actionsButton = within(localHandPanel as HTMLElement).getByRole('button', { name: 'Actions' });
+    expect(actionsButton.parentElement?.parentElement).toHaveStyle({ bottom: '8px' });
   });
 
   it('does not show the p2p hand reveal action for an empty local hand', () => {
@@ -2891,6 +2983,8 @@ describe('GameBoard', () => {
       expect(screen.getByTestId('zone-field-guest')).toHaveStyle({ minHeight: '109px' });
       expect(screen.getByTestId('zone-hand-guest')).toHaveStyle({ minHeight: '102px' });
       expect(screen.getByTestId('zone-hand-host')).toHaveStyle({ minHeight: '109px' });
+      expect(screen.getByTestId('zone-leader-guest')).toHaveStyle({ minHeight: '114px' });
+      expect(screen.getByTestId('zone-leader-host')).toHaveStyle({ minHeight: '114px' });
       const hostControlsPanel = screen.getByTestId('player-tracker-host').parentElement as HTMLElement;
       expect(hostControlsPanel).toHaveStyle({ marginLeft: '1.5rem' });
 

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -109,7 +109,7 @@ const GameBoard: React.FC = () => {
       : '1.25rem';
   const boardColumnStackGap = isCompactBoard ? '0.34rem' : isOverviewBoard ? '0.29rem' : '0.65rem';
   const bottomBoardRowSecondaryMarginTop = isTabletCompactBoard ? '0.2rem' : '0';
-  const boardSectionDividerMargin = isTabletCompactBoard ? '0.3rem 0' : isCompactBoard ? '0.4rem 0' : isOverviewBoard ? '0.28rem 0' : '1rem 0';
+  const boardSectionDividerMargin = isTabletCompactBoard ? '0.3rem 0' : isCompactBoard ? '0.4rem 0' : isOverviewBoard ? '0.18rem 0' : '1rem 0';
   const stackZoneMinHeight = isTabletCompactBoard ? '108px' : isCompactBoard ? '110px' : isOverviewBoard ? '98px' : '150px';
   const fieldZoneMinHeight = isTabletCompactBoard ? '120px' : isCompactBoard ? '124px' : isOverviewBoard ? '109px' : '160px';
   const handZoneMinHeight = isTabletCompactBoard ? '112px' : isCompactBoard ? '116px' : isOverviewBoard ? '102px' : '150px';

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -114,7 +114,7 @@ const GameBoard: React.FC = () => {
   const fieldZoneMinHeight = isTabletCompactBoard ? '120px' : isCompactBoard ? '124px' : isOverviewBoard ? '109px' : '160px';
   const handZoneMinHeight = isTabletCompactBoard ? '112px' : isCompactBoard ? '116px' : isOverviewBoard ? '102px' : '150px';
   const bottomHandZoneMinHeight = isTabletCompactBoard ? '120px' : isCompactBoard ? '124px' : isOverviewBoard ? '109px' : '160px';
-  const leaderZoneMinHeight = isTabletCompactBoard ? '124px' : '150px';
+  const leaderZoneMinHeight = isTabletCompactBoard ? '124px' : isOverviewBoard ? '114px' : '150px';
   const {
     sidePanelWidth,
     topPanelWidth,


### PR DESCRIPTION
## 概要
PC / tablet の GameBoard UI を中心に、縦幅削減と視認性の微調整を行いました。  
主に「手札アクション配置」「zone ラベル表示」「overview 縦寸最適化」を改善しています。

## 背景
- 手札アクションが zone 外にあり、縦方向スペースを圧迫していた
- PC の zone ラベルがサイズ・位置の面でボタンと干渉しやすかった
- overview でリーダー領域とセクション間余白に改善余地があった

## 変更内容
- 手札アクションの配置/展開を調整
  - 自分手札: zone 内配置 + 上展開
  - 相手手札: zone 内配置 + 下展開
- 検索/アクションのトリガーボタンを fine input（PC）でコンパクト化
  - 展開後メニュー項目は従来サイズを維持
- zone ラベルを PC 向けに再調整
  - 文字/カウントをコンパクト化しつつ微調整で読みやすさを確保
  - ラベル位置を `top: -6px` に調整してボタン干渉を軽減
  - 省略記号 (`...`) は使わず `clip` 挙動に統一
- overview の縦幅最適化
  - leader zone min-height を縮小（`114px`）
  - 中央セクション区切り余白を縮小（`0.18rem 0`）

## 影響範囲
- `src/components/GameBoardBottomHandSection.tsx`
- `src/components/GameBoardTopHandSection.tsx`
- `src/components/GameBoardZoneActionsMenu.tsx`
- `src/components/GameBoardZoneSearchButton.tsx`
- `src/components/Zone.tsx`
- `src/pages/GameBoard.tsx`
- 関連テスト:
  - `src/pages/GameBoard.test.tsx`
  - `src/components/Zone.test.tsx`
  - `src/components/GameBoardZoneUi.test.tsx`

## テスト
- [x] `npm run lint`
- [x] `npx tsc --noEmit -p tsconfig.app.json`
- [x] `npx vitest run src/pages/GameBoard.test.tsx src/components/Zone.test.tsx src/components/GameBoardZoneUi.test.tsx`

## デグレリスク
- 低〜中（主に見た目）
  - 手札枚数が多い時の重なり見え方
  - 狭幅時の zone ラベル見切れ（`clip` 前提）

## 確認観点（手動）
- PC で自分/相手手札の `Actions` が意図方向に展開されること
- hand が多い時に操作ボタンが押しづらくなっていないこと
- zone ラベルと検索/アクション周辺の視覚干渉が許容範囲であること
