### PR TITLE
Codex/twoside card

### DIFF
--- a/public/cards.json
+++ b/public/cards.json
@@ -33845,6 +33845,71 @@
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-525.png"
   },
   {
+    "id": "PR-527",
+    "name": "アズヴォルト",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-527.png"
+  },
+  {
+    "id": "PR-528",
+    "name": "剪定の咎人・マガチヨ",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-528.png"
+  },
+  {
+    "id": "PR-529",
+    "name": "対空射撃",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-529.png"
+  },
+  {
+    "id": "PR-530",
+    "name": "アルセーヌ・ルパン",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-530.png"
+  },
+  {
+    "id": "PR-531",
+    "name": "アルセーヌ・ルパン",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-531.png"
+  },
+  {
+    "id": "PR-532",
+    "name": "ファイアーチェイン",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-532.png"
+  },
+  {
+    "id": "PR-533",
+    "name": "ドラゴニックコール",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-533.png"
+  },
+  {
+    "id": "PR-534",
+    "name": "パルクールウルフ",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-534.png"
+  },
+  {
+    "id": "PR-535",
+    "name": "加虐の独房",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-535.png"
+  },
+  {
+    "id": "PR-536",
+    "name": "伝道の司祭・ロレーナ",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-536.png"
+  },
+  {
+    "id": "PR-537",
+    "name": "伝道の司祭・ロレーナ",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-537.png"
+  },
+  {
+    "id": "PR-538",
+    "name": "溶鉄の腹心",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-538.png"
+  },
+  {
+    "id": "PR-539",
+    "name": "迸る光明・アポロン",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-539.png"
+  },
+  {
     "id": "PR-540",
     "name": "操り人形",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-540.png"

--- a/public/cards_detailed.json
+++ b/public/cards_detailed.json
@@ -86696,6 +86696,45 @@
         "name": "愛の妖精・ポーラ"
       }
     ],
+    "faces": [
+      {
+        "side": "front",
+        "name": "深緑の純心・ポーラ",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-005.png",
+        "class": "エルフ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "妖精",
+        "rarity": "GR",
+        "product_name": "ブースターパック第9弾「光影の二重奏」",
+        "cost": "-",
+        "atk": "3",
+        "hp": "3",
+        "ability_text": "【進化時】自分のデッキの上5枚を見る。その中から、[エルフ]スペル1枚を公開して手札に加えてよい。残りを好きな順にデッキの下に置く。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      },
+      {
+        "side": "back",
+        "name": "真紅の絆・ポーラ",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-005_ura.png",
+        "class": "エルフ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "妖精",
+        "rarity": "GR",
+        "cost": "-",
+        "atk": "3",
+        "hp": "3",
+        "ability_text": "【攻撃時】【コンボ_3】相手の場のフォロワー1体を選ぶ。それに3ダメージ。 【進化時】自分の場の他のカード2枚まで選ぶ。それをEXエリアに置く。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      }
+    ],
     "card_kind_normalized": "evolve_follower",
     "deck_section": "evolve",
     "is_token": false,
@@ -87038,6 +87077,45 @@
       {
         "id": "BP09-T07",
         "name": "シールドガーディアン"
+      }
+    ],
+    "faces": [
+      {
+        "side": "front",
+        "name": "希望の戦術家・セリア",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-019.png",
+        "class": "ロイヤル",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "指揮官・光輝",
+        "rarity": "LG",
+        "product_name": "ブースターパック第9弾「光影の二重奏」",
+        "cost": "-",
+        "atk": "2",
+        "hp": "2",
+        "ability_text": "【進化時】『シールドガーディアン』1体を出す。 ――――――――――――――― 『シールドガーディアン』[ロイヤル]兵士・フォロワー[コスト1][攻撃力]1/[体力]1【守護】",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      },
+      {
+        "side": "back",
+        "name": "絶望の使者・セリア",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-019_ura.png",
+        "class": "ロイヤル",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "指揮官・キラー",
+        "rarity": "LG",
+        "cost": "-",
+        "atk": "4",
+        "hp": "4",
+        "ability_text": "【疾走】 【進化時】『スティールナイト』1体と『ナイト』1体を出す。 ――――――――――――――― 『スティールナイト』[ロイヤル]兵士・フォロワー[コスト2][攻撃力]2/[体力]2 『ナイト』[ロイヤル]兵士・フォロワー[コスト1][攻撃力]1/[体力]1",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
       }
     ],
     "card_kind_normalized": "evolve_follower",
@@ -87536,6 +87614,45 @@
         "name": "マナリアの竜術士"
       }
     ],
+    "faces": [
+      {
+        "side": "front",
+        "name": "マナリアの白竜",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-039.png",
+        "class": "ウィッチ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "学院・光輝",
+        "rarity": "GR",
+        "product_name": "ブースターパック第9弾「光影の二重奏」",
+        "cost": "-",
+        "atk": "5",
+        "hp": "5",
+        "ability_text": "【守護】 【進化時】自分のリーダーは[体力]+3する",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      },
+      {
+        "side": "back",
+        "name": "マナリアの黒竜",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-039_ura.png",
+        "class": "ウィッチ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "学院・キラー",
+        "rarity": "GR",
+        "cost": "-",
+        "atk": "5",
+        "hp": "5",
+        "ability_text": "【指定攻撃】 【進化時】相手のリーダーすべてに3ダメージ。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      }
+    ],
     "card_kind_normalized": "evolve_follower",
     "deck_section": "evolve",
     "is_token": false,
@@ -87941,6 +88058,45 @@
         "name": "リントヴルム"
       }
     ],
+    "faces": [
+      {
+        "side": "front",
+        "name": "聖竜・リントヴルム",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-056.png",
+        "class": "ドラゴン",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "竜族・光輝",
+        "rarity": "GR",
+        "product_name": "ブースターパック第9弾「光影の二重奏」",
+        "cost": "-",
+        "atk": "10",
+        "hp": "10",
+        "ability_text": "【守護】 自分のエンドフェイズが来たとき、自分のリーダーは[体力]+6する。3枚引く。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      },
+      {
+        "side": "back",
+        "name": "邪竜・リントヴルム",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-056_ura.png",
+        "class": "ドラゴン",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "竜族・キラー",
+        "rarity": "GR",
+        "cost": "-",
+        "atk": "10",
+        "hp": "10",
+        "ability_text": "【疾走】 これは【守護】を無視して攻撃できる。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      }
+    ],
     "card_kind_normalized": "evolve_follower",
     "deck_section": "evolve",
     "is_token": false,
@@ -88261,6 +88417,45 @@
       {
         "id": "BP09-069",
         "name": "闇夜の姫・ヴァンピィ"
+      }
+    ],
+    "faces": [
+      {
+        "side": "front",
+        "name": "カインドクイーン・ヴァンピィ",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-070.png",
+        "class": "ナイトメア",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "吸血鬼・プリンセス・光輝",
+        "rarity": "LG",
+        "product_name": "ブースターパック第9弾「光影の二重奏」",
+        "cost": "-",
+        "atk": "4",
+        "hp": "4",
+        "ability_text": "これがいる限り、自分が『フォレストバット』をプレイする際、コストを-1する。 自分の場に『フォレストバット』が出たとき、自分のリーダーは[体力]+1する。 【進化時】1枚引く。自分の手札1枚を捨てる。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      },
+      {
+        "side": "back",
+        "name": "ブラッドクイーン・ヴァンピィ",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-070_ura.png",
+        "class": "ナイトメア",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "吸血鬼・プリンセス・キラー",
+        "rarity": "LG",
+        "cost": "-",
+        "atk": "6",
+        "hp": "6",
+        "ability_text": "【疾走】 これがいる限り、自分が『フォレストバット』をプレイする際、コストを-1する。 自分の場に『フォレストバット』が出たとき、相手の場のフォロワー1体を選ぶ。それに3ダメージ。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
       }
     ],
     "card_kind_normalized": "evolve_follower",
@@ -88763,6 +88958,45 @@
       {
         "id": "BP09-089",
         "name": "ケリュネイア"
+      }
+    ],
+    "faces": [
+      {
+        "side": "front",
+        "name": "明転の牝鹿・ケリュネイア",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-090.png",
+        "class": "ビショップ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "信仰・獣・光輝",
+        "rarity": "GR",
+        "product_name": "ブースターパック第9弾「光影の二重奏」",
+        "cost": "-",
+        "atk": "5",
+        "hp": "5",
+        "ability_text": "【守護】 【進化時】場のアミュレット1つを墓場に置く：自分のリーダーは[体力]+4する。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      },
+      {
+        "side": "back",
+        "name": "暗転の牝鹿・ケリュネイア",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-090_ura.png",
+        "class": "ビショップ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "信仰・獣・キラー",
+        "rarity": "GR",
+        "cost": "-",
+        "atk": "5",
+        "hp": "5",
+        "ability_text": "【必殺】 【進化時】場のアミュレット1つを墓場に置く：相手のリーダー1人か相手の場のフォロワー1体を選ぶ。それに4ダメージ。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
       }
     ],
     "card_kind_normalized": "evolve_follower",
@@ -89486,6 +89720,45 @@
         "name": "愛の妖精・ポーラ"
       }
     ],
+    "faces": [
+      {
+        "side": "front",
+        "name": "深緑の純心・ポーラ",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-p02.png",
+        "class": "エルフ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "妖精",
+        "rarity": "GR・プレミアム",
+        "product_name": "ブースターパック第9弾「光影の二重奏」",
+        "cost": "-",
+        "atk": "3",
+        "hp": "3",
+        "ability_text": "【進化時】自分のデッキの上5枚を見る。その中から、[エルフ]スペル1枚を公開して手札に加えてよい。残りを好きな順にデッキの下に置く。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      },
+      {
+        "side": "back",
+        "name": "真紅の絆・ポーラ",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-p02_ura.png",
+        "class": "エルフ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "妖精",
+        "rarity": "GR・プレミアム",
+        "cost": "-",
+        "atk": "3",
+        "hp": "3",
+        "ability_text": "【攻撃時】【コンボ_3】相手の場のフォロワー1体を選ぶ。それに3ダメージ。 【進化時】自分の場の他のカード2枚まで選ぶ。それをEXエリアに置く。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      }
+    ],
     "card_kind_normalized": "evolve_follower",
     "deck_section": "evolve",
     "is_token": false,
@@ -89744,6 +90017,45 @@
         "name": "マナリアの竜術士"
       }
     ],
+    "faces": [
+      {
+        "side": "front",
+        "name": "マナリアの白竜",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-p12.png",
+        "class": "ウィッチ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "学院・光輝",
+        "rarity": "GR・プレミアム",
+        "product_name": "ブースターパック第9弾「光影の二重奏」",
+        "cost": "-",
+        "atk": "5",
+        "hp": "5",
+        "ability_text": "【守護】 【進化時】自分のリーダーは[体力]+3する",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      },
+      {
+        "side": "back",
+        "name": "マナリアの黒竜",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-p12_ura.png",
+        "class": "ウィッチ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "学院・キラー",
+        "rarity": "GR・プレミアム",
+        "cost": "-",
+        "atk": "5",
+        "hp": "5",
+        "ability_text": "【指定攻撃】 【進化時】相手のリーダーすべてに3ダメージ。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      }
+    ],
     "card_kind_normalized": "evolve_follower",
     "deck_section": "evolve",
     "is_token": false,
@@ -89869,6 +90181,45 @@
       {
         "id": "BP09-P16",
         "name": "リントヴルム"
+      }
+    ],
+    "faces": [
+      {
+        "side": "front",
+        "name": "聖竜・リントヴルム",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-p17.png",
+        "class": "ドラゴン",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "竜族・光輝",
+        "rarity": "GR・プレミアム",
+        "product_name": "ブースターパック第9弾「光影の二重奏」",
+        "cost": "-",
+        "atk": "10",
+        "hp": "10",
+        "ability_text": "【守護】 自分のエンドフェイズが来たとき、自分のリーダーは[体力]+6する。3枚引く。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      },
+      {
+        "side": "back",
+        "name": "邪竜・リントヴルム",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-p17_ura.png",
+        "class": "ドラゴン",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "竜族・キラー",
+        "rarity": "GR・プレミアム",
+        "cost": "-",
+        "atk": "10",
+        "hp": "10",
+        "ability_text": "【疾走】 これは【守護】を無視して攻撃できる。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
       }
     ],
     "card_kind_normalized": "evolve_follower",
@@ -90129,6 +90480,45 @@
         "name": "ケリュネイア"
       }
     ],
+    "faces": [
+      {
+        "side": "front",
+        "name": "明転の牝鹿・ケリュネイア",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-p27.png",
+        "class": "ビショップ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "信仰・獣・光輝",
+        "rarity": "GR・プレミアム",
+        "product_name": "ブースターパック第9弾「光影の二重奏」",
+        "cost": "-",
+        "atk": "5",
+        "hp": "5",
+        "ability_text": "【守護】 【進化時】場のアミュレット1つを墓場に置く：自分のリーダーは[体力]+4する。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      },
+      {
+        "side": "back",
+        "name": "暗転の牝鹿・ケリュネイア",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-p27_ura.png",
+        "class": "ビショップ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "信仰・獣・キラー",
+        "rarity": "GR・プレミアム",
+        "cost": "-",
+        "atk": "5",
+        "hp": "5",
+        "ability_text": "【必殺】 【進化時】場のアミュレット1つを墓場に置く：相手のリーダー1人か相手の場のフォロワー1体を選ぶ。それに4ダメージ。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      }
+    ],
     "card_kind_normalized": "evolve_follower",
     "deck_section": "evolve",
     "is_token": false,
@@ -90379,6 +90769,45 @@
         "name": "シールドガーディアン"
       }
     ],
+    "faces": [
+      {
+        "side": "front",
+        "name": "希望の戦術家・セリア",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-sl05.png",
+        "class": "ロイヤル",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "指揮官・光輝",
+        "rarity": "SL",
+        "product_name": "ブースターパック第9弾「光影の二重奏」",
+        "cost": "-",
+        "atk": "2",
+        "hp": "2",
+        "ability_text": "【進化時】『シールドガーディアン』1体を出す。 ――――――――――――――― 『シールドガーディアン』[ロイヤル]兵士・フォロワー[コスト1][攻撃力]1/[体力]1【守護】",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      },
+      {
+        "side": "back",
+        "name": "絶望の使者・セリア",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-sl05_ura.png",
+        "class": "ロイヤル",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "指揮官・キラー",
+        "rarity": "SL",
+        "cost": "-",
+        "atk": "4",
+        "hp": "4",
+        "ability_text": "【疾走】 【進化時】『スティールナイト』1体と『ナイト』1体を出す。 ――――――――――――――― 『スティールナイト』[ロイヤル]兵士・フォロワー[コスト2][攻撃力]2/[体力]2 『ナイト』[ロイヤル]兵士・フォロワー[コスト1][攻撃力]1/[体力]1",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      }
+    ],
     "card_kind_normalized": "evolve_follower",
     "deck_section": "evolve",
     "is_token": false,
@@ -90610,6 +91039,45 @@
       {
         "id": "BP09-SL13",
         "name": "闇夜の姫・ヴァンピィ"
+      }
+    ],
+    "faces": [
+      {
+        "side": "front",
+        "name": "カインドクイーン・ヴァンピィ",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-sl14.png",
+        "class": "ナイトメア",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "吸血鬼・プリンセス・光輝",
+        "rarity": "SL",
+        "product_name": "ブースターパック第9弾「光影の二重奏」",
+        "cost": "-",
+        "atk": "4",
+        "hp": "4",
+        "ability_text": "これがいる限り、自分が『フォレストバット』をプレイする際、コストを-1する。 自分の場に『フォレストバット』が出たとき、自分のリーダーは[体力]+1する。 【進化時】1枚引く。自分の手札1枚を捨てる。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      },
+      {
+        "side": "back",
+        "name": "ブラッドクイーン・ヴァンピィ",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP09/bp09-sl14_ura.png",
+        "class": "ナイトメア",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "吸血鬼・プリンセス・キラー",
+        "rarity": "SL",
+        "cost": "-",
+        "atk": "6",
+        "hp": "6",
+        "ability_text": "【疾走】 これがいる限り、自分が『フォレストバット』をプレイする際、コストを-1する。 自分の場に『フォレストバット』が出たとき、相手の場のフォロワー1体を選ぶ。それに3ダメージ。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
       }
     ],
     "card_kind_normalized": "evolve_follower",
@@ -91304,6 +91772,45 @@
       {
         "id": "BP08-T09",
         "name": "操り人形"
+      }
+    ],
+    "faces": [
+      {
+        "side": "front",
+        "name": "決意の人形・オーキス",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP08/bp08-003_front.png",
+        "class": "エルフ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "人形・光輝",
+        "rarity": "LG",
+        "product_name": "ブースターパック第8弾「次元混沌」",
+        "cost": "-",
+        "atk": "3",
+        "hp": "3",
+        "ability_text": "自分のターンごとに1回、自分の『操り人形』が場を離れたとき、『ロイド』1枚をEXエリアに置く。 【進化時】『操り人形』2体を出す。 ――――――――――――――― 『操り人形』[ニュートラル]人形・フォロワー[コスト1][攻撃力]1/[体力]1【突進】 『ロイド』[エルフ]人形・フォロワー[コスト0][攻撃力]2/[体力]4これは場にいる限り、『操り人形』でもある。【守護】[ファンファーレ]自分のリーダーは[体力]+2する。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      },
+      {
+        "side": "back",
+        "name": "復讐の人形・オーキス",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP08/bp08-003_back.png",
+        "class": "エルフ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "人形・キラー",
+        "rarity": "LG",
+        "cost": "-",
+        "atk": "4",
+        "hp": "4",
+        "ability_text": "これがいる限り、自分の場の『操り人形』すべては【指定攻撃】を持つ。 自分の『操り人形』が場を離れたとき、相手のリーダー1人か相手の場のフォロワー1体を選ぶ。それに2ダメージ。 【進化時】『操り人形』4体を出す。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
       }
     ],
     "card_kind_normalized": "evolve_follower",
@@ -94745,6 +95252,45 @@
       {
         "id": "BP08-T09",
         "name": "操り人形"
+      }
+    ],
+    "faces": [
+      {
+        "side": "front",
+        "name": "決意の人形・オーキス",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP08/bp08-sl03_front.png",
+        "class": "エルフ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "人形・光輝",
+        "rarity": "SL",
+        "product_name": "ブースターパック第8弾「次元混沌」",
+        "cost": "-",
+        "atk": "3",
+        "hp": "3",
+        "ability_text": "自分のターンごとに1回、自分の『操り人形』が場を離れたとき、『ロイド』1枚をEXエリアに置く。 【進化時】『操り人形』2体を出す。 ――――――――――――――― 『操り人形』[ニュートラル]人形・フォロワー[コスト1][攻撃力]1/[体力]1【突進】 『ロイド』[エルフ]人形・フォロワー[コスト0][攻撃力]2/[体力]4これは場にいる限り、『操り人形』でもある。【守護】[ファンファーレ]自分のリーダーは[体力]+2する。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
+      },
+      {
+        "side": "back",
+        "name": "復讐の人形・オーキス",
+        "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP08/bp08-sl03_back.png",
+        "class": "エルフ",
+        "type": "フォロワー・エボルヴ",
+        "subtype": "人形・キラー",
+        "rarity": "SL",
+        "cost": "-",
+        "atk": "4",
+        "hp": "4",
+        "ability_text": "これがいる限り、自分の場の『操り人形』すべては【指定攻撃】を持つ。 自分の『操り人形』が場を離れたとき、相手のリーダー1人か相手の場のフォロワー1体を選ぶ。それに2ダメージ。 【進化時】『操り人形』4体を出す。",
+        "card_kind_normalized": "evolve_follower",
+        "deck_section": "evolve",
+        "is_token": false,
+        "is_evolve_card": true,
+        "is_deck_build_legal": true
       }
     ],
     "card_kind_normalized": "evolve_follower",
@@ -130684,7 +131230,7 @@
   },
   {
     "id": "CSD01-T01",
-    "name": "レジェンドレース　VSスペシャルウィーク",
+    "name": "レジェンドレース VSスペシャルウィーク",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CSD01/csd01-t01.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -135852,7 +136398,7 @@
   },
   {
     "id": "CP01-T11",
-    "name": "レジェンドレース　VSエルコンドルパサー",
+    "name": "レジェンドレース VSエルコンドルパサー",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t11.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -135872,7 +136418,7 @@
   },
   {
     "id": "CP01-T12",
-    "name": "レジェンドレース　VSシンボリルドルフ",
+    "name": "レジェンドレース VSシンボリルドルフ",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t12.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -135892,7 +136438,7 @@
   },
   {
     "id": "CP01-T13",
-    "name": "レジェンドレース　VSキングヘイロー",
+    "name": "レジェンドレース VSキングヘイロー",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t13.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -135912,7 +136458,7 @@
   },
   {
     "id": "CP01-T14",
-    "name": "レジェンドレース　VSタイキシャトル",
+    "name": "レジェンドレース VSタイキシャトル",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t14.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -135932,7 +136478,7 @@
   },
   {
     "id": "CP01-T15",
-    "name": "レジェンドレース　VSサクラバクシンオー",
+    "name": "レジェンドレース VSサクラバクシンオー",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t15.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -135952,7 +136498,7 @@
   },
   {
     "id": "CP01-T16",
-    "name": "レジェンドレース　VSカレンチャン",
+    "name": "レジェンドレース VSカレンチャン",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t16.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -135972,7 +136518,7 @@
   },
   {
     "id": "CP01-T17",
-    "name": "レジェンドレース　VSウイニングチケット",
+    "name": "レジェンドレース VSウイニングチケット",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t17.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -135992,7 +136538,7 @@
   },
   {
     "id": "CP01-T18",
-    "name": "レジェンドレース　VSウオッカ",
+    "name": "レジェンドレース VSウオッカ",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t18.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136012,7 +136558,7 @@
   },
   {
     "id": "CP01-T19",
-    "name": "レジェンドレース　VSトウカイテイオー",
+    "name": "レジェンドレース VSトウカイテイオー",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t19.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136032,7 +136578,7 @@
   },
   {
     "id": "CP01-T20",
-    "name": "レジェンドレース　VSマヤノトップガン",
+    "name": "レジェンドレース VSマヤノトップガン",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t20.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136052,7 +136598,7 @@
   },
   {
     "id": "CP01-T21",
-    "name": "レジェンドレース　VSメジロマックイーン",
+    "name": "レジェンドレース VSメジロマックイーン",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t21.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136072,7 +136618,7 @@
   },
   {
     "id": "CP01-T22",
-    "name": "レジェンドレース　VSテイエムオペラオー",
+    "name": "レジェンドレース VSテイエムオペラオー",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t22.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136092,7 +136638,7 @@
   },
   {
     "id": "CP01-T23",
-    "name": "レジェンドレース　VSスーパークリーク",
+    "name": "レジェンドレース VSスーパークリーク",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t23.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136112,7 +136658,7 @@
   },
   {
     "id": "CP01-T24",
-    "name": "レジェンドレース　VSメジロライアン",
+    "name": "レジェンドレース VSメジロライアン",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t24.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136132,7 +136678,7 @@
   },
   {
     "id": "CP01-T25",
-    "name": "レジェンドレース　VSサイレンススズカ",
+    "name": "レジェンドレース VSサイレンススズカ",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t25.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136152,7 +136698,7 @@
   },
   {
     "id": "CP01-T26",
-    "name": "レジェンドレース　VSゴールドシップ",
+    "name": "レジェンドレース VSゴールドシップ",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t26.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136172,7 +136718,7 @@
   },
   {
     "id": "CP01-T27",
-    "name": "レジェンドレース　VSマルゼンスキー",
+    "name": "レジェンドレース VSマルゼンスキー",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t27.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136192,7 +136738,7 @@
   },
   {
     "id": "CP01-T28",
-    "name": "レジェンドレース　VSフジキセキ",
+    "name": "レジェンドレース VSフジキセキ",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t28.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136212,7 +136758,7 @@
   },
   {
     "id": "CP01-T29",
-    "name": "レジェンドレース　VSミホノブルボン",
+    "name": "レジェンドレース VSミホノブルボン",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t29.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136232,7 +136778,7 @@
   },
   {
     "id": "CP01-T30",
-    "name": "レジェンドレース　VSマチカネフクキタル",
+    "name": "レジェンドレース VSマチカネフクキタル",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t30.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136252,7 +136798,7 @@
   },
   {
     "id": "CP01-T31",
-    "name": "レジェンドレース　VSセイウンスカイ",
+    "name": "レジェンドレース VSセイウンスカイ",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t31.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136272,7 +136818,7 @@
   },
   {
     "id": "CP01-T32",
-    "name": "レジェンドレース　VSビワハヤヒデ",
+    "name": "レジェンドレース VSビワハヤヒデ",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t32.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136292,7 +136838,7 @@
   },
   {
     "id": "CP01-T33",
-    "name": "レジェンドレース　VSエアグルーヴ",
+    "name": "レジェンドレース VSエアグルーヴ",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t33.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136312,7 +136858,7 @@
   },
   {
     "id": "CP01-T34",
-    "name": "レジェンドレース　VSエイシンフラッシュ",
+    "name": "レジェンドレース VSエイシンフラッシュ",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t34.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136332,7 +136878,7 @@
   },
   {
     "id": "CP01-T35",
-    "name": "レジェンドレース　VSアグネスデジタル",
+    "name": "レジェンドレース VSアグネスデジタル",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t35.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136352,7 +136898,7 @@
   },
   {
     "id": "CP01-T36",
-    "name": "レジェンドレース　VSナイスネイチャ",
+    "name": "レジェンドレース VSナイスネイチャ",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t36.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136372,7 +136918,7 @@
   },
   {
     "id": "CP01-T37",
-    "name": "レジェンドレース　VSグラスワンダー",
+    "name": "レジェンドレース VSグラスワンダー",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t37.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136392,7 +136938,7 @@
   },
   {
     "id": "CP01-T38",
-    "name": "レジェンドレース　VSオグリキャップ",
+    "name": "レジェンドレース VSオグリキャップ",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t38.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136412,7 +136958,7 @@
   },
   {
     "id": "CP01-T39",
-    "name": "レジェンドレース　VSヒシアマゾン",
+    "name": "レジェンドレース VSヒシアマゾン",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t39.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136432,7 +136978,7 @@
   },
   {
     "id": "CP01-T40",
-    "name": "レジェンドレース　VSメジロドーベル",
+    "name": "レジェンドレース VSメジロドーベル",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t40.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136452,7 +136998,7 @@
   },
   {
     "id": "CP01-T41",
-    "name": "レジェンドレース　VSゴールドシチー",
+    "name": "レジェンドレース VSゴールドシチー",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t41.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136472,7 +137018,7 @@
   },
   {
     "id": "CP01-T42",
-    "name": "レジェンドレース　VSアグネスタキオン",
+    "name": "レジェンドレース VSアグネスタキオン",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t42.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136492,7 +137038,7 @@
   },
   {
     "id": "CP01-T43",
-    "name": "レジェンドレース　VSナリタタイシン",
+    "name": "レジェンドレース VSナリタタイシン",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t43.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136512,7 +137058,7 @@
   },
   {
     "id": "CP01-T44",
-    "name": "レジェンドレース　VSナリタブライアン",
+    "name": "レジェンドレース VSナリタブライアン",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t44.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136532,7 +137078,7 @@
   },
   {
     "id": "CP01-T45",
-    "name": "レジェンドレース　VSメジロマックイーン",
+    "name": "レジェンドレース VSメジロマックイーン",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t45.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136552,7 +137098,7 @@
   },
   {
     "id": "CP01-T46",
-    "name": "レジェンドレース　VSライスシャワー",
+    "name": "レジェンドレース VSライスシャワー",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t46.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136572,7 +137118,7 @@
   },
   {
     "id": "CP01-T47",
-    "name": "レジェンドレース　VSメジロブライト",
+    "name": "レジェンドレース VSメジロブライト",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t47.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136592,7 +137138,7 @@
   },
   {
     "id": "CP01-T48",
-    "name": "レジェンドレース　VSタマモクロス",
+    "name": "レジェンドレース VSタマモクロス",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t48.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -136612,7 +137158,7 @@
   },
   {
     "id": "CP01-T49",
-    "name": "レジェンドレース　VSメイショウドトウ",
+    "name": "レジェンドレース VSメイショウドトウ",
     "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/CP01/cp01-t49.png",
     "class": "-",
     "title": "ウマ娘 プリティーダービー",
@@ -162327,6 +162873,307 @@
     "deck_section": "main",
     "is_token": false,
     "is_evolve_card": false,
+    "is_deck_build_legal": true
+  },
+  {
+    "id": "PR-527",
+    "name": "アズヴォルト",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-527.png",
+    "class": "ニュートラル",
+    "type": "アミュレット",
+    "subtype": "八獄",
+    "rarity": "PR",
+    "product_name": "PRカード",
+    "cost": "1",
+    "atk": "-",
+    "hp": "-",
+    "ability_text": "[ファンファーレ]自分のデッキの上4枚を見る。その中から、八獄・カード1枚を公開して手札に加えてよい。残りを好きな順にデッキの下に置く。 [起動]これを[アクト]墓場に置く：自分のターンが8ターン目かそれ以降なら、1枚引く。",
+    "card_kind_normalized": "amulet",
+    "deck_section": "main",
+    "is_token": false,
+    "is_evolve_card": false,
+    "is_deck_build_legal": true
+  },
+  {
+    "id": "PR-528",
+    "name": "剪定の咎人・マガチヨ",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-528.png",
+    "class": "エルフ",
+    "type": "フォロワー",
+    "subtype": "八獄・エルフ族",
+    "rarity": "PR",
+    "product_name": "PRカード",
+    "cost": "2",
+    "atk": "2",
+    "hp": "2",
+    "ability_text": "[進化][コスト1]：これは進化する。",
+    "related_cards": [
+      {
+        "id": "BP19-002",
+        "name": "剪定の咎人・マガチヨ"
+      }
+    ],
+    "card_kind_normalized": "follower",
+    "deck_section": "main",
+    "is_token": false,
+    "is_evolve_card": false,
+    "is_deck_build_legal": true
+  },
+  {
+    "id": "PR-529",
+    "name": "対空射撃",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-529.png",
+    "class": "エルフ",
+    "type": "スペル",
+    "subtype": "エルフ族・狩人",
+    "rarity": "PR",
+    "product_name": "PRカード",
+    "cost": "1",
+    "atk": "-",
+    "hp": "-",
+    "ability_text": "自分の場の[エルフ]カード1枚と相手の場のフォロワー1体を選ぶ。前者を手札に戻す。後者に3ダメージ。",
+    "card_kind_normalized": "spell",
+    "deck_section": "main",
+    "is_token": false,
+    "is_evolve_card": false,
+    "is_deck_build_legal": true
+  },
+  {
+    "id": "PR-530",
+    "name": "アルセーヌ・ルパン",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-530.png",
+    "class": "ロイヤル",
+    "type": "フォロワー",
+    "subtype": "兵士・盗賊",
+    "rarity": "PR",
+    "product_name": "PRカード",
+    "cost": "2",
+    "atk": "2",
+    "hp": "1",
+    "ability_text": "[進化][コスト1]：これは進化する。 [ファンファーレ]相手プレイヤーすべては、自身のデッキの上1枚を墓場に置く。墓場に置いたカードの中にフォロワーがあるなら、自分は『黄金の小剣』1枚をEXエリアに置く。墓場に置いたカードの中にスペルやアミュレットがあるなら、自分は『黄金の杯』1枚をEXエリアに置く。",
+    "related_cards": [
+      {
+        "id": "BP15-T01",
+        "name": "黄金の小剣"
+      },
+      {
+        "id": "BP15-T02",
+        "name": "黄金の杯"
+      },
+      {
+        "id": "PR-531",
+        "name": "アルセーヌ・ルパン"
+      }
+    ],
+    "card_kind_normalized": "follower",
+    "deck_section": "main",
+    "is_token": false,
+    "is_evolve_card": false,
+    "is_deck_build_legal": true
+  },
+  {
+    "id": "PR-531",
+    "name": "アルセーヌ・ルパン",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-531.png",
+    "class": "ロイヤル",
+    "type": "フォロワー・エボルヴ",
+    "subtype": "兵士・盗賊",
+    "rarity": "PR",
+    "product_name": "PRカード",
+    "cost": "-",
+    "atk": "3",
+    "hp": "2",
+    "ability_text": "【進化時】自分のデッキの上4枚を見る。その中から、盗賊・カード1枚を公開して手札に加えてよい。残りを好きな順にデッキの下に置く。",
+    "related_cards": [
+      {
+        "id": "PR-530",
+        "name": "アルセーヌ・ルパン"
+      }
+    ],
+    "card_kind_normalized": "evolve_follower",
+    "deck_section": "evolve",
+    "is_token": false,
+    "is_evolve_card": true,
+    "is_deck_build_legal": true
+  },
+  {
+    "id": "PR-532",
+    "name": "ファイアーチェイン",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-532.png",
+    "class": "ウィッチ",
+    "type": "スペル",
+    "subtype": "魔法使い",
+    "rarity": "PR",
+    "product_name": "PRカード",
+    "cost": "2",
+    "atk": "-",
+    "hp": "-",
+    "ability_text": "[クイック] 相手の場のフォロワー2体まで選ぶ。それに3ダメージを割りふる。",
+    "card_kind_normalized": "spell",
+    "deck_section": "main",
+    "is_token": false,
+    "is_evolve_card": false,
+    "is_deck_build_legal": true
+  },
+  {
+    "id": "PR-533",
+    "name": "ドラゴニックコール",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-533.png",
+    "class": "ドラゴン",
+    "type": "スペル",
+    "subtype": "竜族",
+    "rarity": "PR",
+    "product_name": "PRカード",
+    "cost": "2",
+    "atk": "-",
+    "hp": "-",
+    "ability_text": "[クイック] 自分のデッキの上5枚を見る。その中から、元のコスト7以上の[ドラゴン]カード2枚まで公開して手札に加えてよい。残りを好きな順にデッキの下に置く。",
+    "card_kind_normalized": "spell",
+    "deck_section": "main",
+    "is_token": false,
+    "is_evolve_card": false,
+    "is_deck_build_legal": true
+  },
+  {
+    "id": "PR-534",
+    "name": "パルクールウルフ",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-534.png",
+    "class": "ナイトメア",
+    "type": "フォロワー",
+    "subtype": "魔界・獣",
+    "rarity": "PR",
+    "product_name": "PRカード",
+    "cost": "4",
+    "atk": "4",
+    "hp": "4",
+    "ability_text": "これは能力ダメージを受けない。 【攻撃時】相手のリーダーすべてに2ダメージ。自分のリーダーは[体力]+2する。 [起動][コスト2]：これは【疾走】を持つ。",
+    "card_kind_normalized": "follower",
+    "deck_section": "main",
+    "is_token": false,
+    "is_evolve_card": false,
+    "is_deck_build_legal": true
+  },
+  {
+    "id": "PR-535",
+    "name": "加虐の独房",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-535.png",
+    "class": "ナイトメア",
+    "type": "アミュレット",
+    "subtype": "魔界",
+    "rarity": "PR",
+    "product_name": "PRカード",
+    "cost": "2",
+    "atk": "-",
+    "hp": "-",
+    "ability_text": "[ファンファーレ]これに加虐カウンター2個を置く。1枚引く。 [起動]これを[アクト]これの加虐カウンター1個を取る：自分のリーダーに1ダメージ。これに加虐カウンターが置かれていないなら、これを墓場に置く。",
+    "card_kind_normalized": "amulet",
+    "deck_section": "main",
+    "is_token": false,
+    "is_evolve_card": false,
+    "is_deck_build_legal": true
+  },
+  {
+    "id": "PR-536",
+    "name": "伝道の司祭・ロレーナ",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-536.png",
+    "class": "ビショップ",
+    "type": "フォロワー",
+    "subtype": "信仰",
+    "rarity": "PR",
+    "product_name": "PRカード",
+    "cost": "4",
+    "atk": "3",
+    "hp": "3",
+    "ability_text": "[進化][コスト1]：これは進化する。 [ファンファーレ]自分のリーダーは[体力]+4する。",
+    "related_cards": [
+      {
+        "id": "PR-537",
+        "name": "伝道の司祭・ロレーナ"
+      }
+    ],
+    "card_kind_normalized": "follower",
+    "deck_section": "main",
+    "is_token": false,
+    "is_evolve_card": false,
+    "is_deck_build_legal": true
+  },
+  {
+    "id": "PR-537",
+    "name": "伝道の司祭・ロレーナ",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-537.png",
+    "class": "ビショップ",
+    "type": "フォロワー・エボルヴ",
+    "subtype": "信仰",
+    "rarity": "PR",
+    "product_name": "PRカード",
+    "cost": "-",
+    "atk": "4",
+    "hp": "4",
+    "ability_text": "【進化時】相手の場のフォロワー1体を選ぶ。それに「これの攻撃力」と同じダメージ。",
+    "related_cards": [
+      {
+        "id": "PR-536",
+        "name": "伝道の司祭・ロレーナ"
+      }
+    ],
+    "card_kind_normalized": "evolve_follower",
+    "deck_section": "evolve",
+    "is_token": false,
+    "is_evolve_card": true,
+    "is_deck_build_legal": true
+  },
+  {
+    "id": "PR-538",
+    "name": "溶鉄の腹心",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-538.png",
+    "class": "ニュートラル",
+    "type": "フォロワー",
+    "subtype": "八獄・超克",
+    "rarity": "PR",
+    "product_name": "PRカード",
+    "cost": "2",
+    "atk": "3",
+    "hp": "2",
+    "ability_text": "[ファンファーレ]1枚引く。自分の場か自分の墓場に「カード名に『カットスロート』を含むフォロワー」があるなら、自分のPPを2回復する。",
+    "related_cards": [
+      {
+        "id": "BP19-110",
+        "name": "機鋒の咎人・カットスロート"
+      },
+      {
+        "id": "BP19-111",
+        "name": "機鋒の咎人・カットスロート"
+      }
+    ],
+    "card_kind_normalized": "follower",
+    "deck_section": "main",
+    "is_token": false,
+    "is_evolve_card": false,
+    "is_deck_build_legal": true
+  },
+  {
+    "id": "PR-539",
+    "name": "迸る光明・アポロン",
+    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/PR/PR-539.png",
+    "class": "ニュートラル",
+    "type": "フォロワー・エボルヴ",
+    "subtype": "大神",
+    "rarity": "PR",
+    "product_name": "PRカード",
+    "cost": "-",
+    "atk": "4",
+    "hp": "4",
+    "ability_text": "【進化時】相手のリーダーすべてと相手の場のフォロワーすべてに1ダメージ。",
+    "related_cards": [
+      {
+        "id": "PR-508",
+        "name": "迸る光明・アポロン"
+      }
+    ],
+    "card_kind_normalized": "evolve_follower",
+    "deck_section": "evolve",
+    "is_token": false,
+    "is_evolve_card": true,
     "is_deck_build_legal": true
   },
   {

--- a/scrape_details.py
+++ b/scrape_details.py
@@ -11,11 +11,35 @@ from card_metadata import derive_card_metadata
 
 
 DETAIL_URL_TEMPLATE = "https://shadowverse-evolve.com/cardlist/?cardno={card_id}&view=text"
+CARD_SITE_ORIGIN = "https://shadowverse-evolve.com"
 INPUT_PATH = "public/cards.json"
 OUTPUT_PATH = "public/cards_detailed.json"
 BATCH_SIZE = 50
 MAX_RETRIES = 3
 RECOVERY_PASSES = 3
+
+CARD_FIELD_ORDER = [
+    "id",
+    "name",
+    "image",
+    "class",
+    "title",
+    "type",
+    "subtype",
+    "rarity",
+    "product_name",
+    "cost",
+    "atk",
+    "hp",
+    "ability_text",
+    "related_cards",
+    "faces",
+    "card_kind_normalized",
+    "deck_section",
+    "is_token",
+    "is_evolve_card",
+    "is_deck_build_legal",
+]
 
 HEADERS = {
     "User-Agent": "Mozilla/5.0",
@@ -42,6 +66,14 @@ def first_nonempty_text(*values: Optional[str]) -> Optional[str]:
 
 def has_core_details(card: dict) -> bool:
     return all(field in card for field in ("class", "type", "subtype", "cost", "atk", "hp"))
+
+
+def order_card_fields(card: dict) -> dict:
+    ordered = {key: card[key] for key in CARD_FIELD_ORDER if key in card}
+    for key, value in card.items():
+        if key not in ordered:
+            ordered[key] = value
+    return ordered
 
 
 def extract_detail_text(detail_html: str) -> str:
@@ -95,45 +127,120 @@ def extract_related_cards(soup: BeautifulSoup) -> list[dict[str, str]]:
     return related_cards
 
 
+def detail_side_name(index: int) -> str:
+    if index == 0:
+        return "front"
+    if index == 1:
+        return "back"
+    return f"face_{index + 1}"
+
+
+def extract_info_fields(container: BeautifulSoup) -> dict:
+    fields = {}
+    info_div = container.select_one(".info")
+    if not info_div:
+        return fields
+
+    for dl in info_div.select("dl"):
+        dt = clean_text(dl.select_one("dt").get_text()) if dl.select_one("dt") else ""
+        dd = clean_text(dl.select_one("dd").get_text()) if dl.select_one("dd") else ""
+        if dt == "クラス":
+            fields["class"] = dd
+        elif dt == "タイトル":
+            fields["title"] = dd
+        elif dt == "カード種類":
+            fields["type"] = dd
+        elif dt == "タイプ":
+            fields["subtype"] = dd
+        elif dt == "レアリティ":
+            fields["rarity"] = dd
+        elif dt == "収録商品":
+            fields["product_name"] = dd
+
+    return fields
+
+
+def extract_status_fields(container: BeautifulSoup) -> dict:
+    fields = {}
+    status_div = container.select_one(".status")
+    if not status_div:
+        return fields
+
+    cost = status_div.select_one(".status-Item-Cost")
+    atk = status_div.select_one(".status-Item-Power")
+    hp = status_div.select_one(".status-Item-Hp")
+    if cost:
+        fields["cost"] = clean_text(cost.get_text().replace("コスト", ""))
+    if atk:
+        fields["atk"] = clean_text(atk.get_text().replace("攻撃力", ""))
+    if hp:
+        fields["hp"] = clean_text(hp.get_text().replace("体力", ""))
+
+    return fields
+
+
+def extract_image_url(container: BeautifulSoup) -> Optional[str]:
+    image = container.select_one(".img img")
+    if not image:
+        image = container.select_one('img[src*="/cardlist/"]')
+    if not image:
+        return None
+
+    image_src = image.get("src")
+    if not image_src:
+        return None
+
+    return urllib.parse.urljoin(CARD_SITE_ORIGIN, image_src)
+
+
+def parse_card_face(container: BeautifulSoup, side: str) -> dict:
+    face = {"side": side}
+
+    image = container.select_one(".img img")
+    title = container.select_one(".ttl")
+    name = first_nonempty_text(
+        title.get_text(" ", strip=True) if title else None,
+        image.get("alt") if image else None,
+        image.get("title") if image else None,
+    )
+    if name:
+        face["name"] = name
+
+    image_url = extract_image_url(container)
+    if image_url:
+        face["image"] = image_url
+
+    face.update(extract_info_fields(container))
+    face.update(extract_status_fields(container))
+
+    detail_div = container.select_one(".detail")
+    if detail_div:
+        detail_text = extract_detail_text(detail_div.decode_contents())
+        if detail_text:
+            face["ability_text"] = detail_text
+
+    return derive_card_metadata(face)
+
+
 def parse_card_detail_html(card: dict, html: str) -> dict:
     updated_card = dict(card)
     soup = BeautifulSoup(html, "html.parser")
 
-    info_div = soup.select_one(".info")
-    if info_div:
-        for dl in info_div.select("dl"):
-            dt = clean_text(dl.select_one("dt").get_text()) if dl.select_one("dt") else ""
-            dd = clean_text(dl.select_one("dd").get_text()) if dl.select_one("dd") else ""
-            if dt == "クラス":
-                updated_card["class"] = dd
-            elif dt == "タイトル":
-                updated_card["title"] = dd
-            elif dt == "カード種類":
-                updated_card["type"] = dd
-            elif dt == "タイプ":
-                updated_card["subtype"] = dd
-            elif dt == "レアリティ":
-                updated_card["rarity"] = dd
-            elif dt == "収録商品":
-                updated_card["product_name"] = dd
+    face_nodes = soup.select(".cardlist-Detail_Box_Inner") or [soup]
+    faces = [
+        parse_card_face(face_node, detail_side_name(index))
+        for index, face_node in enumerate(face_nodes)
+    ]
 
-    status_div = soup.select_one(".status")
-    if status_div:
-        cost = status_div.select_one(".status-Item-Cost")
-        atk = status_div.select_one(".status-Item-Power")
-        hp = status_div.select_one(".status-Item-Hp")
-        if cost:
-            updated_card["cost"] = clean_text(cost.get_text().replace("コスト", ""))
-        if atk:
-            updated_card["atk"] = clean_text(atk.get_text().replace("攻撃力", ""))
-        if hp:
-            updated_card["hp"] = clean_text(hp.get_text().replace("体力", ""))
+    primary_face = faces[0] if faces else {}
+    for key, value in primary_face.items():
+        if key != "side":
+            updated_card[key] = value
 
-    detail_div = soup.select_one(".detail")
-    if detail_div:
-        detail_text = extract_detail_text(detail_div.decode_contents())
-        if detail_text:
-            updated_card["ability_text"] = detail_text
+    if len(faces) > 1:
+        updated_card["faces"] = faces
+    else:
+        updated_card.pop("faces", None)
 
     related_cards = extract_related_cards(soup)
     if related_cards:
@@ -141,7 +248,7 @@ def parse_card_detail_html(card: dict, html: str) -> dict:
     else:
         updated_card.pop("related_cards", None)
 
-    return derive_card_metadata(updated_card)
+    return order_card_fields(derive_card_metadata(updated_card))
 
 
 async def fetch_html(session: aiohttp.ClientSession, url: str) -> Optional[str]:
@@ -194,7 +301,7 @@ async def main() -> None:
                 cards[index] = await fetch_card_detail(session, cards[index])
             await asyncio.sleep(0.2)
 
-    cards = [derive_card_metadata(card) for card in cards]
+    cards = [order_card_fields(derive_card_metadata(card)) for card in cards]
 
     with open(OUTPUT_PATH, "w", encoding="utf-8") as f:
         json.dump(cards, f, ensure_ascii=False, indent=2)

--- a/scrape_details_test.py
+++ b/scrape_details_test.py
@@ -54,6 +54,50 @@ RELATION_ONLY_HTML = """
 </div>
 """
 
+DOUBLE_FACED_DETAIL_HTML = """
+<div class="cardlist-Detail">
+  <div class="cardlist-Detail_Box">
+    <div class="cardlist-Detail_Box_Inner">
+      <div class="img w100"><img src="/wordpress/wp-content/images/cardlist/BP08/bp08-003_front.png" alt="決意の人形・オーキス" /></div>
+      <div class="txt">
+        <h1 class="ttl Sans">決意の人形・オーキス</h1>
+        <div class="info">
+          <dl><dt>クラス</dt><dd>エルフ</dd></dl>
+          <dl><dt>カード種類</dt><dd>フォロワー・エボルヴ</dd></dl>
+          <dl><dt>タイプ</dt><dd>人形・光輝</dd></dl>
+          <dl><dt>レアリティ</dt><dd>LG</dd></dl>
+          <dl><dt>収録商品</dt><dd>ブースターパック第8弾「次元混沌」</dd></dl>
+        </div>
+        <div class="status">
+          <span class="status-Item-Cost">コスト-</span>
+          <span class="status-Item-Power">攻撃力3</span>
+          <span class="status-Item-Hp">体力3</span>
+        </div>
+        <div class="detail"><p>表面テキスト<br />【進化時】表面能力。</p></div>
+      </div>
+    </div>
+    <div class="cardlist-Detail_Box_Inner">
+      <div class="img w100"><img src="/wordpress/wp-content/images/cardlist/BP08/bp08-003_back.png" alt="復讐の人形・オーキス" /></div>
+      <div class="txt">
+        <h1 class="ttl Sans">復讐の人形・オーキス</h1>
+        <div class="info">
+          <dl><dt>クラス</dt><dd>エルフ</dd></dl>
+          <dl><dt>カード種類</dt><dd>フォロワー・エボルヴ</dd></dl>
+          <dl><dt>タイプ</dt><dd>人形・キラー</dd></dl>
+          <dl><dt>レアリティ</dt><dd>LG</dd></dl>
+        </div>
+        <div class="status">
+          <span class="status-Item-Cost">コスト-</span>
+          <span class="status-Item-Power">攻撃力4</span>
+          <span class="status-Item-Hp">体力4</span>
+        </div>
+        <div class="detail"><p>裏面テキスト<br />【進化時】裏面能力。</p></div>
+      </div>
+    </div>
+  </div>
+</div>
+"""
+
 
 class ScrapeDetailsTest(unittest.TestCase):
     def test_parse_card_detail_html_adds_related_cards_without_dropping_existing_fields(self) -> None:
@@ -85,6 +129,10 @@ class ScrapeDetailsTest(unittest.TestCase):
                 {"id": "BP02-009", "name": "クリスタリア・リリィ"},
                 {"id": "BP02-T01", "name": "フェアリー"},
             ],
+        )
+        self.assertLess(
+            list(updated.keys()).index("related_cards"),
+            list(updated.keys()).index("card_kind_normalized"),
         )
         self.assertEqual(updated["card_kind_normalized"], "follower")
         self.assertEqual(updated["deck_section"], "main")
@@ -122,6 +170,64 @@ class ScrapeDetailsTest(unittest.TestCase):
         self.assertEqual(updated["hp"], "4")
         self.assertEqual(updated["card_kind_normalized"], "evolve_follower")
         self.assertEqual(updated["deck_section"], "evolve")
+
+    def test_parse_card_detail_html_adds_double_faced_card_faces_without_changing_front_fields(self) -> None:
+        card = {
+            "id": "BP08-003",
+            "name": "決意の人形・オーキス",
+            "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP08/bp08-003_front.png",
+        }
+
+        updated = parse_card_detail_html(card, DOUBLE_FACED_DETAIL_HTML)
+
+        self.assertEqual(updated["name"], "決意の人形・オーキス")
+        self.assertEqual(updated["image"], "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP08/bp08-003_front.png")
+        self.assertEqual(updated["subtype"], "人形・光輝")
+        self.assertEqual(updated["atk"], "3")
+        self.assertEqual(updated["hp"], "3")
+        self.assertEqual(updated["ability_text"], "表面テキスト 【進化時】表面能力。")
+        self.assertEqual(
+            updated["faces"],
+            [
+                {
+                    "side": "front",
+                    "name": "決意の人形・オーキス",
+                    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP08/bp08-003_front.png",
+                    "class": "エルフ",
+                    "type": "フォロワー・エボルヴ",
+                    "subtype": "人形・光輝",
+                    "rarity": "LG",
+                    "product_name": "ブースターパック第8弾「次元混沌」",
+                    "cost": "-",
+                    "atk": "3",
+                    "hp": "3",
+                    "ability_text": "表面テキスト 【進化時】表面能力。",
+                    "card_kind_normalized": "evolve_follower",
+                    "deck_section": "evolve",
+                    "is_token": False,
+                    "is_evolve_card": True,
+                    "is_deck_build_legal": True,
+                },
+                {
+                    "side": "back",
+                    "name": "復讐の人形・オーキス",
+                    "image": "https://shadowverse-evolve.com/wordpress/wp-content/images/cardlist/BP08/bp08-003_back.png",
+                    "class": "エルフ",
+                    "type": "フォロワー・エボルヴ",
+                    "subtype": "人形・キラー",
+                    "rarity": "LG",
+                    "cost": "-",
+                    "atk": "4",
+                    "hp": "4",
+                    "ability_text": "裏面テキスト 【進化時】裏面能力。",
+                    "card_kind_normalized": "evolve_follower",
+                    "deck_section": "evolve",
+                    "is_token": False,
+                    "is_evolve_card": True,
+                    "is_deck_build_legal": True,
+                },
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/src/components/Card.test.tsx
+++ b/src/components/Card.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import Card, { type CardInstance } from './Card';
 import GameBoardInputProfileProvider from '../contexts/GameBoardInputProfileProvider';
+import type { CardDetail } from '../utils/cardDetails';
 
 const dndState = {
   transform: null as null | { x: number; y: number },
@@ -65,6 +66,71 @@ describe('Card', () => {
 
     rerender(<Card card={createCard({ isFlipped: true })} />);
     expect(screen.getByAltText('Card Back')).toBeInTheDocument();
+  });
+
+  it('uses the selected face image only while the card is visible', () => {
+    const detail: CardDetail = {
+      id: 'BP08-003',
+      name: 'Front Face',
+      image: '/front.png',
+      className: 'エルフ',
+      title: '',
+      type: 'フォロワー・エボルヴ',
+      subtype: '人形・光輝',
+      cardKindNormalized: 'evolve_follower',
+      cost: '-',
+      atk: 3,
+      hp: 3,
+      abilityText: '',
+      faces: [
+        {
+          side: 'front',
+          name: 'Front Face',
+          image: '/front.png',
+          className: 'エルフ',
+          title: '',
+          type: 'フォロワー・エボルヴ',
+          subtype: '人形・光輝',
+          cardKindNormalized: 'evolve_follower',
+          cost: '-',
+          atk: 3,
+          hp: 3,
+          abilityText: '',
+        },
+        {
+          side: 'back',
+          name: 'Back Face',
+          image: '/back.png',
+          className: 'エルフ',
+          title: '',
+          type: 'フォロワー・エボルヴ',
+          subtype: '人形・キラー',
+          cardKindNormalized: 'evolve_follower',
+          cost: '-',
+          atk: 4,
+          hp: 4,
+          abilityText: '',
+        },
+      ],
+    };
+
+    const { rerender } = render(
+      <Card
+        card={createCard({ cardId: 'BP08-003', selectedFaceSide: 'back' })}
+        detail={detail}
+      />
+    );
+
+    expect(screen.getByAltText('Test Card')).toHaveAttribute('src', '/back.png');
+
+    rerender(
+      <Card
+        card={createCard({ cardId: 'BP08-003', selectedFaceSide: 'back', isFlipped: true })}
+        detail={detail}
+      />
+    );
+
+    expect(screen.getByAltText('Card Back')).toHaveAttribute('src', '/card_back.png');
   });
 
   it('fires quick actions for visible unlocked cards', () => {

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import type { BaseCardStats } from '../utils/cardStats';
 import { isMainDeckSpellCard, type RuntimeBaseCardType } from '../utils/cardType';
-import type { CardDetail } from '../utils/cardDetails';
+import { resolveSelectedCardFaceDetail, type CardDetail, type CardFaceSide } from '../utils/cardDetails';
 import CardArtwork from './CardArtwork';
 import { useGameBoardBoardDensity, useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 import { getCardSizeForInputProfile } from '../utils/gameBoardCardLayout';
@@ -27,6 +27,7 @@ export interface CardInstance {
   isTokenCard?: boolean;
   baseCardType?: RuntimeBaseCardType | null;
   cardKindNormalized?: string;
+  selectedFaceSide?: CardFaceSide;
 }
 
 export interface CardInspectAnchor {
@@ -46,7 +47,7 @@ export interface CardTapAnchor {
 interface Props {
   card: CardInstance;
   baseStats?: BaseCardStats;
-  detail?: Pick<CardDetail, 'name' | 'cost' | 'atk' | 'hp' | 'type' | 'image'>;
+  detail?: CardDetail;
   displayCounters?: { atk: number; hp: number };
   hideCurrentStats?: boolean;
   highlightTone?: 'attack-source' | 'attack-target';
@@ -237,7 +238,8 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
   }
 
   const isStatDisplayZone = card.zone.startsWith('field-') || card.zone.startsWith('ex-');
-  const resolvedImage = detail?.image || card.image;
+  const displayDetail = resolveSelectedCardFaceDetail(detail, card.selectedFaceSide) ?? undefined;
+  const resolvedImage = displayDetail?.image || card.image;
   const effectiveDisplayCounters = displayCounters ?? card.counters;
   const genericCounterValue = card.genericCounter ?? 0;
   const isNormalSpellPlay = isMainDeckSpellCard(card);
@@ -410,7 +412,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
           image={resolvedImage}
           alt={card.name}
           isBack={true}
-          detail={detail}
+          detail={displayDetail}
           baseCardType={card.baseCardType}
           isLeaderCard={card.isLeaderCard}
           isTokenCard={card.isTokenCard}
@@ -423,7 +425,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
           <CardArtwork
             image={resolvedImage}
             alt={card.name}
-            detail={detail}
+            detail={displayDetail}
             baseCardType={card.baseCardType}
             isLeaderCard={card.isLeaderCard}
             isTokenCard={card.isTokenCard}

--- a/src/components/CardSearchModal.test.tsx
+++ b/src/components/CardSearchModal.test.tsx
@@ -490,6 +490,116 @@ describe('CardSearchModal', () => {
     expect(onToggleFlip).toHaveBeenCalledWith('card-1');
   });
 
+  it('fires selected face changes for editable double-faced evolve cards', () => {
+    const onSetCardFace = vi.fn();
+    render(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="My Evolve Deck"
+        zoneId="evolveDeck-host"
+        cards={[createCard({ cardId: 'BP08-003', isEvolveCard: true, zone: 'evolveDeck-host', selectedFaceSide: 'front' })]}
+        cardDetailLookup={{
+          'BP08-003': {
+            id: 'BP08-003',
+            name: '決意の人形・オーキス',
+            image: '/front.png',
+            className: 'エルフ',
+            title: '',
+            type: 'フォロワー・エボルヴ',
+            subtype: '人形・光輝',
+            cardKindNormalized: 'evolve_follower',
+            cost: '-',
+            atk: 3,
+            hp: 3,
+            abilityText: 'Front ability',
+            faces: [
+              {
+                side: 'front',
+                name: '決意の人形・オーキス',
+                image: '/front.png',
+                className: 'エルフ',
+                title: '',
+                type: 'フォロワー・エボルヴ',
+                subtype: '人形・光輝',
+                cardKindNormalized: 'evolve_follower',
+                cost: '-',
+                atk: 3,
+                hp: 3,
+                abilityText: 'Front ability',
+              },
+              {
+                side: 'back',
+                name: '復讐の人形・オーキス',
+                image: '/back.png',
+                className: 'エルフ',
+                title: '',
+                type: 'フォロワー・エボルヴ',
+                subtype: '人形・キラー',
+                cardKindNormalized: 'evolve_follower',
+                cost: '-',
+                atk: 4,
+                hp: 4,
+                abilityText: 'Back ability',
+              },
+            ],
+          },
+        }}
+        onExtractCard={vi.fn()}
+        onSetCardFace={onSetCardFace}
+        canEditSearchedEvolveDeck={true}
+        viewerRole="host"
+        targetRole="host"
+        allowHandExtraction={false}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Front' })).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(onSetCardFace).toHaveBeenCalledWith('card-1', 'back');
+  });
+
+  it('hides selected face controls when the searched evolve deck is not editable', () => {
+    render(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Opponent Evolve Deck"
+        zoneId="evolveDeck-guest"
+        cards={[createCard({ cardId: 'BP08-003', owner: 'guest', isEvolveCard: true, zone: 'evolveDeck-guest' })]}
+        cardDetailLookup={{
+          'BP08-003': {
+            id: 'BP08-003',
+            name: '決意の人形・オーキス',
+            image: '/front.png',
+            className: 'エルフ',
+            title: '',
+            type: 'フォロワー・エボルヴ',
+            subtype: '人形・光輝',
+            cardKindNormalized: 'evolve_follower',
+            cost: '-',
+            atk: 3,
+            hp: 3,
+            abilityText: '',
+            faces: [
+              { side: 'front', name: 'Front', image: '/front.png', className: '', title: '', type: '', subtype: '', cardKindNormalized: '', cost: '-', atk: 3, hp: 3, abilityText: '' },
+              { side: 'back', name: 'Back', image: '/back.png', className: '', title: '', type: '', subtype: '', cardKindNormalized: '', cost: '-', atk: 4, hp: 4, abilityText: '' },
+            ],
+          },
+        }}
+        onExtractCard={vi.fn()}
+        onSetCardFace={vi.fn()}
+        canEditSearchedEvolveDeck={false}
+        viewerRole="guest"
+        targetRole="guest"
+        allowHandExtraction={false}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Front' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
+  });
+
   it('hides action controls in read-only mode', () => {
     render(
       <CardSearchModal
@@ -591,6 +701,80 @@ describe('CardSearchModal', () => {
     fireEvent.click(screen.getByAltText('First Card'));
     expect(screen.getByTestId('search-card-detail-popover')).toHaveTextContent('Sample ability text');
     expect(screen.getByTestId('search-card-grid')).toHaveStyle({ paddingBottom: '1.5rem' });
+  });
+
+  it('shows both faces in the detail popover for double-faced cards', () => {
+    render(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Evolve Deck"
+        zoneId="evolveDeck-host"
+        cards={[createCard({ cardId: 'BP08-003', name: '決意の人形・オーキス', isEvolveCard: true, zone: 'evolveDeck-host' })]}
+        cardDetailLookup={{
+          'BP08-003': {
+            id: 'BP08-003',
+            name: '決意の人形・オーキス',
+            image: '/front.png',
+            className: 'エルフ',
+            title: '',
+            type: 'フォロワー・エボルヴ',
+            subtype: '人形・光輝',
+            cardKindNormalized: 'evolve_follower',
+            cost: '-',
+            atk: 3,
+            hp: 3,
+            abilityText: 'Front ability',
+            faces: [
+              {
+                side: 'front',
+                name: '決意の人形・オーキス',
+                image: '/front.png',
+                className: 'エルフ',
+                title: '',
+                type: 'フォロワー・エボルヴ',
+                subtype: '人形・光輝',
+                cardKindNormalized: 'evolve_follower',
+                cost: '-',
+                atk: 3,
+                hp: 3,
+                abilityText: 'Front face ability',
+              },
+              {
+                side: 'back',
+                name: '復讐の人形・オーキス',
+                image: '/back.png',
+                className: 'エルフ',
+                title: '',
+                type: 'フォロワー・エボルヴ',
+                subtype: '人形・キラー',
+                cardKindNormalized: 'evolve_follower',
+                cost: '-',
+                atk: 4,
+                hp: 4,
+                abilityText: 'Back face ability',
+              },
+            ],
+          },
+        }}
+        onExtractCard={vi.fn()}
+        viewerRole="host"
+      />
+    );
+
+    fireEvent.click(screen.getByAltText('決意の人形・オーキス'));
+
+    const popover = screen.getByTestId('search-card-detail-popover');
+    expect(popover).toHaveTextContent('Front');
+    expect(popover).toHaveTextContent('Back');
+    expect(popover).toHaveTextContent('決意の人形・オーキス');
+    expect(popover).toHaveTextContent('復讐の人形・オーキス');
+    expect(popover).toHaveTextContent('人形・光輝');
+    expect(popover).toHaveTextContent('人形・キラー');
+    expect(popover).toHaveTextContent('3 / 3');
+    expect(popover).toHaveTextContent('4 / 4');
+    expect(popover).toHaveTextContent('Front face ability');
+    expect(popover).toHaveTextContent('Back face ability');
   });
 
   it('only reserves extra bottom space for the detail popover when the grid overflows', () => {

--- a/src/components/CardSearchModal.tsx
+++ b/src/components/CardSearchModal.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import type { CardInstance } from './Card';
 import type { PlayerRole } from '../types/game';
-import { formatAbilityText, type CardDetailLookup } from '../utils/cardDetails';
+import { formatAbilityText, resolveSelectedCardFaceDetail, type CardDetailLookup, type CardFaceSide } from '../utils/cardDetails';
 import { normalizeBaseCardType, type RuntimeBaseCardType } from '../utils/cardType';
 import CardArtwork from './CardArtwork';
+import GameBoardCardFacePreview from './GameBoardCardFacePreview';
 import { useTranslation } from 'react-i18next';
 import { useGameBoardInputProfile } from '../contexts/gameBoardInputProfileContext';
 
@@ -22,6 +23,8 @@ interface CardSearchModalProps {
   onBanish?: (cardId: string) => void;
   onBanishCards?: (cardIds: string[]) => void;
   onToggleFlip?: (cardId: string) => void;
+  onSetCardFace?: (cardId: string, faceSide: CardFaceSide) => void;
+  canEditSearchedEvolveDeck?: boolean;
   viewerRole?: PlayerRole;
   targetRole?: PlayerRole;
   zoneId?: string;
@@ -73,6 +76,8 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
   onBanish,
   onBanishCards,
   onToggleFlip,
+  onSetCardFace,
+  canEditSearchedEvolveDeck = false,
   viewerRole,
   targetRole,
   zoneId,
@@ -215,7 +220,9 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
   const actionRole = targetRole ?? viewerRole;
   const bulkSelectedCards = cards.filter(card => bulkSelectedCardIds.includes(card.id));
   const selectedCard = selectedCardId ? cards.find(card => card.id === selectedCardId) ?? null : null;
-  const selectedCardDetail = selectedCard ? cardDetailLookup[selectedCard.cardId] : null;
+  const selectedCardDetail = selectedCard
+    ? resolveSelectedCardFaceDetail(cardDetailLookup[selectedCard.cardId], selectedCard.selectedFaceSide)
+    : null;
   const selectedCardMeta = [
     selectedCardDetail?.className,
     selectedCardDetail?.title
@@ -227,6 +234,7 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
   const selectedCardStats = selectedCardDetail && selectedCardDetail.atk !== null && selectedCardDetail.hp !== null
     ? `${selectedCardDetail.atk} / ${selectedCardDetail.hp}`
     : null;
+  const selectedCardHasFaces = Boolean(selectedCardDetail?.faces && selectedCardDetail.faces.length > 1);
 
   const canAddCardToHand = (card: CardInstance) => (
     !isPreparingMainDeckSearch && card.owner === viewerRole && !card.isEvolveCard
@@ -520,6 +528,11 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
           }}
         >
           {visibleCards.map(c => {
+            const baseCardDetail = cardDetailLookup[c.cardId];
+            const cardDisplayDetail = resolveSelectedCardFaceDetail(baseCardDetail, c.selectedFaceSide) ?? undefined;
+            const hasSelectableFaces = Boolean(baseCardDetail?.faces && baseCardDetail.faces.length > 1);
+            const selectedFaceSide = c.selectedFaceSide ?? 'front';
+            const canSetCardFace = Boolean(onSetCardFace && canEditSearchedEvolveDeck && c.isEvolveCard && c.owner === targetRole && hasSelectableFaces);
             const isUsed = isEvolveDeck && !c.isFlipped;
             const canAddToHand = canAddCardToHand(c);
             const canRevealToHand = canRevealCardToHand(c);
@@ -552,9 +565,9 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
                 }}
               >
                 <CardArtwork
-                  image={c.image}
+                  image={cardDisplayDetail?.image || c.image}
                   alt={c.name}
-                  detail={cardDetailLookup[c.cardId]}
+                  detail={cardDisplayDetail}
                   baseCardType={c.baseCardType}
                   isLeaderCard={c.isLeaderCard}
                   isTokenCard={c.isTokenCard}
@@ -736,6 +749,44 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
                         {c.isFlipped ? t('gameBoard.modals.search.setUsed') : t('gameBoard.modals.search.setUnused')}
                       </button>
                     )}
+                    {canSetCardFace && (
+                      <div
+                        style={{
+                          width: '100%',
+                          display: 'grid',
+                          gridTemplateColumns: '1fr 1fr',
+                          gap: '3px',
+                          marginTop: '2px',
+                        }}
+                      >
+                        {(['front', 'back'] as const).map((faceSide) => {
+                          const isSelected = selectedFaceSide === faceSide;
+                          return (
+                            <button
+                              key={faceSide}
+                              type="button"
+                              aria-pressed={isSelected}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                onSetCardFace?.(c.id, faceSide);
+                              }}
+                              style={{
+                                background: isSelected ? '#f59e0b' : '#334155',
+                                color: isSelected ? '#111827' : 'white',
+                                border: isSelected ? '1px solid #fbbf24' : '1px solid #64748b',
+                                padding: '3px',
+                                borderRadius: '4px',
+                                fontSize: '10px',
+                                fontWeight: 'bold',
+                                cursor: 'pointer',
+                              }}
+                            >
+                              {t(`gameBoard.modals.search.face.${faceSide}`)}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
                   </div>
                 )}
               </div>
@@ -887,7 +938,7 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
               right: '1rem',
               bottom: '1rem',
               width: 'min(320px, calc(100% - 2rem))',
-              maxHeight: '190px',
+              maxHeight: selectedCardHasFaces ? '360px' : '190px',
               overflowY: 'auto',
               background: 'rgba(15, 23, 42, 0.98)',
               border: '1px solid rgba(255,255,255,0.12)',
@@ -935,18 +986,26 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
               </button>
             </div>
 
-            <div style={{
-              borderTop: '1px solid rgba(255,255,255,0.08)',
-              paddingTop: '0.5rem',
-              whiteSpace: 'pre-wrap',
-              color: '#e5e7eb',
-              fontSize: '0.74rem',
-              lineHeight: 1.55
-            }}>
-              {selectedCardDetail?.abilityText
-                ? formatAbilityText(selectedCardDetail.abilityText)
-                : t('gameBoard.modals.search.noDetailText')}
-            </div>
+            {selectedCardHasFaces && selectedCardDetail ? (
+              <GameBoardCardFacePreview
+                card={selectedCard}
+                detail={selectedCardDetail}
+                compact={true}
+              />
+            ) : (
+              <div style={{
+                borderTop: '1px solid rgba(255,255,255,0.08)',
+                paddingTop: '0.5rem',
+                whiteSpace: 'pre-wrap',
+                color: '#e5e7eb',
+                fontSize: '0.74rem',
+                lineHeight: 1.55
+              }}>
+                {selectedCardDetail?.abilityText
+                  ? formatAbilityText(selectedCardDetail.abilityText)
+                  : t('gameBoard.modals.search.noDetailText')}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/components/DeckBuilderDialogUi.test.tsx
+++ b/src/components/DeckBuilderDialogUi.test.tsx
@@ -225,6 +225,78 @@ describe('DeckBuilder extracted UI components - dialogs', () => {
     expect(onClose).toHaveBeenCalledTimes(2);
   });
 
+  it('renders both faces in the preview modal for double-faced cards', () => {
+    const onClose = vi.fn();
+    const doubleFacedCard: DeckBuilderCardData = {
+      ...sampleCard,
+      id: 'BP08-003',
+      name: '決意の人形・オーキス',
+      image: '/orchis-front.png',
+      class: 'エルフ',
+      type: 'フォロワー・エボルヴ',
+      subtype: '人形・光輝',
+      cost: '-',
+      atk: '3',
+      hp: '3',
+      card_kind_normalized: 'evolve_follower',
+      deck_section: 'evolve',
+      is_evolve_card: true,
+      faces: [
+        {
+          side: 'front',
+          name: '決意の人形・オーキス',
+          image: '/orchis-front.png',
+          class: 'エルフ',
+          type: 'フォロワー・エボルヴ',
+          subtype: '人形・光輝',
+          cost: '-',
+          atk: '3',
+          hp: '3',
+          ability_text: '表面能力。',
+          card_kind_normalized: 'evolve_follower',
+          deck_section: 'evolve',
+          is_evolve_card: true,
+        },
+        {
+          side: 'back',
+          name: '復讐の人形・オーキス',
+          image: '/orchis-back.png',
+          class: 'エルフ',
+          type: 'フォロワー・エボルヴ',
+          subtype: '人形・キラー',
+          cost: '-',
+          atk: '4',
+          hp: '4',
+          ability_text: '裏面能力。',
+          card_kind_normalized: 'evolve_follower',
+          deck_section: 'evolve',
+          is_evolve_card: true,
+        },
+      ],
+    };
+
+    render(
+      <DeckBuilderPreviewModal
+        previewCard={doubleFacedCard}
+        previewDetail={null}
+        onClose={onClose}
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Card Faces' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Front: 決意の人形・オーキス' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Back: 復讐の人形・オーキス' })).toBeInTheDocument();
+    expect(screen.getAllByText('決意の人形・オーキス')).toHaveLength(2);
+    expect(screen.getByText('復讐の人形・オーキス')).toBeInTheDocument();
+    expect(screen.getAllByText(/人形・光輝/)).toHaveLength(2);
+    expect(screen.getByText(/人形・キラー/)).toBeInTheDocument();
+    expect(screen.getByText('3 / 3')).toBeInTheDocument();
+    expect(screen.getByText('4 / 4')).toBeInTheDocument();
+    expect(screen.getAllByText('Ability Text')).toHaveLength(2);
+    expect(screen.getByText('表面能力。')).toBeInTheDocument();
+    expect(screen.getByText('裏面能力。')).toBeInTheDocument();
+  });
+
   it('renders hover preview content with the expected fixed position', () => {
     const { container } = render(
       <DeckBuilderHoverPreview

--- a/src/components/DeckBuilderPreviewModal.tsx
+++ b/src/components/DeckBuilderPreviewModal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import CardArtwork from './CardArtwork';
 import { getBaseCardType } from '../models/cardClassification';
-import type { DeckBuilderCardData } from '../models/deckBuilderCard';
+import type { CardFaceData, DeckBuilderCardData } from '../models/deckBuilderCard';
 import {
   buildCardDetailPresentation,
   formatAbilityText,
@@ -16,13 +16,114 @@ type DeckBuilderPreviewModalProps = {
   onClose: () => void;
 };
 
+const toCardDetail = (
+  card: DeckBuilderCardData,
+  face?: CardFaceData
+): CardDetail => ({
+  id: card.id,
+  name: face?.name ?? card.name,
+  image: face?.image ?? card.image,
+  className: face?.class ?? card.class ?? '',
+  title: face?.title ?? card.title ?? '',
+  type: face?.type ?? card.type ?? '',
+  subtype: face?.subtype ?? card.subtype ?? '',
+  cardKindNormalized: face?.card_kind_normalized ?? card.card_kind_normalized ?? '',
+  cost: face?.cost ?? card.cost ?? '-',
+  atk: parseNullableStat(face?.atk ?? card.atk),
+  hp: parseNullableStat(face?.hp ?? card.hp),
+  abilityText: face?.ability_text ?? card.ability_text ?? '',
+});
+
+const getFaceLabelKey = (side: string): string => (
+  side === 'front' || side === 'back'
+    ? `deckBuilder.preview.faces.${side}`
+    : side
+);
+
+const getDetailCardKind = (
+  detail: CardDetail,
+  fallbackCard: DeckBuilderCardData
+): string => detail.cardKindNormalized || fallbackCard.card_kind_normalized || '';
+
 const DeckBuilderPreviewModal: React.FC<DeckBuilderPreviewModalProps> = ({
   previewCard,
   previewDetail,
   onClose,
 }) => {
   const { t } = useTranslation();
-  const previewPresentation = buildCardDetailPresentation(previewDetail);
+  const fallbackDetail = toCardDetail(previewCard);
+  const resolvedPreviewDetail = previewDetail ?? fallbackDetail;
+  const previewPresentation = buildCardDetailPresentation(resolvedPreviewDetail);
+  const singlePreviewKind = getDetailCardKind(resolvedPreviewDetail, previewCard);
+  const faceDetails = (previewCard.faces ?? []).length > 1
+    ? previewCard.faces?.map(face => ({
+      face,
+      detail: toCardDetail(previewCard, face),
+      label: t(getFaceLabelKey(face.side)),
+    })) ?? []
+    : [];
+  const hasFaceDetails = faceDetails.length > 1;
+
+  const renderArtworkAndStats = (
+    detail: CardDetail,
+    presentation: ReturnType<typeof buildCardDetailPresentation>,
+    imageAlt: string,
+    cardKind: string,
+    artworkStyle: React.CSSProperties
+  ) => (
+    <div style={{ display: 'flex', gap: '0.8rem', alignItems: 'flex-start', marginBottom: '0.25rem' }}>
+      <CardArtwork
+        image={detail.image || previewCard.image}
+        alt={imageAlt}
+        detail={detail}
+        baseCardType={getBaseCardType(cardKind)}
+        isLeaderCard={cardKind === 'leader'}
+        isTokenCard={cardKind.startsWith('token_') || previewCard.deck_section === 'token' || previewCard.is_token}
+        isEvolveCard={cardKind.startsWith('evolve_') || previewCard.is_evolve_card}
+        style={artworkStyle}
+      />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem', minWidth: 0, flex: 1 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: '56px 1fr', gap: '0.14rem 0.4rem', color: '#e2e8f0', fontSize: '0.76rem' }}>
+          <span style={{ color: '#94a3b8' }}>{t('deckBuilder.preview.id')}</span>
+          <span>{previewCard.id}</span>
+          <span style={{ color: '#94a3b8' }}>{t('deckBuilder.preview.cost')}</span>
+          <span>{detail.cost || previewCard.cost || '-'}</span>
+          {presentation.stats && (
+            <>
+              <span style={{ color: '#94a3b8' }}>{t('deckBuilder.preview.stats')}</span>
+              <span>{presentation.stats}</span>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderAbilityText = (detail: CardDetail, maxHeight: string) => (
+    <div style={{ borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: '0.6rem' }}>
+      <div style={{ color: '#f8fafc', fontWeight: 700, fontSize: '0.82rem', marginBottom: '0.35rem' }}>
+        {t('gameBoard.inspector.abilityText')}
+      </div>
+      <div
+        style={{
+          whiteSpace: 'pre-wrap',
+          color: '#e5e7eb',
+          fontSize: '0.76rem',
+          lineHeight: 1.58,
+          background: 'rgba(15, 23, 42, 0.76)',
+          borderRadius: '10px',
+          padding: '0.65rem',
+          border: '1px solid rgba(255,255,255,0.08)',
+          maxHeight,
+          overflowY: 'auto',
+        }}
+      >
+        {detail.abilityText
+          ? formatAbilityText(detail.abilityText)
+          : t('gameBoard.inspector.noAbilityText')}
+      </div>
+    </div>
+  );
 
   return (
     <div
@@ -47,7 +148,7 @@ const DeckBuilderPreviewModal: React.FC<DeckBuilderPreviewModalProps> = ({
         style={{
           position: 'relative',
           width: '100%',
-          maxWidth: '660px',
+          maxWidth: hasFaceDetails ? '980px' : '660px',
           display: 'flex',
           flexDirection: 'column',
           gap: '0.6rem',
@@ -97,75 +198,93 @@ const DeckBuilderPreviewModal: React.FC<DeckBuilderPreviewModalProps> = ({
           </div>
         </div>
 
-        <div style={{ display: 'flex', gap: '0.8rem', alignItems: 'flex-start', marginBottom: '0.25rem' }}>
-          <CardArtwork
-            image={previewDetail?.image || previewCard.image}
-            alt={t('deckBuilder.preview.enlargedAlt', { name: previewCard.name })}
-            detail={previewDetail ?? {
-              id: previewCard.id,
-              name: previewCard.name,
-              image: previewCard.image,
-              className: previewCard.class ?? '',
-              title: previewCard.title ?? '',
-              type: previewCard.type ?? '',
-              subtype: previewCard.subtype ?? '',
-              cost: previewCard.cost ?? '-',
-              atk: parseNullableStat(previewCard.atk),
-              hp: parseNullableStat(previewCard.hp),
-              abilityText: previewCard.ability_text ?? '',
-            }}
-            baseCardType={getBaseCardType(previewCard.card_kind_normalized)}
-            isLeaderCard={previewCard.deck_section === 'leader'}
-            isTokenCard={previewCard.deck_section === 'token' || previewCard.is_token}
-            isEvolveCard={previewCard.is_evolve_card}
-            style={{
-              width: '160px',
-              maxWidth: '40vw',
-              height: '224px',
-              borderRadius: '10px',
-              boxShadow: '0 8px 20px rgba(0,0,0,0.32)',
-              flexShrink: 0,
-            }}
-          />
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem', minWidth: 0, flex: 1 }}>
-            <div style={{ display: 'grid', gridTemplateColumns: '56px 1fr', gap: '0.14rem 0.4rem', color: '#e2e8f0', fontSize: '0.76rem' }}>
-              <span style={{ color: '#94a3b8' }}>{t('deckBuilder.preview.id')}</span>
-              <span>{previewCard.id}</span>
-              <span style={{ color: '#94a3b8' }}>{t('deckBuilder.preview.cost')}</span>
-              <span>{previewDetail?.cost || previewCard.cost || '-'}</span>
-              {previewPresentation.stats && (
-                <>
-                  <span style={{ color: '#94a3b8' }}>{t('deckBuilder.preview.stats')}</span>
-                  <span>{previewPresentation.stats}</span>
-                </>
-              )}
-            </div>
-          </div>
-        </div>
+        {!hasFaceDetails && renderArtworkAndStats(
+          resolvedPreviewDetail,
+          previewPresentation,
+          t('deckBuilder.preview.enlargedAlt', { name: previewCard.name }),
+          singlePreviewKind,
+          {
+            width: '160px',
+            maxWidth: '40vw',
+            height: '224px',
+            borderRadius: '10px',
+            boxShadow: '0 8px 20px rgba(0,0,0,0.32)',
+            flexShrink: 0,
+          }
+        )}
 
-        <div style={{ borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: '0.6rem' }}>
-          <div style={{ color: '#f8fafc', fontWeight: 700, fontSize: '0.82rem', marginBottom: '0.35rem' }}>
-            {t('gameBoard.inspector.abilityText')}
-          </div>
-          <div
-            style={{
-              whiteSpace: 'pre-wrap',
-              color: '#e5e7eb',
-              fontSize: '0.76rem',
-              lineHeight: 1.58,
-              background: 'rgba(15, 23, 42, 0.76)',
-              borderRadius: '10px',
-              padding: '0.65rem',
-              border: '1px solid rgba(255,255,255,0.08)',
-              maxHeight: '30vh',
-              overflowY: 'auto',
-            }}
-          >
-            {previewDetail?.abilityText
-              ? formatAbilityText(previewDetail.abilityText)
-              : t('gameBoard.inspector.noAbilityText')}
-          </div>
-        </div>
+        {hasFaceDetails && (
+          <section>
+            <h2 style={{ color: '#f8fafc', fontWeight: 800, fontSize: '0.86rem', margin: '0 0 0.55rem' }}>
+              {t('deckBuilder.preview.faces.heading')}
+            </h2>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+                gap: '0.75rem',
+              }}
+            >
+              {faceDetails.map(({ face, detail, label }) => {
+                const facePresentation = buildCardDetailPresentation(detail);
+                const faceKind = getDetailCardKind(detail, previewCard);
+
+                return (
+                  <article
+                    key={`${face.side}:${detail.name}`}
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: '0.6rem',
+                      background: 'rgba(15, 23, 42, 0.72)',
+                      border: '1px solid rgba(255,255,255,0.08)',
+                      borderRadius: '12px',
+                      padding: '0.7rem',
+                    }}
+                  >
+                    <div style={{ minWidth: 0 }}>
+                      <div style={{ color: '#93c5fd', fontSize: '0.7rem', fontWeight: 800, textTransform: 'uppercase', letterSpacing: '0.08em' }}>
+                        {label}
+                      </div>
+                      <div style={{ color: '#f8fafc', fontSize: '0.92rem', fontWeight: 800, marginTop: '0.12rem', lineHeight: 1.35 }}>
+                        {detail.name}
+                      </div>
+                      {facePresentation.primaryMeta && (
+                        <div style={{ color: '#cbd5e1', fontSize: '0.74rem', marginTop: '0.2rem', lineHeight: 1.4 }}>
+                          {facePresentation.primaryMeta}
+                        </div>
+                      )}
+                      {facePresentation.secondaryMeta && (
+                        <div style={{ color: '#94a3b8', fontSize: '0.72rem', marginTop: '0.1rem', lineHeight: 1.4 }}>
+                          {facePresentation.secondaryMeta}
+                        </div>
+                      )}
+                    </div>
+                    {renderArtworkAndStats(
+                      detail,
+                      facePresentation,
+                      t('deckBuilder.preview.faces.imageAlt', { side: label, name: detail.name }),
+                      faceKind,
+                      {
+                        width: '160px',
+                        maxWidth: '40vw',
+                        height: '224px',
+                        borderRadius: '10px',
+                        boxShadow: '0 8px 20px rgba(0,0,0,0.32)',
+                        flexShrink: 0,
+                      }
+                    )}
+                    {renderAbilityText(detail, '22vh')}
+                  </article>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {!hasFaceDetails && (
+          renderAbilityText(resolvedPreviewDetail, '30vh')
+        )}
       </div>
     </div>
   );

--- a/src/components/GameBoardCardFacePreview.tsx
+++ b/src/components/GameBoardCardFacePreview.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import CardArtwork from './CardArtwork';
+import {
+  buildCardDetailPresentation,
+  formatAbilityText,
+  type CardDetail,
+  type CardFaceDetail,
+} from '../utils/cardDetails';
+import type { CardInstance } from './Card';
+
+type GameBoardCardFacePreviewProps = {
+  card: CardInstance;
+  detail: CardDetail;
+  showArtwork?: boolean;
+  compact?: boolean;
+};
+
+const getFaceLabelKey = (side: CardFaceDetail['side']) => (
+  side === 'back' ? 'gameBoard.modals.search.face.back' : 'gameBoard.modals.search.face.front'
+);
+
+const GameBoardCardFacePreview: React.FC<GameBoardCardFacePreviewProps> = ({
+  card,
+  detail,
+  showArtwork = false,
+  compact = false,
+}) => {
+  const { t } = useTranslation();
+  const faces = detail.faces ?? [];
+
+  if (faces.length <= 1) return null;
+
+  return (
+    <div
+      data-testid="game-board-card-face-preview"
+      style={{
+        display: 'grid',
+        gridTemplateColumns: compact ? '1fr' : 'repeat(auto-fit, minmax(210px, 1fr))',
+        gap: compact ? '0.55rem' : '0.75rem',
+      }}
+    >
+      {faces.map(face => {
+        const presentation = buildCardDetailPresentation(face);
+        return (
+          <article
+            key={face.side}
+            style={{
+              background: 'rgba(15, 23, 42, 0.72)',
+              border: '1px solid rgba(255,255,255,0.1)',
+              borderRadius: compact ? '9px' : '12px',
+              padding: compact ? '0.55rem' : '0.7rem',
+              minWidth: 0,
+            }}
+          >
+            <div style={{ display: 'flex', gap: compact ? '0.5rem' : '0.65rem', alignItems: 'flex-start' }}>
+              {showArtwork && (
+                <CardArtwork
+                  image={face.image || card.image}
+                  alt={face.name}
+                  detail={face}
+                  baseCardType={card.baseCardType}
+                  isLeaderCard={card.isLeaderCard}
+                  isTokenCard={card.isTokenCard}
+                  isEvolveCard={card.isEvolveCard}
+                  style={{
+                    width: '72px',
+                    height: '101px',
+                    objectFit: 'cover',
+                    borderRadius: '7px',
+                    boxShadow: '0 8px 18px rgba(0,0,0,0.28)',
+                    flexShrink: 0,
+                  }}
+                  draggable={false}
+                />
+              )}
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <div style={{ color: '#fbbf24', fontSize: compact ? '0.64rem' : '0.68rem', fontWeight: 800, textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+                  {t(getFaceLabelKey(face.side))}
+                </div>
+                <div style={{ color: '#f8fafc', fontWeight: 800, fontSize: compact ? '0.78rem' : '0.88rem', lineHeight: 1.35, marginTop: '0.16rem' }}>
+                  {face.name}
+                </div>
+                {presentation.primaryMeta && (
+                  <div style={{ color: '#cbd5e1', fontSize: compact ? '0.64rem' : '0.7rem', marginTop: '0.12rem', lineHeight: 1.4 }}>
+                    {presentation.primaryMeta}
+                  </div>
+                )}
+                {presentation.secondaryMeta && (
+                  <div style={{ color: '#94a3b8', fontSize: compact ? '0.62rem' : '0.68rem', marginTop: '0.08rem', lineHeight: 1.4 }}>
+                    {presentation.secondaryMeta}
+                  </div>
+                )}
+                <div style={{ display: 'grid', gridTemplateColumns: '48px 1fr', gap: '0.1rem 0.4rem', marginTop: '0.38rem', color: '#e2e8f0', fontSize: compact ? '0.64rem' : '0.7rem' }}>
+                  <span style={{ color: '#94a3b8' }}>{t('gameBoard.inspector.cost')}</span>
+                  <span>{face.cost || '-'}</span>
+                  {presentation.stats && (
+                    <>
+                      <span style={{ color: '#94a3b8' }}>{t('gameBoard.inspector.stats')}</span>
+                      <span>{presentation.stats}</span>
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div style={{ marginTop: compact ? '0.45rem' : '0.6rem' }}>
+              <div style={{ color: '#f8fafc', fontWeight: 700, fontSize: compact ? '0.68rem' : '0.76rem', marginBottom: '0.3rem' }}>
+                {t('gameBoard.inspector.abilityText')}
+              </div>
+              <div style={{
+                whiteSpace: 'pre-wrap',
+                color: '#e5e7eb',
+                fontSize: compact ? '0.66rem' : '0.72rem',
+                lineHeight: compact ? 1.48 : 1.58,
+              }}>
+                {face.abilityText ? formatAbilityText(face.abilityText) : t('gameBoard.inspector.noAbilityText')}
+              </div>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+};
+
+export default GameBoardCardFacePreview;

--- a/src/components/GameBoardCardInspector.tsx
+++ b/src/components/GameBoardCardInspector.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import type { CardInstance } from './Card';
 import CardArtwork from './CardArtwork';
+import GameBoardCardFacePreview from './GameBoardCardFacePreview';
 import {
   formatAbilityText,
   type CardDetail,
@@ -25,6 +26,7 @@ const GameBoardCardInspector = React.forwardRef<HTMLDivElement, GameBoardCardIns
     onClose,
   }, ref) => {
     const { t } = useTranslation();
+    const hasFaces = Boolean(selectedInspectorDetail?.faces && selectedInspectorDetail.faces.length > 1);
 
     return (
       <div
@@ -65,59 +67,69 @@ const GameBoardCardInspector = React.forwardRef<HTMLDivElement, GameBoardCardIns
         </button>
       </div>
 
-      <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'flex-start', marginBottom: '0.8rem' }}>
-        <CardArtwork
-          image={selectedInspectorDetail?.image || selectedInspectorCard.image}
-          alt={selectedInspectorDetail?.name || selectedInspectorCard.name}
-          detail={selectedInspectorDetail ?? undefined}
-          baseCardType={selectedInspectorCard.baseCardType}
-          isLeaderCard={selectedInspectorCard.isLeaderCard}
-          isTokenCard={selectedInspectorCard.isTokenCard}
-          isEvolveCard={selectedInspectorCard.isEvolveCard}
-          style={{
-            width: '92px',
-            height: '128px',
-            objectFit: 'cover',
-            borderRadius: '8px',
-            boxShadow: '0 8px 20px rgba(0,0,0,0.32)',
-            flexShrink: 0,
-          }}
+      {hasFaces && selectedInspectorDetail ? (
+        <GameBoardCardFacePreview
+          card={selectedInspectorCard}
+          detail={selectedInspectorDetail}
+          showArtwork={true}
         />
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.45rem', minWidth: 0, flex: 1 }}>
-          <div style={{ display: 'grid', gridTemplateColumns: '60px 1fr', gap: '0.16rem 0.45rem', color: '#e2e8f0', fontSize: '0.76rem' }}>
-            <span style={{ color: '#94a3b8' }}>{t('gameBoard.inspector.id')}</span>
-            <span>{selectedInspectorCard.cardId}</span>
-            <span style={{ color: '#94a3b8' }}>{t('gameBoard.inspector.cost')}</span>
-            <span>{selectedInspectorDetail?.cost || '-'}</span>
-            {inspectorPresentation.stats && (
-              <>
-                <span style={{ color: '#94a3b8' }}>{t('gameBoard.inspector.stats')}</span>
-                <span>{inspectorPresentation.stats}</span>
-              </>
-            )}
+      ) : (
+        <>
+          <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'flex-start', marginBottom: '0.8rem' }}>
+            <CardArtwork
+              image={selectedInspectorDetail?.image || selectedInspectorCard.image}
+              alt={selectedInspectorDetail?.name || selectedInspectorCard.name}
+              detail={selectedInspectorDetail ?? undefined}
+              baseCardType={selectedInspectorCard.baseCardType}
+              isLeaderCard={selectedInspectorCard.isLeaderCard}
+              isTokenCard={selectedInspectorCard.isTokenCard}
+              isEvolveCard={selectedInspectorCard.isEvolveCard}
+              style={{
+                width: '92px',
+                height: '128px',
+                objectFit: 'cover',
+                borderRadius: '8px',
+                boxShadow: '0 8px 20px rgba(0,0,0,0.32)',
+                flexShrink: 0,
+              }}
+            />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.45rem', minWidth: 0, flex: 1 }}>
+              <div style={{ display: 'grid', gridTemplateColumns: '60px 1fr', gap: '0.16rem 0.45rem', color: '#e2e8f0', fontSize: '0.76rem' }}>
+                <span style={{ color: '#94a3b8' }}>{t('gameBoard.inspector.id')}</span>
+                <span>{selectedInspectorCard.cardId}</span>
+                <span style={{ color: '#94a3b8' }}>{t('gameBoard.inspector.cost')}</span>
+                <span>{selectedInspectorDetail?.cost || '-'}</span>
+                {inspectorPresentation.stats && (
+                  <>
+                    <span style={{ color: '#94a3b8' }}>{t('gameBoard.inspector.stats')}</span>
+                    <span>{inspectorPresentation.stats}</span>
+                  </>
+                )}
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
 
-      <div style={{ borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: '0.75rem' }}>
-        <div style={{ color: '#f8fafc', fontWeight: 700, fontSize: '0.82rem', marginBottom: '0.45rem' }}>
-          {t('gameBoard.inspector.abilityText')}
-        </div>
-        <div style={{
-          whiteSpace: 'pre-wrap',
-          color: '#e5e7eb',
-          fontSize: '0.78rem',
-          lineHeight: 1.65,
-          background: 'rgba(15, 23, 42, 0.76)',
-          borderRadius: '10px',
-          padding: '0.75rem',
-          border: '1px solid rgba(255,255,255,0.08)',
-        }}>
-          {selectedInspectorDetail?.abilityText
-            ? formatAbilityText(selectedInspectorDetail.abilityText)
-            : t('gameBoard.inspector.noAbilityText')}
-        </div>
-      </div>
+          <div style={{ borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: '0.75rem' }}>
+            <div style={{ color: '#f8fafc', fontWeight: 700, fontSize: '0.82rem', marginBottom: '0.45rem' }}>
+              {t('gameBoard.inspector.abilityText')}
+            </div>
+            <div style={{
+              whiteSpace: 'pre-wrap',
+              color: '#e5e7eb',
+              fontSize: '0.78rem',
+              lineHeight: 1.65,
+              background: 'rgba(15, 23, 42, 0.76)',
+              borderRadius: '10px',
+              padding: '0.75rem',
+              border: '1px solid rgba(255,255,255,0.08)',
+            }}>
+              {selectedInspectorDetail?.abilityText
+                ? formatAbilityText(selectedInspectorDetail.abilityText)
+                : t('gameBoard.inspector.noAbilityText')}
+            </div>
+          </div>
+        </>
+      )}
     </div>
     );
   }

--- a/src/components/GameBoardInspectorUi.test.tsx
+++ b/src/components/GameBoardInspectorUi.test.tsx
@@ -77,6 +77,88 @@ describe('GameBoard extracted UI components - card inspector', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('renders both faces for double-faced cards in the inspector', () => {
+    render(
+      <GameBoardCardInspector
+        selectedInspectorCard={{
+          id: 'card-1',
+          cardId: 'BP08-003',
+          name: '決意の人形・オーキス',
+          image: '/front.png',
+          zone: 'field-host',
+          owner: 'host',
+          isTapped: false,
+          isFlipped: false,
+          counters: { atk: 0, hp: 0 },
+          genericCounter: 0,
+          baseCardType: 'follower',
+          cardKindNormalized: 'evolve_follower',
+        }}
+        selectedInspectorDetail={{
+          id: 'BP08-003',
+          name: '決意の人形・オーキス',
+          image: '/front.png',
+          className: 'エルフ',
+          title: '',
+          type: 'フォロワー・エボルヴ',
+          subtype: '人形・光輝',
+          cardKindNormalized: 'evolve_follower',
+          cost: '-',
+          atk: 3,
+          hp: 3,
+          abilityText: 'Front ability',
+          faces: [
+            {
+              side: 'front',
+              name: '決意の人形・オーキス',
+              image: '/front.png',
+              className: 'エルフ',
+              title: '',
+              type: 'フォロワー・エボルヴ',
+              subtype: '人形・光輝',
+              cardKindNormalized: 'evolve_follower',
+              cost: '-',
+              atk: 3,
+              hp: 3,
+              abilityText: 'Front face ability',
+            },
+            {
+              side: 'back',
+              name: '復讐の人形・オーキス',
+              image: '/back.png',
+              className: 'エルフ',
+              title: '',
+              type: 'フォロワー・エボルヴ',
+              subtype: '人形・キラー',
+              cardKindNormalized: 'evolve_follower',
+              cost: '-',
+              atk: 4,
+              hp: 4,
+              abilityText: 'Back face ability',
+            },
+          ],
+        }}
+        inspectorPresentation={{
+          primaryMeta: 'エルフ',
+          secondaryMeta: 'フォロワー・エボルヴ / 人形・光輝',
+          stats: '3 / 3',
+        }}
+        inspectorPopoverStyle={{ position: 'fixed', top: 40, left: 40 }}
+        onClose={vi.fn()}
+      />
+    );
+
+    const facePreview = screen.getByTestId('game-board-card-face-preview');
+    expect(facePreview).toHaveTextContent('決意の人形・オーキス');
+    expect(facePreview).toHaveTextContent('復讐の人形・オーキス');
+    expect(facePreview).toHaveTextContent('人形・光輝');
+    expect(facePreview).toHaveTextContent('人形・キラー');
+    expect(facePreview).toHaveTextContent('3 / 3');
+    expect(facePreview).toHaveTextContent('4 / 4');
+    expect(facePreview).toHaveTextContent('Front face ability');
+    expect(facePreview).toHaveTextContent('Back face ability');
+  });
+
   it('renders card inspector section and returns null without selection', () => {
     const { rerender } = render(
       <GameBoardCardInspectorSection

--- a/src/hooks/useGameBoardFieldActions.test.tsx
+++ b/src/hooks/useGameBoardFieldActions.test.tsx
@@ -259,6 +259,18 @@ describe('useGameBoardFieldActions (Pure Hook)', () => {
     });
   });
 
+  it('dispatches SET_CARD_FACE for the searched player role', () => {
+    const { result } = renderHook(() => useGameBoardFieldActions(defaultArgs));
+    result.current.handleSetCardFace('card-1', 'back', 'guest');
+
+    expect(defaultArgs.dispatchGameEvent).toHaveBeenCalledWith({
+      type: 'SET_CARD_FACE',
+      actor: 'guest',
+      cardId: 'card-1',
+      faceSide: 'back',
+    });
+  });
+
   // ─── 8. handleSendToBottom ────────────────────────────────────────
   it('dispatches SEND_TO_BOTTOM', () => {
     const { result } = renderHook(() => useGameBoardFieldActions(defaultArgs));

--- a/src/hooks/useGameBoardFieldActions.ts
+++ b/src/hooks/useGameBoardFieldActions.ts
@@ -227,6 +227,10 @@ export function useGameBoardFieldActions({
         dispatchGameEvent({ type: 'TOGGLE_FLIP', actor: targetRole, cardId });
     }, [dispatchGameEvent]);
 
+    const handleSetCardFace = useCallback((cardId: string, faceSide: 'front' | 'back', targetRole?: PlayerRole) => {
+        dispatchGameEvent({ type: 'SET_CARD_FACE', actor: targetRole, cardId, faceSide });
+    }, [dispatchGameEvent]);
+
     const handleSendToBottom = useCallback((cardId: string) => {
         dispatchGameEvent({ type: 'SEND_TO_BOTTOM', actor: getSoloCardMoveActor(cardId), cardId });
         setSearchZone(null);
@@ -368,6 +372,7 @@ export function useGameBoardFieldActions({
         handleDragEnd,
         toggleTap,
         handleFlipCard,
+        handleSetCardFace,
         handleSendToBottom,
         handleSendCardsToBottom,
         handleBanish,

--- a/src/hooks/useGameBoardInspectorUi.ts
+++ b/src/hooks/useGameBoardInspectorUi.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import type { CardInspectAnchor, CardInstance } from '../components/Card';
 import { canInspectCard, shouldClearInspectorSelection } from '../utils/gameBoardCombat';
 import type { CardDetailLookup } from '../utils/cardDetails';
-import { buildCardDetailPresentation } from '../utils/cardDetails';
+import { buildCardDetailPresentation, resolveSelectedCardFaceDetail } from '../utils/cardDetails';
 import { getInspectorPopoverStyle } from '../utils/gameBoardPresentation';
 import {
   shouldDismissInspectorOnPointerDown,
@@ -88,7 +88,7 @@ export const useGameBoardInspectorUi = ({
     ? cards.find((card) => card.id === selectedInspectorCardId) ?? null
     : null;
   const selectedInspectorDetail = selectedInspectorCard
-    ? cardDetailLookup[selectedInspectorCard.cardId]
+    ? resolveSelectedCardFaceDetail(cardDetailLookup[selectedInspectorCard.cardId], selectedInspectorCard.selectedFaceSide)
     : null;
   const inspectorPresentation = buildCardDetailPresentation(selectedInspectorDetail);
   const inspectorPopoverStyle = React.useMemo<React.CSSProperties | null>(() => {

--- a/src/hooks/useGameBoardLogic.test.tsx
+++ b/src/hooks/useGameBoardLogic.test.tsx
@@ -4310,4 +4310,71 @@ describe('useGameBoardLogic action handlers', () => {
     expect(screen.getByTestId('evolve-search-attached-to')).toHaveTextContent('none');
   });
 
+  it('uses the selected face name when an evolve-deck card is played to field', async () => {
+    installMockCatalogFetch([
+      createCatalogCard({
+        id: 'BP08-003',
+        name: '決意の人形・オーキス',
+        deck_section: 'evolve',
+        card_kind_normalized: 'evolve_follower',
+        faces: [
+          {
+            side: 'front',
+            name: '決意の人形・オーキス',
+            image: '/orkis-front.png',
+            class: 'エルフ',
+            type: 'フォロワー・エボルヴ',
+            subtype: '人形・光輝',
+            cost: '-',
+            atk: '3',
+            hp: '3',
+            ability_text: 'Front ability',
+          },
+          {
+            side: 'back',
+            name: '復讐の人形・オーキス',
+            image: '/orkis-back.png',
+            class: 'エルフ',
+            type: 'フォロワー・エボルヴ',
+            subtype: '人形・キラー',
+            cost: '-',
+            atk: '4',
+            hp: '4',
+            ability_text: 'Back ability',
+          },
+        ],
+      }),
+    ]);
+
+    renderResumedHostHarness({
+      cards: [
+        {
+          id: 'evolve-search-card',
+          cardId: 'BP08-003',
+          name: '決意の人形・オーキス',
+          image: '/orkis-front.png',
+          zone: 'evolveDeck-host',
+          owner: 'host',
+          isTapped: false,
+          isFlipped: false,
+          counters: { atk: 0, hp: 0 },
+          isEvolveCard: true,
+          selectedFaceSide: 'back',
+        },
+      ],
+      gameStatus: 'playing',
+      turnCount: 2,
+      phase: 'Main',
+      revision: 8,
+    });
+
+    await flushCatalogEffects();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Extract Evolve to Field' }));
+
+    expect(screen.getByTestId('card-play-message')).toHaveTextContent(
+      'You played to field 復讐の人形・オーキス from Evolve Deck'
+    );
+  });
+
 });

--- a/src/hooks/useGameBoardLogic.ts
+++ b/src/hooks/useGameBoardLogic.ts
@@ -18,6 +18,7 @@ import { buildTopDeckSummaryEffect } from '../utils/topDeckSummary';
 import { buildCardRevealEffect } from '../utils/cardReveal';
 import { buildAttackDeclaredEffect } from '../utils/attackUi';
 import { buildCardPlayedEffect } from '../utils/cardPlayUi';
+import { resolveCardDisplayName } from '../utils/cardDetails';
 
 import {
   buildSnapshotRequestMessage,
@@ -69,6 +70,7 @@ export type DispatchableGameSyncEvent =
   | { type: 'MOVE_TOP_CARD_TO_EX'; actor?: PlayerRole }
   | { type: 'TOGGLE_TAP'; actor?: PlayerRole; cardId: string }
   | { type: 'TOGGLE_FLIP'; actor?: PlayerRole; cardId: string }
+  | { type: 'SET_CARD_FACE'; actor?: PlayerRole; cardId: string; faceSide: 'front' | 'back' }
   | { type: 'SEND_TO_BOTTOM'; actor?: PlayerRole; cardId: string }
   | { type: 'SEND_TO_BOTTOM_BATCH'; actor?: PlayerRole; cardIds: string[] }
   | { type: 'BANISH_CARD'; actor?: PlayerRole; cardId: string }
@@ -575,7 +577,7 @@ export const useGameBoardLogic = () => {
         const effect: SharedUiEffect = {
           type: 'EVOLVE_CARD_PLACED',
           actor: event.actor,
-          cardName: evolveExtractedCards[0].name,
+          cardName: resolveCardDisplayName(evolveExtractedCards[0], cardDetailLookupRef.current),
         };
         queueSnapshotEffect(effect);
       }
@@ -676,7 +678,7 @@ export const useGameBoardLogic = () => {
         const effect: SharedUiEffect = {
           type: 'EVOLVE_USAGE_TOGGLED',
           actor: event.actor,
-          cardName: toggledCard.name,
+          cardName: resolveCardDisplayName(toggledCard, cardDetailLookupRef.current),
           isUsed: toggledCard.isFlipped,
         };
         playSharedUiEffect(effect);
@@ -753,7 +755,7 @@ export const useGameBoardLogic = () => {
         sendSharedUiEffect(effect);
       }
     }
-  }, [applyLocalState, playSharedUiEffect, role, sendSharedUiEffect, sendSnapshot]);
+  }, [applyLocalState, cardDetailLookupRef, playSharedUiEffect, role, sendSharedUiEffect, sendSnapshot]);
 
   const dispatchGameEvent = useCallback((event: DispatchableGameSyncEvent) => {
     if (!canInteract) {
@@ -1226,6 +1228,7 @@ export const useGameBoardLogic = () => {
     handleDragEnd,
     toggleTap,
     handleFlipCard,
+    handleSetCardFace,
     handleSendToBottom,
     handleSendCardsToBottom,
     handleBanish,
@@ -1285,7 +1288,7 @@ export const useGameBoardLogic = () => {
     handlePureCoinFlip, handleRollDice, handleStartGame, handleToggleReady,
     handleDrawInitialHand, startMulligan, handleMulliganOrderSelect, executeMulligan,
     drawCard, handleExtractCard, handleExtractCards, confirmResetGame, handleDeckUpload, importDeckData, spawnToken, spawnTokens,
-    handleModifyCounter, handleModifyGenericCounter, handleDragEnd, toggleTap, handleFlipCard, handleSendToBottom, handleSendCardsToBottom,
+    handleModifyCounter, handleModifyGenericCounter, handleDragEnd, toggleTap, handleFlipCard, handleSetCardFace, handleSendToBottom, handleSendCardsToBottom,
     handleBanish, handleBanishCards, handlePlayToField, handleSendToCemetery, handleSendCardsToCemetery, handleReturnEvolve, handleShuffleDeck, handleDeclareAttack,
     handleSetRevealHandsMode, handleSetEndStop,
     evolveAutoAttachSelection, confirmEvolveAutoAttachSelection, cancelEvolveAutoAttachSelection,

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -261,7 +261,13 @@
       "closeAria": "Close card preview",
       "openAria": "Preview {{name}}",
       "openTitle": "Preview {{name}}",
-      "enlargedAlt": "{{name}} enlarged"
+      "enlargedAlt": "{{name}} enlarged",
+      "faces": {
+        "heading": "Card Faces",
+        "front": "Front",
+        "back": "Back",
+        "imageAlt": "{{side}}: {{name}}"
+      }
     },
     "pagination": {
       "prev": "Prev",

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -663,6 +663,10 @@
         "addToEx": "Add to EX Area",
         "setUsed": "Set USED",
         "setUnused": "Set UNUSED",
+        "face": {
+          "front": "Front",
+          "back": "Back"
+        },
         "empty": "This zone is empty.",
         "typeCounts": "Follower: {{follower}} / Spell: {{spell}} / Amulet: {{amulet}}",
         "stats": "Stats",

--- a/src/i18n/ja/translation.json
+++ b/src/i18n/ja/translation.json
@@ -198,7 +198,13 @@
       "closeAria": "カードプレビューを閉じる",
       "openAria": "{{name}} をプレビュー",
       "openTitle": "{{name}} をプレビュー",
-      "enlargedAlt": "{{name}} の拡大表示"
+      "enlargedAlt": "{{name}} の拡大表示",
+      "faces": {
+        "heading": "カードの表裏",
+        "front": "表面",
+        "back": "裏面",
+        "imageAlt": "{{side}}: {{name}}"
+      }
     },
     "pagination": {
       "prev": "前へ",

--- a/src/i18n/ja/translation.json
+++ b/src/i18n/ja/translation.json
@@ -609,6 +609,10 @@
         "addToEx": "EXエリアに置く",
         "setUsed": "使用済にする",
         "setUnused": "未使用にする",
+        "face": {
+          "front": "表面",
+          "back": "裏面"
+        },
         "empty": "このゾーンは空です",
         "typeCounts": "フォロワー: {{follower}} / スペル: {{spell}} / アミュレット: {{amulet}}",
         "stats": "スタッツ",

--- a/src/models/deckBuilderCard.ts
+++ b/src/models/deckBuilderCard.ts
@@ -7,6 +7,27 @@ export interface RelatedCardReference {
   name: string;
 }
 
+export interface CardFaceData {
+  side: string;
+  name?: string;
+  image?: string;
+  class?: CardClassValue;
+  title?: string;
+  type?: string;
+  subtype?: string;
+  rarity?: string;
+  product_name?: string;
+  cost?: string;
+  atk?: string;
+  hp?: string;
+  ability_text?: string;
+  card_kind_normalized?: CardKindNormalized;
+  deck_section?: DeckSection;
+  is_token?: boolean;
+  is_evolve_card?: boolean;
+  is_deck_build_legal?: boolean;
+}
+
 export interface DeckBuilderCardData {
   id: string; // EXP-NUM format, e.g PCS01-001
   name: string;
@@ -27,6 +48,7 @@ export interface DeckBuilderCardData {
   is_evolve_card?: boolean;
   is_deck_build_legal?: boolean;
   related_cards?: RelatedCardReference[];
+  faces?: CardFaceData[];
 }
 
 const compareJa = (left: string, right: string) => left.localeCompare(right, 'ja');

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -57,6 +57,7 @@ import {
 import {
   getAttackTargetFromCard as resolveAttackTargetFromCard,
 } from '../utils/gameBoardCombat';
+import { canEditSearchedEvolveDeck } from '../utils/gameBoardEvolveFaceSelection';
 
 const GameBoard: React.FC = () => {
   const [viewportWidth, setViewportWidth] = React.useState(() => (
@@ -137,7 +138,7 @@ const GameBoard: React.FC = () => {
     handlePureCoinFlip, handleRollDice, handleStartGame, handleToggleReady,
     handleDrawInitialHand, startMulligan, handleMulliganOrderSelect, executeMulligan,
     drawCard, handleExtractCard, handleExtractCards, confirmResetGame, handleDeckUpload, importDeckData, spawnTokens,
-    handleModifyCounter, handleModifyGenericCounter, handleDragEnd, toggleTap, handleFlipCard, handleSendToBottom, handleSendCardsToBottom,
+    handleModifyCounter, handleModifyGenericCounter, handleDragEnd, toggleTap, handleFlipCard, handleSetCardFace, handleSendToBottom, handleSendCardsToBottom,
     handleBanish, handleBanishCards, handlePlayToField, handleSendToCemetery, handleSendCardsToCemetery, handleReturnEvolve, handleShuffleDeck, handleDeclareAttack,
     handleSetRevealHandsMode, handleSetEndStop,
     evolveAutoAttachSelection, confirmEvolveAutoAttachSelection, cancelEvolveAutoAttachSelection,
@@ -1149,6 +1150,14 @@ const GameBoard: React.FC = () => {
         onBanish={handleBanish}
         onBanishCards={handleBanishCards}
         onToggleFlip={(cardId) => handleFlipCard(cardId, searchTargetRole)}
+        onSetCardFace={(cardId, faceSide) => handleSetCardFace(cardId, faceSide, searchTargetRole)}
+        canEditSearchedEvolveDeck={canEditSearchedEvolveDeck({
+          searchZoneId: searchZone?.id,
+          isSoloMode,
+          isSpectator,
+          searchTargetRole,
+          role,
+        })}
         viewerRole={searchTargetRole}
         targetRole={searchTargetRole}
         onRequestMainDeckShuffleConfirm={handleRequestMainDeckShuffleConfirm}

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -1,6 +1,7 @@
 import type { CardInstance } from '../components/Card';
 import type { PlayerRole, SyncState, TokenOption } from './game';
 import type { TopDeckResult } from '../utils/cardLogic';
+import type { CardFaceSide } from '../utils/cardDetails';
 
 export interface PublicCardView {
   cardId: string;
@@ -33,6 +34,7 @@ export type GameSyncEvent =
   | { id: string; type: 'MOVE_TOP_CARD_TO_EX'; actor: PlayerRole }
   | { id: string; type: 'TOGGLE_TAP'; actor: PlayerRole; cardId: string }
   | { id: string; type: 'TOGGLE_FLIP'; actor: PlayerRole; cardId: string }
+  | { id: string; type: 'SET_CARD_FACE'; actor: PlayerRole; cardId: string; faceSide: CardFaceSide }
   | { id: string; type: 'SEND_TO_BOTTOM'; actor: PlayerRole; cardId: string }
   | { id: string; type: 'SEND_TO_BOTTOM_BATCH'; actor: PlayerRole; cardIds: string[] }
   | { id: string; type: 'BANISH_CARD'; actor: PlayerRole; cardId: string }

--- a/src/utils/cardDetails.test.ts
+++ b/src/utils/cardDetails.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildCardDetailLookup, buildCardDetailPresentation, formatAbilityText } from './cardDetails';
+import { buildCardDetailLookup, buildCardDetailPresentation, formatAbilityText, resolveCardDisplayName, resolveSelectedCardFaceDetail } from './cardDetails';
 
 describe('cardDetails', () => {
   it('builds a lookup with parsed stats and text fields', () => {
@@ -17,6 +17,35 @@ describe('cardDetails', () => {
       hp: '4',
       ability_text: 'Alpha',
       related_cards: [{ id: 'TK01-001', name: 'Token' }],
+      faces: [
+        {
+          side: 'front',
+          name: 'Front Face',
+          image: '/front.png',
+          class: 'ロイヤル',
+          title: 'Front Title',
+          type: 'フォロワー・エボルヴ',
+          subtype: '兵士',
+          card_kind_normalized: 'evolve_follower',
+          cost: '3',
+          atk: '2',
+          hp: '4',
+          ability_text: 'Front ability',
+        },
+        {
+          side: 'back',
+          name: 'Back Face',
+          image: '/back.png',
+          class: 'ロイヤル',
+          type: 'フォロワー・エボルヴ',
+          subtype: '指揮官',
+          card_kind_normalized: 'evolve_follower',
+          cost: '-',
+          atk: '5',
+          hp: '6',
+          ability_text: 'Back ability',
+        },
+      ],
     };
 
     const lookup = buildCardDetailLookup([
@@ -41,10 +70,110 @@ describe('cardDetails', () => {
       atk: 2,
       hp: 4,
       abilityText: 'Alpha',
+      faces: [
+        {
+          side: 'front',
+          name: 'Front Face',
+          image: '/front.png',
+          className: 'ロイヤル',
+          title: 'Front Title',
+          type: 'フォロワー・エボルヴ',
+          subtype: '兵士',
+          cardKindNormalized: 'evolve_follower',
+          cost: '3',
+          atk: 2,
+          hp: 4,
+          abilityText: 'Front ability',
+        },
+        {
+          side: 'back',
+          name: 'Back Face',
+          image: '/back.png',
+          className: 'ロイヤル',
+          title: '',
+          type: 'フォロワー・エボルヴ',
+          subtype: '指揮官',
+          cardKindNormalized: 'evolve_follower',
+          cost: '-',
+          atk: 5,
+          hp: 6,
+          abilityText: 'Back ability',
+        },
+      ],
     });
     expect(lookup['BP01-002'].atk).toBeNull();
     expect(lookup['BP01-002'].hp).toBeNull();
     expect(lookup['BP01-001']).not.toHaveProperty('related_cards');
+  });
+
+  it('resolves selected double-faced card details without mutating the base detail', () => {
+    const detail = buildCardDetailLookup([
+      {
+        id: 'BP01-001',
+        name: 'Front Base',
+        image: '/base.png',
+        type: 'フォロワー・エボルヴ',
+        atk: '2',
+        hp: '4',
+        faces: [
+          {
+            side: 'front',
+            name: 'Front Face',
+            image: '/front.png',
+            type: 'フォロワー・エボルヴ',
+            atk: '2',
+            hp: '4',
+            ability_text: 'Front ability',
+          },
+          {
+            side: 'back',
+            name: 'Back Face',
+            image: '/back.png',
+            type: 'フォロワー・エボルヴ',
+            atk: '5',
+            hp: '6',
+            ability_text: 'Back ability',
+          },
+        ],
+      },
+    ])['BP01-001'];
+
+    const resolved = resolveSelectedCardFaceDetail(detail, 'back');
+
+    expect(resolved).toMatchObject({
+      id: 'BP01-001',
+      name: 'Back Face',
+      image: '/back.png',
+      atk: 5,
+      hp: 6,
+      abilityText: 'Back ability',
+    });
+    expect(detail.name).toBe('Front Base');
+    expect(resolveSelectedCardFaceDetail(detail, undefined)).toBe(detail);
+    expect(resolveSelectedCardFaceDetail(detail, 'unknown')).toBe(detail);
+  });
+
+  it('resolves a card display name from the selected face', () => {
+    const lookup = buildCardDetailLookup([
+      {
+        id: 'BP01-001',
+        name: 'Front Base',
+        faces: [
+          { side: 'front', name: 'Front Face' },
+          { side: 'back', name: 'Back Face' },
+        ],
+      },
+    ]);
+
+    expect(resolveCardDisplayName({
+      cardId: 'BP01-001',
+      name: 'Front Base',
+      selectedFaceSide: 'back',
+    }, lookup)).toBe('Back Face');
+    expect(resolveCardDisplayName({
+      cardId: 'BP01-001',
+      name: 'Front Base',
+    }, lookup)).toBe('Front Base');
   });
 
   it('formats separators in ability text for readability', () => {

--- a/src/utils/cardDetails.ts
+++ b/src/utils/cardDetails.ts
@@ -11,6 +11,24 @@ export interface CardDetail {
   atk: number | null;
   hp: number | null;
   abilityText: string;
+  faces?: CardFaceDetail[];
+}
+
+export type CardFaceSide = 'front' | 'back';
+
+export interface CardFaceDetail {
+  side: CardFaceSide;
+  name: string;
+  image: string;
+  className: string;
+  title: string;
+  type: string;
+  subtype: string;
+  cardKindNormalized?: string;
+  cost: string;
+  atk: number | null;
+  hp: number | null;
+  abilityText: string;
 }
 
 export type CardDetailLookup = Record<string, CardDetail>;
@@ -22,6 +40,22 @@ export type CardDetailPresentation = {
 
 interface CardDetailSource {
   id: string;
+  name?: string;
+  image?: string;
+  class?: string;
+  title?: string;
+  type?: string;
+  subtype?: string;
+  card_kind_normalized?: string;
+  cost?: string;
+  atk?: string;
+  hp?: string;
+  ability_text?: string;
+  faces?: CardFaceSource[];
+}
+
+interface CardFaceSource {
+  side?: string;
   name?: string;
   image?: string;
   class?: string;
@@ -47,6 +81,23 @@ const parseNumericStat = (value?: string): number | null => {
 
 export const buildCardDetailLookup = (cards: CardDetailSource[]): CardDetailLookup => (
   cards.reduce<CardDetailLookup>((lookup, card) => {
+    const faces = (card.faces ?? [])
+      .filter((face): face is CardFaceSource & { side: CardFaceSide } => face.side === 'front' || face.side === 'back')
+      .map<CardFaceDetail>((face) => ({
+        side: face.side,
+        name: face.name ?? '',
+        image: face.image ?? '',
+        className: face.class ?? '',
+        title: face.title ?? '',
+        type: face.type ?? '',
+        subtype: face.subtype ?? '',
+        cardKindNormalized: face.card_kind_normalized ?? '',
+        cost: face.cost ?? '-',
+        atk: parseNumericStat(face.atk),
+        hp: parseNumericStat(face.hp),
+        abilityText: face.ability_text ?? '',
+      }));
+
     lookup[card.id] = {
       id: card.id,
       name: card.name ?? '',
@@ -60,10 +111,43 @@ export const buildCardDetailLookup = (cards: CardDetailSource[]): CardDetailLook
       atk: parseNumericStat(card.atk),
       hp: parseNumericStat(card.hp),
       abilityText: card.ability_text ?? '',
+      ...(faces.length > 0 ? { faces } : {}),
     };
 
     return lookup;
   }, {})
+);
+
+export const resolveSelectedCardFaceDetail = (
+  detail: CardDetail | undefined | null,
+  selectedFaceSide?: string | null
+): CardDetail | undefined | null => {
+  if (!detail || !selectedFaceSide) return detail;
+
+  const selectedFace = detail.faces?.find(face => face.side === selectedFaceSide);
+  if (!selectedFace) return detail;
+
+  return {
+    ...detail,
+    name: selectedFace.name,
+    image: selectedFace.image,
+    className: selectedFace.className,
+    title: selectedFace.title,
+    type: selectedFace.type,
+    subtype: selectedFace.subtype,
+    cardKindNormalized: selectedFace.cardKindNormalized,
+    cost: selectedFace.cost,
+    atk: selectedFace.atk,
+    hp: selectedFace.hp,
+    abilityText: selectedFace.abilityText,
+  };
+};
+
+export const resolveCardDisplayName = (
+  card: { cardId: string; name: string; selectedFaceSide?: string | null },
+  detailLookup: CardDetailLookup
+): string => (
+  resolveSelectedCardFaceDetail(detailLookup[card.cardId], card.selectedFaceSide)?.name || card.name
 );
 
 export const formatAbilityText = (abilityText: string): string => (

--- a/src/utils/deckFile.test.ts
+++ b/src/utils/deckFile.test.ts
@@ -18,6 +18,24 @@ const baseCard: DeckBuilderCardData = {
   card_kind_normalized: 'follower',
   deck_section: 'main',
   related_cards: [{ id: 'TK01-001', name: 'Knight Token' }],
+  faces: [
+    {
+      side: 'front',
+      name: 'Alpha Knight',
+      image: '/alpha-front.png',
+      type: 'フォロワー',
+      card_kind_normalized: 'follower',
+      deck_section: 'main',
+    },
+    {
+      side: 'back',
+      name: 'Alpha Knight Back',
+      image: '/alpha-back.png',
+      type: 'フォロワー',
+      card_kind_normalized: 'follower',
+      deck_section: 'main',
+    },
+  ],
 };
 
 const ruleConfig: DeckRuleConfig = {
@@ -38,7 +56,7 @@ describe('deckFile', () => {
     vi.restoreAllMocks();
   });
 
-  it('builds an exportable payload without related card metadata', () => {
+  it('builds an exportable payload without catalog-only metadata', () => {
     const payload = buildExportableDeckPayload('My Deck', ruleConfig, {
       mainDeck: [baseCard],
       evolveDeck: [],
@@ -57,6 +75,7 @@ describe('deckFile', () => {
       deck_section: 'main',
     });
     expect(payload.mainDeck[0]).not.toHaveProperty('related_cards');
+    expect(payload.mainDeck[0]).not.toHaveProperty('faces');
   });
 
   it('sanitizes export file names and preserves supported characters', () => {

--- a/src/utils/deckFile.ts
+++ b/src/utils/deckFile.ts
@@ -2,7 +2,7 @@ import type { DeckBuilderCardData } from '../models/deckBuilderCard';
 import type { DeckState } from '../models/deckState';
 import type { DeckFormat, DeckRuleConfig } from '../models/deckRule';
 
-export type ExportableDeckCard = Omit<DeckBuilderCardData, 'related_cards'>;
+export type ExportableDeckCard = Omit<DeckBuilderCardData, 'related_cards' | 'faces'>;
 
 export type ExportableDeckPayload = {
   deckName: string;
@@ -18,8 +18,9 @@ export type ExportableDeckPayload = {
 };
 
 const toExportableDeckCard = (card: DeckBuilderCardData): ExportableDeckCard => {
-  const { related_cards: omittedRelatedCards, ...exportableCard } = card;
+  const { related_cards: omittedRelatedCards, faces: omittedFaces, ...exportableCard } = card;
   void omittedRelatedCards;
+  void omittedFaces;
   return exportableCard;
 };
 

--- a/src/utils/deckStorage.test.ts
+++ b/src/utils/deckStorage.test.ts
@@ -36,6 +36,24 @@ const mockCards: DeckBuilderCardData[] = [
         name: 'Knight Token',
       },
     ],
+    faces: [
+      {
+        side: 'front',
+        name: 'Alpha Knight',
+        image: '/alpha-front.png',
+        type: 'フォロワー',
+        card_kind_normalized: 'follower',
+        deck_section: 'main',
+      },
+      {
+        side: 'back',
+        name: 'Alpha Knight Back',
+        image: '/alpha-back.png',
+        type: 'フォロワー',
+        card_kind_normalized: 'follower',
+        deck_section: 'main',
+      },
+    ],
   },
   {
     id: 'EV01-001',
@@ -136,7 +154,7 @@ describe('deckStorage', () => {
     expect(restoredDraft.snapshot.deckState.mainDeck).toEqual([mockCards[0], mockCards[0]]);
   });
 
-  it('stores only card references while restoring catalog metadata such as related cards', () => {
+  it('stores only card references while restoring catalog metadata such as related cards and faces', () => {
     saveDeck({
       name: 'Royal Related Test',
       ruleConfig: otherRuleConfig,
@@ -164,14 +182,18 @@ describe('deckStorage', () => {
     const draftPayload = window.localStorage.getItem(DECK_BUILDER_DRAFT_KEY) ?? '';
 
     expect(savedDecksPayload).not.toContain('related_cards');
+    expect(savedDecksPayload).not.toContain('faces');
     expect(draftPayload).not.toContain('related_cards');
+    expect(draftPayload).not.toContain('faces');
 
     const savedDeck = listSavedDecks()[0];
     const restoredSaved = restoreSavedDeckToSnapshot(savedDeck, mockCards);
     const restoredDraft = restoreDraftToSnapshot(loadDraft()!, mockCards);
 
     expect(restoredSaved.snapshot.deckState.mainDeck[0].related_cards).toEqual(mockCards[0].related_cards);
+    expect(restoredSaved.snapshot.deckState.mainDeck[0].faces).toEqual(mockCards[0].faces);
     expect(restoredDraft.snapshot.deckState.mainDeck[0].related_cards).toEqual(mockCards[0].related_cards);
+    expect(restoredDraft.snapshot.deckState.mainDeck[0].faces).toEqual(mockCards[0].faces);
   });
 
   it('ignores broken storage payloads and clears drafts safely', () => {

--- a/src/utils/gameBoardEvolveFaceSelection.test.ts
+++ b/src/utils/gameBoardEvolveFaceSelection.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { canEditSearchedEvolveDeck } from './gameBoardEvolveFaceSelection';
+
+describe('gameBoardEvolveFaceSelection', () => {
+  it('allows editing the searched evolve deck for self in p2p and both players in solo', () => {
+    expect(canEditSearchedEvolveDeck({
+      searchZoneId: 'evolveDeck-host',
+      isSoloMode: false,
+      isSpectator: false,
+      searchTargetRole: 'host',
+      role: 'host',
+    })).toBe(true);
+
+    expect(canEditSearchedEvolveDeck({
+      searchZoneId: 'evolveDeck-guest',
+      isSoloMode: false,
+      isSpectator: false,
+      searchTargetRole: 'guest',
+      role: 'host',
+    })).toBe(false);
+
+    expect(canEditSearchedEvolveDeck({
+      searchZoneId: 'evolveDeck-guest',
+      isSoloMode: true,
+      isSpectator: false,
+      searchTargetRole: 'guest',
+      role: 'host',
+    })).toBe(true);
+
+    expect(canEditSearchedEvolveDeck({
+      searchZoneId: 'evolveDeck-host',
+      isSoloMode: true,
+      isSpectator: false,
+      searchTargetRole: 'host',
+      role: 'host',
+    })).toBe(true);
+  });
+
+  it('rejects spectators and non-evolve searches', () => {
+    expect(canEditSearchedEvolveDeck({
+      searchZoneId: 'evolveDeck-host',
+      isSoloMode: true,
+      isSpectator: true,
+      searchTargetRole: 'host',
+      role: 'host',
+    })).toBe(false);
+
+    expect(canEditSearchedEvolveDeck({
+      searchZoneId: 'mainDeck-host',
+      isSoloMode: true,
+      isSpectator: false,
+      searchTargetRole: 'host',
+      role: 'host',
+    })).toBe(false);
+
+    expect(canEditSearchedEvolveDeck({
+      searchZoneId: null,
+      isSoloMode: true,
+      isSpectator: false,
+      searchTargetRole: 'host',
+      role: 'host',
+    })).toBe(false);
+  });
+});

--- a/src/utils/gameBoardEvolveFaceSelection.ts
+++ b/src/utils/gameBoardEvolveFaceSelection.ts
@@ -1,0 +1,21 @@
+import type { PlayerRole } from '../types/game';
+
+type CanEditSearchedEvolveDeckArgs = {
+  searchZoneId?: string | null;
+  isSoloMode: boolean;
+  isSpectator: boolean;
+  searchTargetRole: PlayerRole;
+  role: PlayerRole;
+};
+
+export const canEditSearchedEvolveDeck = ({
+  searchZoneId,
+  isSoloMode,
+  isSpectator,
+  searchTargetRole,
+  role,
+}: CanEditSearchedEvolveDeckArgs): boolean => (
+  Boolean(searchZoneId?.startsWith('evolveDeck-')) &&
+  !isSpectator &&
+  (isSoloMode || searchTargetRole === role)
+);

--- a/src/utils/gameSyncReducer.test.ts
+++ b/src/utils/gameSyncReducer.test.ts
@@ -1170,6 +1170,90 @@ describe('gameSyncReducer', () => {
     expect(duringGameFlip.cards.find(c => c.id === 'guest-evo')?.isFlipped).toBe(false);
   });
 
+  it('sets the selected face for an owned evolve-deck card without changing usage state', () => {
+    const state = createState({
+      revision: 4,
+      gameStatus: 'playing',
+      cards: [
+        {
+          id: 'guest-evo',
+          cardId: 'BP08-003',
+          name: 'Double Face Evolve',
+          image: '',
+          zone: 'evolveDeck-guest',
+          owner: 'guest',
+          isTapped: false,
+          isFlipped: true,
+          counters: { atk: 0, hp: 0 },
+          isEvolveCard: true,
+        },
+      ],
+    });
+
+    const result = applyGameSyncEvent(state, {
+      id: 'evt-set-face',
+      type: 'SET_CARD_FACE',
+      actor: 'guest',
+      cardId: 'guest-evo',
+      faceSide: 'back',
+    });
+
+    const updatedCard = result.cards.find(c => c.id === 'guest-evo');
+    expect(updatedCard?.selectedFaceSide).toBe('back');
+    expect(updatedCard?.isFlipped).toBe(true);
+    expect(result.revision).toBe(5);
+  });
+
+  it('rejects selected face changes from the wrong requester or non-evolve deck cards', () => {
+    const state = createState({
+      revision: 4,
+      cards: [
+        {
+          id: 'guest-evo',
+          cardId: 'BP08-003',
+          name: 'Guest Evolve',
+          image: '',
+          zone: 'evolveDeck-guest',
+          owner: 'guest',
+          isTapped: false,
+          isFlipped: true,
+          counters: { atk: 0, hp: 0 },
+          isEvolveCard: true,
+        },
+        {
+          id: 'host-main',
+          cardId: 'BP01-001',
+          name: 'Host Main',
+          image: '',
+          zone: 'evolveDeck-host',
+          owner: 'host',
+          isTapped: false,
+          isFlipped: true,
+          counters: { atk: 0, hp: 0 },
+          isEvolveCard: false,
+        },
+      ],
+    });
+
+    const wrongRequester = applyGameSyncEvent(state, {
+      id: 'evt-set-face-denied-requester',
+      type: 'SET_CARD_FACE',
+      actor: 'guest',
+      cardId: 'guest-evo',
+      faceSide: 'back',
+    }, 'host');
+    expect(wrongRequester).toBe(state);
+
+    const nonEvolve = applyGameSyncEvent(state, {
+      id: 'evt-set-face-denied-kind',
+      type: 'SET_CARD_FACE',
+      actor: 'host',
+      cardId: 'host-main',
+      faceSide: 'back',
+    });
+    expect(nonEvolve).toBe(state);
+  });
+
   it('applies shortcut movement events through shared card rules', () => {
     const state = createState({
       revision: 10,

--- a/src/utils/gameSyncReducer.ts
+++ b/src/utils/gameSyncReducer.ts
@@ -156,6 +156,22 @@ const canToggleEvolveDeckUsage = (
   return card.owner === actor && card.zone === `evolveDeck-${actor}` && card.isEvolveCard === true;
 };
 
+const setSelectedCardFace = (
+  cards: SyncState['cards'],
+  cardId: string,
+  faceSide: Extract<GameSyncEvent, { type: 'SET_CARD_FACE' }>['faceSide']
+): SyncState['cards'] => {
+  let didChange = false;
+  const nextCards = cards.map(card => {
+    if (card.id !== cardId) return card;
+    if (card.selectedFaceSide === faceSide) return card;
+    didChange = true;
+    return { ...card, selectedFaceSide: faceSide };
+  });
+
+  return didChange ? nextCards : cards;
+};
+
 const isPreparingMainDeckFieldSet = (
   state: SyncState,
   actor: GameSyncEvent['actor'],
@@ -393,6 +409,17 @@ export const applyGameSyncEvent = (
       if (!isActorRequester(requester, event.actor)) return state;
       if (!canToggleEvolveDeckUsage(state, event.actor, event.cardId)) return state;
       const nextCards = CardLogic.toggleFlip(state.cards, event.cardId);
+      if (nextCards === state.cards) return state;
+      return bumpRevision({
+        ...state,
+        cards: nextCards,
+      });
+    }
+
+    case 'SET_CARD_FACE': {
+      if (!isActorRequester(requester, event.actor)) return state;
+      if (!canToggleEvolveDeckUsage(state, event.actor, event.cardId)) return state;
+      const nextCards = setSelectedCardFace(state.cards, event.cardId, event.faceSide);
       if (nextCards === state.cards) return state;
       return bumpRevision({
         ...state,


### PR DESCRIPTION
## 概要

両面カード対応として、公式カード詳細の `faces` 取得、deckbuilder / gameboard 側の表示・操作対応を追加しました。

## 変更内容

- 公式カード詳細スクレイプで両面カードの表面・裏面情報を `faces` として取得するようにしました
- `cards.json` / `cards_detailed.json` を通常カード更新フローに沿って更新しました
- deckbuilder のカードプレビューで、`faces` があるカードは表面・裏面の詳細を並べて表示するようにしました
- deck export / saved deck には `faces` を保存しないようにし、既存の保存データ肥大化を避けました
- gameboard のエボルヴデッキ検索モーダルで、両面カードの使用面を表面/裏面から選択できるようにしました
- P2P では自分のエボルヴデッキのみ操作可能、solo では両プレイヤーのエボルヴデッキを操作可能にしました
- カードバックは通常カードと同じまま維持し、未使用/使用済み判別の既存仕様を維持しました
- gameboard 内のカードプレビューで、`faces` があるカードは表面・裏面の詳細を表示するようにしました
- エボルヴデッキから場に出したときなどの表示名は、選択中の面の名前を使うようにしました

## 確認内容

- `npm run test:e2e`
- `16 passed`
- 既存の E2E シナリオが通ることを確認しました

## 補足

- `faces` は optional な追加情報のため、既存の単面カードは従来どおり表示されます
- 表裏の選択状態は `selectedFaceSide` として同期され、カード自体の裏向き表示は従来のカードバックを使用します
