### PR TITLE
Codex/gameboard UI

### DIFF
--- a/src/components/Card.test.tsx
+++ b/src/components/Card.test.tsx
@@ -505,16 +505,24 @@ describe('Card', () => {
     expect(screen.getByText('-1')).toBeInTheDocument();
   });
 
-  it('disables quick-action pointer events when requested', () => {
+  it('hides quick actions when requested while keeping click inspect available', () => {
+    const onInspect = vi.fn();
     render(
       <Card
         card={createCard()}
         onCemetery={vi.fn()}
+        onInspect={onInspect}
         quickActionsDisabled={true}
       />
     );
 
-    expect(screen.getByTestId('card-controls')).toHaveStyle({ pointerEvents: 'none' });
+    expect(screen.queryByTestId('card-controls')).not.toBeInTheDocument();
+
+    const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
+    fireEvent.pointerDown(cardElement, { clientX: 10, clientY: 20, button: 0 });
+    fireEvent.pointerUp(cardElement, { clientX: 10, clientY: 20, button: 0 });
+
+    expect(onInspect).toHaveBeenCalledWith(expect.objectContaining({ id: 'card-1' }), expect.any(Object));
   });
 
   it('keeps quick actions hidden by default for coarse input until card tap', () => {

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -514,7 +514,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
           )}
 
           {/* Quick Edit Overlay - desktop/fine path */}
-          {canShowQuickActionOverlay && !isCoarseInput && (
+          {canShowQuickActionOverlay && !quickActionsDisabled && !isCoarseInput && (
             <div className="card-controls"
               data-testid="card-controls"
               data-quick-actions-open={String(isQuickActionsOpen)}
@@ -649,7 +649,7 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
           )}
 
           {/* Coarse input uses an external action sheet with larger touch targets */}
-          {canShowQuickActionOverlay && isCoarseInput && isQuickActionsOpen && typeof document !== 'undefined' && createPortal(
+          {canShowQuickActionOverlay && !quickActionsDisabled && isCoarseInput && isQuickActionsOpen && typeof document !== 'undefined' && createPortal(
             <div
               ref={coarseActionSheetRef}
               data-testid="card-coarse-action-sheet"

--- a/src/components/CardSearchModal.test.tsx
+++ b/src/components/CardSearchModal.test.tsx
@@ -1055,6 +1055,28 @@ describe('CardSearchModal', () => {
     expect(onSendToCemetery).toHaveBeenCalledWith('card-1');
   });
 
+  it('sends a banished card to cemetery immediately', () => {
+    const onSendToCemetery = vi.fn();
+
+    render(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Banish"
+        zoneId="banish-host"
+        cards={[createCard({ zone: 'banish-host' })]}
+        onExtractCard={vi.fn()}
+        onSendToCemetery={onSendToCemetery}
+        viewerRole="host"
+        allowHandExtraction={true}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send to cemetery' }));
+
+    expect(onSendToCemetery).toHaveBeenCalledWith('card-1');
+  });
+
   it('supports bulk sending selected main-deck cards to cemetery', () => {
     const onSendCardsToCemetery = vi.fn();
 
@@ -1067,6 +1089,34 @@ describe('CardSearchModal', () => {
         cards={[
           createCard({ id: 'card-1', name: 'First Card', zone: 'mainDeck-host' }),
           createCard({ id: 'card-2', cardId: 'BP01-002', name: 'Second Card', zone: 'mainDeck-host' }),
+        ]}
+        onExtractCard={vi.fn()}
+        onSendCardsToCemetery={onSendCardsToCemetery}
+        viewerRole="host"
+        allowHandExtraction={true}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Select Multiple'));
+    fireEvent.click(screen.getByAltText('First Card'));
+    fireEvent.click(screen.getByAltText('Second Card'));
+    fireEvent.click(screen.getByRole('button', { name: 'Send to cemetery' }));
+
+    expect(onSendCardsToCemetery).toHaveBeenCalledWith(['card-1', 'card-2']);
+  });
+
+  it('supports bulk sending selected banished cards to cemetery', () => {
+    const onSendCardsToCemetery = vi.fn();
+
+    render(
+      <CardSearchModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Banish"
+        zoneId="banish-host"
+        cards={[
+          createCard({ id: 'card-1', name: 'First Card', zone: 'banish-host' }),
+          createCard({ id: 'card-2', cardId: 'BP01-002', name: 'Second Card', zone: 'banish-host' }),
         ]}
         onExtractCard={vi.fn()}
         onSendCardsToCemetery={onSendCardsToCemetery}

--- a/src/components/CardSearchModal.tsx
+++ b/src/components/CardSearchModal.tsx
@@ -257,7 +257,13 @@ const CardSearchModal: React.FC<CardSearchModalProps> = ({
   );
 
   const canSendCardToCemetery = (card: CardInstance) => (
-    Boolean((onSendCardsToCemetery || onSendToCemetery) && isMainDeckSearch && !isPreparingMainDeckSearch && card.owner === viewerRole)
+    Boolean(
+      (onSendCardsToCemetery || onSendToCemetery) &&
+      (
+        (isMainDeckSearch && !isPreparingMainDeckSearch && card.owner === viewerRole) ||
+        sourceZonePrefix === 'banish'
+      )
+    )
   );
 
   const canBanishCard = () => (

--- a/src/components/GameBoardBoardRow.tsx
+++ b/src/components/GameBoardBoardRow.tsx
@@ -5,6 +5,7 @@ type GameBoardBoardRowProps = {
   width: number;
   children: React.ReactNode;
   overlay?: React.ReactNode;
+  rowGap?: string;
 };
 
 const GameBoardBoardRow: React.FC<GameBoardBoardRowProps> = ({
@@ -12,13 +13,14 @@ const GameBoardBoardRow: React.FC<GameBoardBoardRowProps> = ({
   width,
   children,
   overlay,
+  rowGap = '0.75rem',
 }) => {
   const grid = (
     <div
       style={{
         display: 'grid',
         gridTemplateColumns: columns,
-        gap: '0.75rem',
+        gap: rowGap,
         width: `${width}px`,
         alignItems: 'start',
       }}

--- a/src/components/GameBoardHandRow.tsx
+++ b/src/components/GameBoardHandRow.tsx
@@ -6,6 +6,7 @@ type GameBoardHandRowProps = {
   centerWidth: number;
   justifyCenter?: boolean;
   minHeight?: string;
+  rowGap?: string;
   children: React.ReactNode;
 };
 
@@ -15,13 +16,14 @@ const GameBoardHandRow: React.FC<GameBoardHandRowProps> = ({
   centerWidth,
   justifyCenter = false,
   minHeight,
+  rowGap = '0.75rem',
   children,
 }) => (
   <div
     style={{
       display: 'grid',
       gridTemplateColumns: columns,
-      gap: '0.75rem',
+      gap: rowGap,
       width: `${width}px`,
       alignItems: 'start',
     }}

--- a/src/components/GameBoardMainDeckSection.tsx
+++ b/src/components/GameBoardMainDeckSection.tsx
@@ -18,6 +18,7 @@ type GameBoardMainDeckSectionProps = {
   direction?: 'down' | 'up';
   onActiveMenuChange: (menuId: string | null) => void;
   useTapToOpenActions?: boolean;
+  actionPlacement?: 'below' | 'overlay';
 };
 
 const GameBoardMainDeckSection: React.FC<GameBoardMainDeckSectionProps> = ({
@@ -29,11 +30,23 @@ const GameBoardMainDeckSection: React.FC<GameBoardMainDeckSectionProps> = ({
   direction,
   onActiveMenuChange,
   useTapToOpenActions = false,
+  actionPlacement = 'below',
 }) => {
   const [isTouchSheetOpen, setIsTouchSheetOpen] = React.useState(false);
   const [touchSheetAnchor, setTouchSheetAnchor] = React.useState<{ x: number; y: number } | null>(null);
   const hasActions = Boolean(actions && actions.length > 0);
   const shouldUseTapToOpenActions = useTapToOpenActions && hasActions;
+  const shouldOverlayActions = actionPlacement === 'overlay' && !shouldUseTapToOpenActions && hasActions;
+  const actionsSection = hasActions ? (
+    <GameBoardZoneActionsSection
+      menuId={menuId}
+      activeMenuId={activeMenuId}
+      actionsLabel={actionsLabel}
+      actions={actions as ZoneAction[]}
+      direction={direction}
+      onActiveMenuChange={onActiveMenuChange}
+    />
+  ) : null;
 
   React.useEffect(() => {
     if (!shouldUseTapToOpenActions) {
@@ -43,7 +56,14 @@ const GameBoardMainDeckSection: React.FC<GameBoardMainDeckSectionProps> = ({
   }, [shouldUseTapToOpenActions]);
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: shouldOverlayActions ? '0' : '4px',
+        position: shouldOverlayActions ? 'relative' : undefined,
+      }}
+    >
       <Zone
         {...zoneProps}
         onCardTapAction={(_, anchor) => {
@@ -60,16 +80,19 @@ const GameBoardMainDeckSection: React.FC<GameBoardMainDeckSectionProps> = ({
           setIsTouchSheetOpen(true);
         }}
       />
-      {!shouldUseTapToOpenActions && hasActions ? (
-        <GameBoardZoneActionsSection
-          menuId={menuId}
-          activeMenuId={activeMenuId}
-          actionsLabel={actionsLabel}
-          actions={actions as ZoneAction[]}
-          direction={direction}
-          onActiveMenuChange={onActiveMenuChange}
-        />
-      ) : null}
+      {shouldOverlayActions ? (
+        <div
+          style={{
+            position: 'absolute',
+            right: '6px',
+            bottom: '6px',
+            width: 'min(72px, calc(100% - 12px))',
+            zIndex: activeMenuId === menuId ? 70 : 30,
+          }}
+        >
+          {actionsSection}
+        </div>
+      ) : !shouldUseTapToOpenActions ? actionsSection : null}
       <GameBoardTouchActionSheet
         isOpen={isTouchSheetOpen}
         actions={(actions ?? []).map((action) => ({

--- a/src/components/GameBoardMainDeckSection.tsx
+++ b/src/components/GameBoardMainDeckSection.tsx
@@ -21,6 +21,9 @@ type GameBoardMainDeckSectionProps = {
   actionPlacement?: 'below' | 'overlay';
 };
 
+const MAIN_DECK_ACTIONS_Z_INDEX = 180;
+const OPEN_MAIN_DECK_ACTIONS_Z_INDEX = 220;
+
 const GameBoardMainDeckSection: React.FC<GameBoardMainDeckSectionProps> = ({
   zoneProps,
   menuId,
@@ -88,7 +91,7 @@ const GameBoardMainDeckSection: React.FC<GameBoardMainDeckSectionProps> = ({
             right: '6px',
             bottom: '6px',
             width: 'min(72px, calc(100% - 12px))',
-            zIndex: activeMenuId === menuId ? 70 : 30,
+            zIndex: activeMenuId === menuId ? OPEN_MAIN_DECK_ACTIONS_Z_INDEX : MAIN_DECK_ACTIONS_Z_INDEX,
           }}
         >
           {actionsSection}

--- a/src/components/GameBoardMainDeckSection.tsx
+++ b/src/components/GameBoardMainDeckSection.tsx
@@ -44,6 +44,7 @@ const GameBoardMainDeckSection: React.FC<GameBoardMainDeckSectionProps> = ({
       actionsLabel={actionsLabel}
       actions={actions as ZoneAction[]}
       direction={direction}
+      menuMinWidth={shouldOverlayActions ? '154px' : undefined}
       onActiveMenuChange={onActiveMenuChange}
     />
   ) : null;

--- a/src/components/GameBoardRecentEventsPanel.tsx
+++ b/src/components/GameBoardRecentEventsPanel.tsx
@@ -22,6 +22,10 @@ const GameBoardRecentEventsPanel: React.FC<GameBoardRecentEventsPanelProps> = ({
       style={{
         alignSelf: 'flex-end',
         width: isCompact ? 'min(240px, 100%)' : 'min(320px, 100%)',
+        boxSizing: 'border-box',
+        maxHeight: isCompact ? '76px' : '132px',
+        overflowY: 'auto',
+        overflowX: 'hidden',
         background: 'rgba(15, 23, 42, 0.88)',
         border: '1px solid rgba(148, 163, 184, 0.22)',
         borderRadius: '12px',

--- a/src/components/GameBoardSearchableStackSection.tsx
+++ b/src/components/GameBoardSearchableStackSection.tsx
@@ -10,6 +10,7 @@ type GameBoardSearchableStackSectionProps = {
   searchTitle?: string;
   isSearchInteractive?: boolean;
   useTapToOpenActions?: boolean;
+  actionPlacement?: 'below' | 'overlay';
 };
 
 const GameBoardSearchableStackSection: React.FC<GameBoardSearchableStackSectionProps> = ({
@@ -19,10 +20,20 @@ const GameBoardSearchableStackSection: React.FC<GameBoardSearchableStackSectionP
   searchTitle,
   isSearchInteractive,
   useTapToOpenActions = false,
+  actionPlacement = 'below',
 }) => {
   const [isTouchSheetOpen, setIsTouchSheetOpen] = React.useState(false);
   const [touchSheetAnchor, setTouchSheetAnchor] = React.useState<{ x: number; y: number } | null>(null);
   const shouldUseTapToOpenActions = useTapToOpenActions;
+  const shouldOverlayActions = actionPlacement === 'overlay' && !shouldUseTapToOpenActions;
+  const searchButton = (
+    <GameBoardZoneSearchButton
+      label={searchLabel}
+      onClick={onSearch}
+      title={searchTitle}
+      isInteractive={isSearchInteractive}
+    />
+  );
 
   React.useEffect(() => {
     if (!shouldUseTapToOpenActions) {
@@ -32,7 +43,14 @@ const GameBoardSearchableStackSection: React.FC<GameBoardSearchableStackSectionP
   }, [shouldUseTapToOpenActions]);
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: shouldOverlayActions ? '0' : '4px',
+        position: shouldOverlayActions ? 'relative' : undefined,
+      }}
+    >
       <Zone
         {...zoneProps}
         onCardTapAction={(_, anchor) => {
@@ -47,14 +65,19 @@ const GameBoardSearchableStackSection: React.FC<GameBoardSearchableStackSectionP
           setIsTouchSheetOpen(true);
         }}
       />
-      {!shouldUseTapToOpenActions ? (
-        <GameBoardZoneSearchButton
-          label={searchLabel}
-          onClick={onSearch}
-          title={searchTitle}
-          isInteractive={isSearchInteractive}
-        />
-      ) : null}
+      {shouldOverlayActions ? (
+        <div
+          style={{
+            position: 'absolute',
+            right: '6px',
+            bottom: '6px',
+            width: 'min(72px, calc(100% - 12px))',
+            zIndex: 30,
+          }}
+        >
+          {searchButton}
+        </div>
+      ) : !shouldUseTapToOpenActions ? searchButton : null}
       <GameBoardTouchActionSheet
         isOpen={isTouchSheetOpen}
         actions={[{ label: searchLabel, onClick: onSearch, tone: 'accent' }]}

--- a/src/components/GameBoardStatusUi.test.tsx
+++ b/src/components/GameBoardStatusUi.test.tsx
@@ -387,6 +387,32 @@ describe('GameBoard extracted UI components - status and preparation', () => {
     expect(screen.getByText('Guest evolved Alpha Knight.')).toBeInTheDocument();
   });
 
+  it('keeps all fine-input recent events inside a fixed-height scroll panel', () => {
+    render(
+      <GameBoardRecentEventsPanel
+        eventHistory={[
+          'Host drew a card.',
+          'Guest evolved Alpha Knight.',
+          'Host added Alpha Knight to hand.',
+          'Guest revealed Beta Mage.',
+        ]}
+      />
+    );
+
+    const panel = screen.getByTestId('gameboard-recent-events');
+    expect(panel).toHaveStyle({
+      maxHeight: '132px',
+      overflowY: 'auto',
+      overflowX: 'hidden',
+      boxSizing: 'border-box',
+    });
+    expect(screen.getByText('Host drew a card.')).toBeInTheDocument();
+    expect(screen.getByText('Guest evolved Alpha Knight.')).toBeInTheDocument();
+    expect(screen.getByText('Host added Alpha Knight to hand.')).toBeInTheDocument();
+    expect(screen.getByText('Guest revealed Beta Mage.')).toBeInTheDocument();
+    expect(screen.queryByText('+')).not.toBeInTheDocument();
+  });
+
   it('shows a compact recent events panel and truncates history in coarse mode', () => {
     renderWithInputProfile(
       'coarse',
@@ -400,7 +426,7 @@ describe('GameBoard extracted UI components - status and preparation', () => {
     );
 
     const panel = screen.getByTestId('gameboard-recent-events');
-    expect(panel).toHaveStyle({ width: 'min(240px, 100%)', padding: '0.45rem 0.52rem' });
+    expect(panel).toHaveStyle({ width: 'min(240px, 100%)', maxHeight: '76px', overflowY: 'auto', padding: '0.45rem 0.52rem' });
     expect(screen.getByText('Host drew a card.')).toBeInTheDocument();
     expect(screen.getByText('Guest evolved Alpha Knight.')).toBeInTheDocument();
     expect(screen.queryByText('Host attacked the leader.')).not.toBeInTheDocument();

--- a/src/components/GameBoardTopHandSection.tsx
+++ b/src/components/GameBoardTopHandSection.tsx
@@ -17,6 +17,7 @@ type GameBoardTopHandSectionProps = {
   centerWidth: number;
   justifyCenter?: boolean;
   minHeight?: string;
+  rowGap?: string;
   zoneProps: React.ComponentProps<typeof Zone>;
   activeMenuId: string | null;
   onActiveMenuChange: (menuId: string | null) => void;
@@ -38,6 +39,7 @@ const GameBoardTopHandSection: React.FC<GameBoardTopHandSectionProps> = ({
   centerWidth,
   justifyCenter = false,
   minHeight,
+  rowGap,
   zoneProps,
   activeMenuId,
   onActiveMenuChange,
@@ -65,6 +67,7 @@ const GameBoardTopHandSection: React.FC<GameBoardTopHandSectionProps> = ({
       centerWidth={centerWidth}
       justifyCenter={justifyCenter}
       minHeight={minHeight}
+      rowGap={rowGap}
     >
       <Zone {...zoneProps} />
 

--- a/src/components/GameBoardZoneActionsMenu.tsx
+++ b/src/components/GameBoardZoneActionsMenu.tsx
@@ -12,6 +12,7 @@ type GameBoardZoneActionsMenuProps = {
   isOpen: boolean;
   actions: ZoneAction[];
   direction?: 'down' | 'up';
+  menuMinWidth?: string;
   onToggle: () => void;
   onActionClick: (action: () => void) => void;
 };
@@ -21,6 +22,7 @@ const GameBoardZoneActionsMenu: React.FC<GameBoardZoneActionsMenuProps> = ({
   isOpen,
   actions,
   direction = 'down',
+  menuMinWidth,
   onToggle,
   onActionClick,
 }) => {
@@ -59,8 +61,9 @@ const GameBoardZoneActionsMenu: React.FC<GameBoardZoneActionsMenuProps> = ({
             position: 'absolute',
             top: direction === 'down' ? 'calc(100% + 4px)' : 'auto',
             bottom: direction === 'up' ? 'calc(100% + 4px)' : 'auto',
-            left: 0,
+            left: menuMinWidth ? 'auto' : 0,
             right: 0,
+            minWidth: menuMinWidth,
             zIndex: 62,
             display: 'flex',
             flexDirection: 'column',
@@ -84,6 +87,7 @@ const GameBoardZoneActionsMenu: React.FC<GameBoardZoneActionsMenuProps> = ({
                 color: 'white',
                 borderRadius: '4px',
                 cursor: 'pointer',
+                whiteSpace: menuMinWidth ? 'nowrap' : undefined,
               }}
             >
               {action.label}

--- a/src/components/GameBoardZoneActionsSection.tsx
+++ b/src/components/GameBoardZoneActionsSection.tsx
@@ -13,6 +13,7 @@ type GameBoardZoneActionsSectionProps = {
   actionsLabel: string;
   actions: ZoneAction[];
   direction?: 'down' | 'up';
+  menuMinWidth?: string;
   onActiveMenuChange: (menuId: string | null) => void;
 };
 
@@ -22,6 +23,7 @@ const GameBoardZoneActionsSection: React.FC<GameBoardZoneActionsSectionProps> = 
   actionsLabel,
   actions,
   direction = 'down',
+  menuMinWidth,
   onActiveMenuChange,
 }) => {
   const isOpen = activeMenuId === menuId;
@@ -32,6 +34,7 @@ const GameBoardZoneActionsSection: React.FC<GameBoardZoneActionsSectionProps> = 
       isOpen={isOpen}
       actions={actions}
       direction={direction}
+      menuMinWidth={menuMinWidth}
       onToggle={() => onActiveMenuChange(isOpen ? null : menuId)}
       onActionClick={(action) => {
         action();

--- a/src/components/GameBoardZoneUi.test.tsx
+++ b/src/components/GameBoardZoneUi.test.tsx
@@ -573,7 +573,7 @@ describe('GameBoard extracted UI components - zones and controls', () => {
 
     const button = screen.getByRole('button', { name: 'Actions' });
 
-    expect(button.parentElement?.parentElement).toHaveStyle({ zIndex: '70' });
+    expect(button.parentElement?.parentElement).toHaveStyle({ zIndex: '220' });
     expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Look Top (N)' }).parentElement).toHaveStyle({
       minWidth: '154px',
@@ -582,6 +582,28 @@ describe('GameBoard extracted UI components - zones and controls', () => {
     expect(screen.getByRole('button', { name: 'Look Top (N)' })).toHaveStyle({
       whiteSpace: 'nowrap',
     });
+  });
+
+  it('keeps overlaid main deck actions above a full deck stack while closed', () => {
+    render(
+      <GameBoardMainDeckSection
+        zoneProps={{
+          id: 'mainDeck-host',
+          label: 'Main Deck',
+          cards: Array.from({ length: 40 }, (_, index) => ({ id: `card-${index}` } as never)),
+        }}
+        menuId="mainDeck-host"
+        activeMenuId={null}
+        actionsLabel="Actions"
+        actions={[{ label: 'Search', onClick: vi.fn() }]}
+        onActiveMenuChange={vi.fn()}
+        actionPlacement="overlay"
+      />
+    );
+
+    const button = screen.getByRole('button', { name: 'Actions' });
+
+    expect(button.parentElement?.parentElement).toHaveStyle({ zIndex: '180' });
   });
 
   it('uses a compact two-column touch sheet layout for multiple main deck actions', () => {

--- a/src/components/GameBoardZoneUi.test.tsx
+++ b/src/components/GameBoardZoneUi.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import { describe, expect, it, vi } from 'vitest';
 import GameBoardEndTurnButton from './GameBoardEndTurnButton';
 import GameBoardEndTurnSection from './GameBoardEndTurnSection';
+import GameBoardBoardRow from './GameBoardBoardRow';
+import GameBoardHandRow from './GameBoardHandRow';
 import GameBoardLeaderZone from './GameBoardLeaderZone';
 import GameBoardLeaderZoneSection from './GameBoardLeaderZoneSection';
 import GameBoardPlayerTracker from './GameBoardPlayerTracker';
@@ -63,6 +65,24 @@ const renderWithInputProfile = (
 );
 
 describe('GameBoard extracted UI components - zones and controls', () => {
+  it('lets board and hand rows share the board spacing token', () => {
+    render(
+      <>
+        <GameBoardBoardRow columns="100px 200px 100px" width={400} rowGap="0.42rem">
+          <div />
+          <div />
+          <div />
+        </GameBoardBoardRow>
+        <GameBoardHandRow columns="100px 200px 100px" width={400} centerWidth={200} rowGap="0.42rem">
+          <div>Hand</div>
+        </GameBoardHandRow>
+      </>
+    );
+
+    expect(screen.getByText('Hand').parentElement?.parentElement).toHaveStyle({ gap: '0.42rem' });
+    expect(screen.getByText('Hand').parentElement?.parentElement?.previousElementSibling).toHaveStyle({ gap: '0.42rem' });
+  });
+
   it('renders leader zone section and wires search action', () => {
     const onSearch = vi.fn();
 

--- a/src/components/GameBoardZoneUi.test.tsx
+++ b/src/components/GameBoardZoneUi.test.tsx
@@ -562,7 +562,10 @@ describe('GameBoard extracted UI components - zones and controls', () => {
         menuId="mainDeck-host"
         activeMenuId="mainDeck-host"
         actionsLabel="Actions"
-        actions={[{ label: 'Search', onClick: vi.fn() }]}
+        actions={[
+          { label: 'Search', onClick: vi.fn() },
+          { label: 'Look Top (N)', onClick: vi.fn(), tone: 'accent' },
+        ]}
         onActiveMenuChange={vi.fn()}
         actionPlacement="overlay"
       />
@@ -572,6 +575,13 @@ describe('GameBoard extracted UI components - zones and controls', () => {
 
     expect(button.parentElement?.parentElement).toHaveStyle({ zIndex: '70' });
     expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Look Top (N)' }).parentElement).toHaveStyle({
+      minWidth: '154px',
+      right: 0,
+    });
+    expect(screen.getByRole('button', { name: 'Look Top (N)' })).toHaveStyle({
+      whiteSpace: 'nowrap',
+    });
   });
 
   it('uses a compact two-column touch sheet layout for multiple main deck actions', () => {

--- a/src/components/GameBoardZoneUi.test.tsx
+++ b/src/components/GameBoardZoneUi.test.tsx
@@ -249,6 +249,38 @@ describe('GameBoard extracted UI components - zones and controls', () => {
     expect(onSearch).toHaveBeenCalledTimes(1);
   });
 
+  it('overlays stack search actions without adding vertical height', () => {
+    const onSearch = vi.fn();
+
+    render(
+      <GameBoardSearchableStackSection
+        zoneProps={{
+          id: 'banish-host',
+          label: 'Banish',
+          cards: [{ id: 'card-1' } as never],
+        }}
+        searchLabel="Search"
+        onSearch={onSearch}
+        actionPlacement="overlay"
+      />
+    );
+
+    const button = screen.getByRole('button', { name: 'Search' });
+    expect(screen.getByTestId('zone-banish-host').parentElement).toHaveStyle({
+      gap: '0',
+      position: 'relative',
+    });
+    expect(button.parentElement).toHaveStyle({
+      position: 'absolute',
+      right: '6px',
+      bottom: '6px',
+    });
+
+    fireEvent.click(button);
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+  });
+
   it('hides inline zone search button for empty zones and opens via zone tap when tap-to-open is enabled', () => {
     const onSearch = vi.fn();
 
@@ -481,6 +513,65 @@ describe('GameBoard extracted UI components - zones and controls', () => {
 
     expect(onActiveMenuChange).toHaveBeenCalledWith(null);
     expect(onSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it('overlays main deck actions without adding vertical height', () => {
+    const onSearch = vi.fn();
+    const onActiveMenuChange = vi.fn();
+
+    render(
+      <GameBoardMainDeckSection
+        zoneProps={{
+          id: 'mainDeck-host',
+          label: 'Main Deck',
+          cards: [{ id: 'card-1' } as never],
+        }}
+        menuId="mainDeck-host"
+        activeMenuId={null}
+        actionsLabel="Actions"
+        actions={[{ label: 'Search', onClick: onSearch }]}
+        onActiveMenuChange={onActiveMenuChange}
+        actionPlacement="overlay"
+      />
+    );
+
+    const button = screen.getByRole('button', { name: 'Actions' });
+    expect(screen.getByTestId('zone-mainDeck-host').parentElement).toHaveStyle({
+      gap: '0',
+      position: 'relative',
+    });
+    expect(button.parentElement?.parentElement).toHaveStyle({
+      position: 'absolute',
+      right: '6px',
+      bottom: '6px',
+    });
+
+    fireEvent.click(button);
+
+    expect(onActiveMenuChange).toHaveBeenCalledWith('mainDeck-host');
+  });
+
+  it('raises overlaid main deck actions while the menu is open', () => {
+    render(
+      <GameBoardMainDeckSection
+        zoneProps={{
+          id: 'mainDeck-host',
+          label: 'Main Deck',
+          cards: [{ id: 'card-1' } as never],
+        }}
+        menuId="mainDeck-host"
+        activeMenuId="mainDeck-host"
+        actionsLabel="Actions"
+        actions={[{ label: 'Search', onClick: vi.fn() }]}
+        onActiveMenuChange={vi.fn()}
+        actionPlacement="overlay"
+      />
+    );
+
+    const button = screen.getByRole('button', { name: 'Actions' });
+
+    expect(button.parentElement?.parentElement).toHaveStyle({ zIndex: '70' });
+    expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
   });
 
   it('uses a compact two-column touch sheet layout for multiple main deck actions', () => {

--- a/src/components/Zone.test.tsx
+++ b/src/components/Zone.test.tsx
@@ -36,12 +36,13 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('./Card', () => ({
-  default: ({ card, isHidden, isLocked, debugIndex, hideCurrentStats, displayCounters, baseStats, onSendToBottom, onBanish, onCemetery, onReturnEvolve }: { card: CardInstance; isHidden?: boolean; isLocked?: boolean; debugIndex?: number; hideCurrentStats?: boolean; displayCounters?: { atk: number; hp: number }; baseStats?: { atk: number; hp: number }; onSendToBottom?: (id: string) => void; onBanish?: (id: string) => void; onCemetery?: (id: string) => void; onReturnEvolve?: (id: string) => void }) => (
+  default: ({ card, isHidden, isLocked, quickActionsDisabled, debugIndex, hideCurrentStats, displayCounters, baseStats, onSendToBottom, onBanish, onCemetery, onReturnEvolve }: { card: CardInstance; isHidden?: boolean; isLocked?: boolean; quickActionsDisabled?: boolean; debugIndex?: number; hideCurrentStats?: boolean; displayCounters?: { atk: number; hp: number }; baseStats?: { atk: number; hp: number }; onSendToBottom?: (id: string) => void; onBanish?: (id: string) => void; onCemetery?: (id: string) => void; onReturnEvolve?: (id: string) => void }) => (
     <div
       data-testid="mock-card"
       data-card-id={card.id}
       data-hidden={String(Boolean(isHidden))}
       data-locked={String(Boolean(isLocked))}
+      data-quick-actions-disabled={String(Boolean(quickActionsDisabled))}
       data-debug-index={debugIndex ?? ''}
       data-hide-current-stats={String(Boolean(hideCurrentStats))}
       data-display-counters={displayCounters ? `${displayCounters.atk}/${displayCounters.hp}` : ''}
@@ -282,6 +283,40 @@ describe('Zone', () => {
     expect(linkedCard).toHaveAttribute('data-has-return-evolve', 'true');
   });
 
+  it('disables hover quick actions for cemetery and banish cards without locking drag or inspect', () => {
+    const { rerender } = render(
+      <Zone
+        id="cemetery-host"
+        label="Cemetery"
+        cards={[createCard('cemetery-card', { zone: 'cemetery-host' })]}
+        onInspectCard={vi.fn()}
+        onSendToBottom={vi.fn()}
+        onBanish={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('mock-card')).toHaveAttribute('data-quick-actions-disabled', 'true');
+    expect(screen.getByTestId('mock-card')).toHaveAttribute('data-locked', 'false');
+    expect(screen.getByTestId('mock-card')).toHaveAttribute('data-has-send-to-bottom', 'true');
+    expect(screen.getByTestId('mock-card')).toHaveAttribute('data-has-banish', 'true');
+
+    rerender(
+      <Zone
+        id="banish-host"
+        label="Banish"
+        cards={[createCard('banish-card', { zone: 'banish-host' })]}
+        onInspectCard={vi.fn()}
+        onSendToBottom={vi.fn()}
+        onCemetery={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('mock-card')).toHaveAttribute('data-quick-actions-disabled', 'true');
+    expect(screen.getByTestId('mock-card')).toHaveAttribute('data-locked', 'false');
+    expect(screen.getByTestId('mock-card')).toHaveAttribute('data-has-send-to-bottom', 'true');
+    expect(screen.getByTestId('mock-card')).toHaveAttribute('data-has-cemetery', 'true');
+  });
+
   it('uses tighter field spacing for coarse input', () => {
     const { container } = renderWithInputProfile(
       'coarse',
@@ -321,7 +356,7 @@ describe('Zone', () => {
 
     expect(container.firstChild).toHaveStyle({ padding: '0.32rem' });
     const zoneLabel = screen.getByText('Cemetery');
-    expect(zoneLabel).toHaveStyle({ fontSize: '0.48rem' });
+    expect(zoneLabel).toHaveStyle({ fontSize: '0.5rem' });
     expect(zoneLabel).toHaveStyle({
       whiteSpace: 'normal',
       textOverflow: 'clip',
@@ -360,7 +395,7 @@ describe('Zone', () => {
 
     const zoneLabel = screen.getByText('エボルヴデッキ');
     expect(zoneLabel).toHaveStyle({
-      fontSize: '0.52rem',
+      fontSize: '0.56rem',
       textOverflow: 'clip',
       whiteSpace: 'nowrap',
     });
@@ -394,7 +429,7 @@ describe('Zone', () => {
 
     const zoneLabel = screen.getByText('エボルヴ');
     expect(zoneLabel).toHaveStyle({
-      fontSize: '0.52rem',
+      fontSize: '0.56rem',
       textOverflow: 'clip',
       whiteSpace: 'nowrap',
     });

--- a/src/components/Zone.tsx
+++ b/src/components/Zone.tsx
@@ -62,10 +62,11 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
   const isStack = layout === 'stack';
   const isFieldZone = id.startsWith('field-');
   const isExZone = id.startsWith('ex-');
+  const shouldDisableZoneQuickActions = id.startsWith('cemetery-') || id.startsWith('banish-');
   const isReadOnlySpectator = viewerRole === 'spectator';
   const zoneLabelChipGap = isCompactInput ? '2px' : isFineInput ? '3px' : isOverviewDesktop ? '4px' : '6px';
   const zoneLabelChipPadding = isCompactInput ? '1px 4px' : isFineInput ? '1px 5px' : isOverviewDesktop ? '1px 6px' : '2px 8px';
-  const zoneLabelFontSize = isCompactInput ? '0.48rem' : isFineInput ? '0.52rem' : isOverviewDesktop ? '0.62rem' : '0.68rem';
+  const zoneLabelFontSize = isCompactInput ? '0.5rem' : isFineInput ? '0.56rem' : isOverviewDesktop ? '0.62rem' : '0.68rem';
   const zoneCountMinWidth = isCompactInput ? '16px' : isFineInput ? '17px' : isOverviewDesktop ? '18px' : '22px';
   const zoneCountPadding = isCompactInput ? '0 3px' : isFineInput ? '0 4px' : isOverviewDesktop ? '0 4px' : '0 6px';
   const zoneCountFontSize = isCompactInput ? '0.44rem' : isFineInput ? '0.46rem' : isOverviewDesktop ? '0.62rem' : '0.7rem';
@@ -108,14 +109,14 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
           onCemetery={linkedCard.isTokenCard ? onCemetery : undefined}
           isHidden={hideCards}
           isLocked={lockCards || isReadOnlySpectator || (isProtected && viewerRole !== 'all' && linkedCard.owner !== viewerRole)}
-          quickActionsDisabled={disableQuickActionsForCard?.(linkedCard)}
+          quickActionsDisabled={shouldDisableZoneQuickActions || disableQuickActionsForCard?.(linkedCard)}
           disableCombatAndCounterControls={true}
           onCardTapAction={onCardTapAction}
           debugIndex={isDebug ? index : undefined}
         />
       </div>
     ));
-  }, [attachmentLeftOffset, attachmentTopOffset, cardDetailLookup, cardStatLookup, disableQuickActionsForCard, getHighlightTone, hideCards, isDebug, isProtected, isReadOnlySpectator, linkedCardLeftOffset, linkedCardTopOffset, lockCards, onBanish, onCardTapAction, onCemetery, onInspectCard, onReturnEvolve, onSendToBottom, viewerRole]);
+  }, [attachmentLeftOffset, attachmentTopOffset, cardDetailLookup, cardStatLookup, disableQuickActionsForCard, getHighlightTone, hideCards, isDebug, isProtected, isReadOnlySpectator, linkedCardLeftOffset, linkedCardTopOffset, lockCards, onBanish, onCardTapAction, onCemetery, onInspectCard, onReturnEvolve, onSendToBottom, shouldDisableZoneQuickActions, viewerRole]);
 
   return (
     <div
@@ -282,7 +283,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                       onPlayToField={onPlayToField}
                       isHidden={hideCards}
                       isLocked={lockCards || isReadOnlySpectator || (isProtected && viewerRole !== 'all' && card.owner !== viewerRole)}
-                      quickActionsDisabled={disableQuickActionsForCard?.(card)}
+                      quickActionsDisabled={shouldDisableZoneQuickActions || disableQuickActionsForCard?.(card)}
                       disableCombatAndCounterControls={hasCardOnTop(card.id)}
                       onCardTapAction={onCardTapAction}
                       debugIndex={isDebug ? index : undefined}
@@ -311,7 +312,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                           onPlayToField={onPlayToField}
                           isHidden={hideCards}
                           isLocked={lockCards || isReadOnlySpectator || (isProtected && viewerRole !== 'all' && attachedCard.owner !== viewerRole)}
-                          quickActionsDisabled={disableQuickActionsForCard?.(attachedCard)}
+                          quickActionsDisabled={shouldDisableZoneQuickActions || disableQuickActionsForCard?.(attachedCard)}
                           disableCombatAndCounterControls={hasCardOnTop(attachedCard.id)}
                           onCardTapAction={onCardTapAction}
                           debugIndex={isDebug ? i : undefined}
@@ -356,7 +357,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                 onPlayToField={onPlayToField}
                 isHidden={hideCards}
                 isLocked={lockCards || isReadOnlySpectator || (isProtected && viewerRole !== 'all' && card.owner !== viewerRole)}
-                quickActionsDisabled={disableQuickActionsForCard?.(card)}
+                quickActionsDisabled={shouldDisableZoneQuickActions || disableQuickActionsForCard?.(card)}
                 disableCombatAndCounterControls={hasCardOnTop(card.id)}
                 onCardTapAction={onCardTapAction}
                 debugIndex={isDebug ? topLevelCards.indexOf(card) : undefined}
@@ -385,7 +386,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                     onPlayToField={onPlayToField}
                     isHidden={hideCards}
                     isLocked={lockCards || isReadOnlySpectator || (isProtected && viewerRole !== 'all' && attachedCard.owner !== viewerRole)}
-                    quickActionsDisabled={disableQuickActionsForCard?.(attachedCard)}
+                    quickActionsDisabled={shouldDisableZoneQuickActions || disableQuickActionsForCard?.(attachedCard)}
                     disableCombatAndCounterControls={hasCardOnTop(attachedCard.id)}
                     onCardTapAction={onCardTapAction}
                     debugIndex={isDebug ? i : undefined}

--- a/src/pages/GameBoard.test.tsx
+++ b/src/pages/GameBoard.test.tsx
@@ -2975,19 +2975,19 @@ describe('GameBoard', () => {
       expect(shell).toHaveAttribute('data-layout-profile', 'desktop');
       expect(shell).toHaveAttribute('data-input-profile', 'fine');
       expect(shell).toHaveAttribute('data-board-density', 'overview');
-      expect(shell).toHaveStyle({ padding: '0.48rem', gap: '0.44rem', width: '100%', height: '100%' });
+      expect(shell).toHaveStyle({ padding: '0.44rem', gap: '0.36rem', width: '100%', height: '100%' });
       expect(shell.style.zoom).toBe('');
-      expect(playmat).toHaveStyle({ padding: '0.44rem', gap: '0.24rem' });
-      expect(topSection).toHaveStyle({ padding: '0.26rem 0.29rem' });
+      expect(playmat).toHaveStyle({ padding: '0.38rem', gap: '0.18rem' });
+      expect(topSection).toHaveStyle({ padding: '0.22rem 0.26rem' });
       expect(topGrid).toHaveStyle({ gridTemplateColumns: '150px 864px 176px' });
       expect(sectionDivider).not.toBeNull();
-      expect(sectionDivider as HTMLElement).toHaveStyle({ margin: '0.18rem 0' });
-      expect(screen.getByTestId('zone-cemetery-guest')).toHaveStyle({ minHeight: '98px' });
-      expect(screen.getByTestId('zone-field-guest')).toHaveStyle({ minHeight: '109px' });
-      expect(screen.getByTestId('zone-hand-guest')).toHaveStyle({ minHeight: '102px' });
-      expect(screen.getByTestId('zone-hand-host')).toHaveStyle({ minHeight: '109px' });
-      expect(screen.getByTestId('zone-leader-guest')).toHaveStyle({ minHeight: '114px' });
-      expect(screen.getByTestId('zone-leader-host')).toHaveStyle({ minHeight: '114px' });
+      expect(sectionDivider as HTMLElement).toHaveStyle({ margin: '0.12rem 0' });
+      expect(screen.getByTestId('zone-cemetery-guest')).toHaveStyle({ minHeight: '96px' });
+      expect(screen.getByTestId('zone-field-guest')).toHaveStyle({ minHeight: '106px' });
+      expect(screen.getByTestId('zone-hand-guest')).toHaveStyle({ minHeight: '100px' });
+      expect(screen.getByTestId('zone-hand-host')).toHaveStyle({ minHeight: '106px' });
+      expect(screen.getByTestId('zone-leader-guest')).toHaveStyle({ minHeight: '110px' });
+      expect(screen.getByTestId('zone-leader-host')).toHaveStyle({ minHeight: '110px' });
       const hostControlsPanel = screen.getByTestId('player-tracker-host').parentElement as HTMLElement;
       expect(hostControlsPanel).toHaveStyle({ marginLeft: '1.5rem' });
 
@@ -3058,9 +3058,9 @@ describe('GameBoard', () => {
       expect(shell).toHaveAttribute('data-layout-profile', 'desktop');
       expect(shell).toHaveAttribute('data-input-profile', 'fine');
       expect(shell).toHaveAttribute('data-board-density', 'overview');
-      expect(shell).toHaveStyle({ padding: '0.48rem', gap: '0.44rem', width: '100%', height: '100%' });
+      expect(shell).toHaveStyle({ padding: '0.44rem', gap: '0.36rem', width: '100%', height: '100%' });
       expect(shell.style.zoom).toBe('');
-      expect(playmat).toHaveStyle({ padding: '0.44rem', gap: '0.24rem' });
+      expect(playmat).toHaveStyle({ padding: '0.38rem', gap: '0.18rem' });
     } finally {
       Object.defineProperty(window, 'innerWidth', {
         configurable: true,
@@ -3186,17 +3186,17 @@ describe('GameBoard', () => {
       const topSection = screen.getByTestId('board-section-top');
       const topGrid = topSection.firstElementChild as HTMLElement;
 
-      expect(shell).toHaveStyle({ padding: '0.46rem', gap: '0.4rem' });
+      expect(shell).toHaveStyle({ padding: '0.42rem', gap: '0.34rem' });
       expect(header).toHaveStyle({ padding: '0.42rem 0.56rem', rowGap: '0.28rem' });
-      expect(playmat).toHaveStyle({ padding: '0.36rem', gap: '0.22rem' });
-      expect(topSection).toHaveStyle({ padding: '0.24rem 0.28rem' });
+      expect(playmat).toHaveStyle({ padding: '0.32rem', gap: '0.18rem' });
+      expect(topSection).toHaveStyle({ padding: '0.2rem 0.24rem' });
       expect(topGrid).toHaveStyle({ columnGap: '0.5rem' });
-      expect(screen.getByTestId('zone-cemetery-guest')).toHaveStyle({ minHeight: '108px' });
-      expect(screen.getByTestId('zone-field-guest')).toHaveStyle({ minHeight: '120px' });
-      expect(screen.getByTestId('zone-hand-guest')).toHaveStyle({ minHeight: '112px' });
-      expect(screen.getByTestId('zone-hand-host')).toHaveStyle({ minHeight: '120px' });
-      expect(screen.getByTestId('zone-leader-guest')).toHaveStyle({ minHeight: '124px' });
-      expect(screen.getByTestId('zone-leader-host')).toHaveStyle({ minHeight: '124px' });
+      expect(screen.getByTestId('zone-cemetery-guest')).toHaveStyle({ minHeight: '104px' });
+      expect(screen.getByTestId('zone-field-guest')).toHaveStyle({ minHeight: '116px' });
+      expect(screen.getByTestId('zone-hand-guest')).toHaveStyle({ minHeight: '108px' });
+      expect(screen.getByTestId('zone-hand-host')).toHaveStyle({ minHeight: '116px' });
+      expect(screen.getByTestId('zone-leader-guest')).toHaveStyle({ minHeight: '120px' });
+      expect(screen.getByTestId('zone-leader-host')).toHaveStyle({ minHeight: '120px' });
       expect(screen.getByTestId('bottom-board-row-secondary-wrap')).toHaveStyle({ marginTop: '0.2rem' });
       const hostControlsPanel = screen.getByTestId('player-tracker-host').parentElement as HTMLElement;
       expect(hostControlsPanel).toHaveStyle({ marginLeft: '1.35rem' });

--- a/src/pages/GameBoard.test.tsx
+++ b/src/pages/GameBoard.test.tsx
@@ -2988,6 +2988,8 @@ describe('GameBoard', () => {
       expect(screen.getByTestId('zone-hand-host')).toHaveStyle({ minHeight: '106px' });
       expect(screen.getByTestId('zone-leader-guest')).toHaveStyle({ minHeight: '110px' });
       expect(screen.getByTestId('zone-leader-host')).toHaveStyle({ minHeight: '110px' });
+      expect(screen.getByTestId('zone-cemetery-guest').parentElement).toHaveStyle({ gap: '0' });
+      expect(screen.getByTestId('zone-mainDeck-host').parentElement).toHaveStyle({ gap: '0' });
       const hostControlsPanel = screen.getByTestId('player-tracker-host').parentElement as HTMLElement;
       expect(hostControlsPanel).toHaveStyle({ marginLeft: '1.5rem' });
 

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -96,6 +96,7 @@ const GameBoard: React.FC = () => {
   const isCompactBoard = inputProfile === 'coarse';
   const isTabletLayout = layoutProfile === 'tablet';
   const isTabletCompactBoard = isCompactBoard && isTabletLayout;
+  const zoneActionPlacement = inputProfile === 'fine' && boardDensity === 'overview' ? 'overlay' : 'below';
   const {
     boardShellPadding,
     boardShellGap,
@@ -746,6 +747,7 @@ const GameBoard: React.FC = () => {
                       searchTitle={interactionBlockedTitle}
                       isSearchInteractive={canView}
                       useTapToOpenActions={isTabletCompactBoard}
+                      actionPlacement={zoneActionPlacement}
                     />
                     <Zone
                       id={`ex-${topRole}`}
@@ -772,6 +774,7 @@ const GameBoard: React.FC = () => {
                       searchTitle={interactionBlockedTitle}
                       isSearchInteractive={canView}
                       useTapToOpenActions={isTabletCompactBoard}
+                      actionPlacement={zoneActionPlacement}
                     />
                   </GameBoardBoardRow>
 
@@ -809,6 +812,7 @@ const GameBoard: React.FC = () => {
                         direction="up"
                         onActiveMenuChange={setActiveZoneActions}
                         useTapToOpenActions={isTabletCompactBoard}
+                        actionPlacement={zoneActionPlacement}
                       />
                       <Zone
                         id={`field-${topRole}`}
@@ -839,6 +843,7 @@ const GameBoard: React.FC = () => {
                         searchTitle={interactionBlockedTitle}
                         isSearchInteractive={canView}
                         useTapToOpenActions={isTabletCompactBoard}
+                        actionPlacement={zoneActionPlacement}
                       />
                   </GameBoardBoardRow>
                 </div>
@@ -862,6 +867,7 @@ const GameBoard: React.FC = () => {
                       searchLabel={t('gameBoard.zones.search')}
                       onSearch={() => openSearchZone(`cemetery-${topRole}`, t('gameBoard.zones.cemetery', { label: topLabel }))}
                       useTapToOpenActions={isTabletCompactBoard}
+                      actionPlacement={zoneActionPlacement}
                     />
                     <Zone
                       id={`ex-${topRole}`}
@@ -879,6 +885,7 @@ const GameBoard: React.FC = () => {
                       searchLabel={t('gameBoard.zones.search')}
                       onSearch={() => openSearchZone(`banish-${topRole}`, t('gameBoard.zones.banish', { label: topLabel }))}
                       useTapToOpenActions={isTabletCompactBoard}
+                      actionPlacement={zoneActionPlacement}
                     />
                   </GameBoardBoardRow>
 
@@ -916,6 +923,7 @@ const GameBoard: React.FC = () => {
                         direction="up"
                         onActiveMenuChange={setActiveZoneActions}
                         useTapToOpenActions={isTabletCompactBoard}
+                        actionPlacement={zoneActionPlacement}
                       />
                       <Zone
                         id={`field-${topRole}`}
@@ -938,6 +946,7 @@ const GameBoard: React.FC = () => {
                         searchLabel={t('common.buttons.search')}
                         onSearch={() => openSearchZone(`evolveDeck-${topRole}`, t('gameBoard.zones.evolveDeck', { label: topLabel }))}
                         useTapToOpenActions={isTabletCompactBoard}
+                        actionPlacement={zoneActionPlacement}
                       />
                   </GameBoardBoardRow>
                 </div>
@@ -988,6 +997,7 @@ const GameBoard: React.FC = () => {
                     searchTitle={interactionBlockedTitle}
                     isSearchInteractive={canView}
                     useTapToOpenActions={isTabletCompactBoard}
+                    actionPlacement={zoneActionPlacement}
                   />
                   <Zone id={`field-${bottomRole}`} label={t('gameBoard.zones.field', { label: bottomLabel })} cards={getCards(`field-${bottomRole}`)} cardStatLookup={cardStatLookup} cardDetailLookup={cardDetailLookup} getHighlightTone={getAttackHighlightTone} onInspectCard={handleInspectCard} onAttack={gameState.turnPlayer === bottomRole ? handleStartAttack : undefined} onTap={toggleTap} onModifyCounter={handleModifyCounter} onModifyGenericCounter={handleModifyGenericCounter} onSendToBottom={handleSendToBottom} onBanish={handleBanish} onReturnEvolve={handleReturnEvolve} onCemetery={handleSendToCemetery} onPlayToField={handlePlayToField} disableQuickActionsForCard={shouldDisableQuickActionsForAttackTarget} viewerRole={viewerRole} containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: fieldZoneMinHeight, width: `${centerZoneWidth}px`, flex: 'none' }} isDebug={isDebug} />
                   <GameBoardMainDeckSection
@@ -998,6 +1008,7 @@ const GameBoard: React.FC = () => {
                     actions={bottomMainDeckZoneActions.actions}
                     onActiveMenuChange={setActiveZoneActions}
                     useTapToOpenActions={isTabletCompactBoard}
+                    actionPlacement={zoneActionPlacement}
                   />
                   </GameBoardBoardRow>
 
@@ -1013,6 +1024,7 @@ const GameBoard: React.FC = () => {
                     searchTitle={interactionBlockedTitle}
                     isSearchInteractive={canView}
                     useTapToOpenActions={isTabletCompactBoard}
+                    actionPlacement={zoneActionPlacement}
                   />
 		                  <Zone id={`ex-${bottomRole}`} label={t('gameBoard.zones.exArea', { label: bottomLabel })} cards={getCards(`ex-${bottomRole}`)} cardStatLookup={cardStatLookup} cardDetailLookup={cardDetailLookup} onInspectCard={handleInspectCard} onModifyCounter={handleModifyCounter} onModifyGenericCounter={handleModifyGenericCounter} onSendToBottom={handleSendToBottom} onBanish={handleBanish} onReturnEvolve={handleReturnEvolve} onCemetery={handleSendToCemetery} onPlayToField={handlePlayToField} viewerRole={viewerRole} containerStyle={{ maxWidth: `${centerZoneWidth}px`, minHeight: stackZoneMinHeight, flex: 'none', width: `${centerZoneWidth}px` }} isDebug={isDebug} />
                   <GameBoardSearchableStackSection
@@ -1022,6 +1034,7 @@ const GameBoard: React.FC = () => {
                     searchTitle={interactionBlockedTitle}
                     isSearchInteractive={canView}
                     useTapToOpenActions={isTabletCompactBoard}
+                    actionPlacement={zoneActionPlacement}
                   />
 	                </GameBoardBoardRow>
                   </div>

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -52,6 +52,7 @@ import {
 import {
   activeBoardSectionStyle,
   resolveBoardLayout,
+  resolveBoardLayoutSpacing,
   soloMulliganButtonStyle,
 } from './gameBoardLayout';
 import {
@@ -95,27 +96,28 @@ const GameBoard: React.FC = () => {
   const isCompactBoard = inputProfile === 'coarse';
   const isTabletLayout = layoutProfile === 'tablet';
   const isTabletCompactBoard = isCompactBoard && isTabletLayout;
-  const isOverviewBoard = boardDensity === 'overview';
-  const boardShellPadding = isTabletCompactBoard ? '0.46rem' : isCompactBoard ? '0.52rem' : isOverviewBoard ? '0.48rem' : '1rem';
-  const boardShellGap = isTabletCompactBoard ? '0.4rem' : isCompactBoard ? '0.48rem' : isOverviewBoard ? '0.44rem' : '1rem';
-  const playmatPadding = isTabletCompactBoard ? '0.36rem' : isCompactBoard ? '0.42rem' : isOverviewBoard ? '0.44rem' : '1rem';
-  const playmatGap = isTabletCompactBoard ? '0.22rem' : isCompactBoard ? '0.24rem' : isOverviewBoard ? '0.24rem' : '0.5rem';
-  const boardSectionPadding = isTabletCompactBoard ? '0.24rem 0.28rem' : isCompactBoard ? '0.28rem 0.32rem' : isOverviewBoard ? '0.26rem 0.29rem' : '0.55rem 0.6rem';
-  const boardSectionGap = isTabletCompactBoard ? '0.18rem' : isCompactBoard ? '0.22rem' : isOverviewBoard ? '0.21rem' : '0.5rem';
-  const boardShellColumnGap = isCompactBoard ? '0.5rem' : isOverviewBoard ? '0.56rem' : '1rem';
-  const bottomPanelMarginLeft = isCompactBoard
-    ? (isTabletLayout ? '1.35rem' : '1.1rem')
-    : isOverviewBoard
-      ? '1.5rem'
-      : '1.25rem';
-  const boardColumnStackGap = isCompactBoard ? '0.34rem' : isOverviewBoard ? '0.29rem' : '0.65rem';
-  const bottomBoardRowSecondaryMarginTop = isTabletCompactBoard ? '0.2rem' : '0';
-  const boardSectionDividerMargin = isTabletCompactBoard ? '0.3rem 0' : isCompactBoard ? '0.4rem 0' : isOverviewBoard ? '0.18rem 0' : '1rem 0';
-  const stackZoneMinHeight = isTabletCompactBoard ? '108px' : isCompactBoard ? '110px' : isOverviewBoard ? '98px' : '150px';
-  const fieldZoneMinHeight = isTabletCompactBoard ? '120px' : isCompactBoard ? '124px' : isOverviewBoard ? '109px' : '160px';
-  const handZoneMinHeight = isTabletCompactBoard ? '112px' : isCompactBoard ? '116px' : isOverviewBoard ? '102px' : '150px';
-  const bottomHandZoneMinHeight = isTabletCompactBoard ? '120px' : isCompactBoard ? '124px' : isOverviewBoard ? '109px' : '160px';
-  const leaderZoneMinHeight = isTabletCompactBoard ? '124px' : isOverviewBoard ? '114px' : '150px';
+  const {
+    boardShellPadding,
+    boardShellGap,
+    playmatPadding,
+    playmatGap,
+    boardSectionPadding,
+    boardSectionGap,
+    boardShellColumnGap,
+    bottomPanelMarginLeft,
+    boardColumnStackGap,
+    bottomBoardRowSecondaryMarginTop,
+    boardSectionDividerMargin,
+    boardRowGap,
+    stackZoneMinHeight,
+    fieldZoneMinHeight,
+    handZoneMinHeight,
+    bottomHandZoneMinHeight,
+    leaderZoneMinHeight,
+  } = React.useMemo(
+    () => resolveBoardLayoutSpacing(inputProfile, layoutProfile, boardDensity),
+    [inputProfile, layoutProfile, boardDensity]
+  );
   const {
     sidePanelWidth,
     topPanelWidth,
@@ -460,6 +462,7 @@ const GameBoard: React.FC = () => {
     columns: boardColumns,
     width: boardContentWidth,
     centerWidth: centerZoneWidth,
+    rowGap: boardRowGap,
     minHeight: handZoneMinHeight,
     zoneProps: {
       id: `hand-${topRole}`,
@@ -493,6 +496,7 @@ const GameBoard: React.FC = () => {
     columns: boardColumns,
     width: boardContentWidth,
     centerWidth: centerZoneWidth,
+    rowGap: boardRowGap,
     justifyCenter: true,
     zoneProps: {
       id: `hand-${topRole}`,
@@ -734,7 +738,7 @@ const GameBoard: React.FC = () => {
                 <div style={{ width: `${boardContentWidth}px`, minWidth: 0, display: 'flex', flexDirection: 'column', gap: boardColumnStackGap, alignItems: 'flex-start' }}>
                   <GameBoardTopHandSection {...topSoloHandSectionProps} />
 
-                  <GameBoardBoardRow columns={boardColumns} width={boardContentWidth}>
+                  <GameBoardBoardRow columns={boardColumns} width={boardContentWidth} rowGap={boardRowGap}>
                     <GameBoardSearchableStackSection
                       zoneProps={{ id: `cemetery-${topRole}`, label: t('gameBoard.zones.cemetery', { label: topLabel }), cards: getCards(`cemetery-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                       searchLabel={t('gameBoard.zones.search')}
@@ -774,6 +778,7 @@ const GameBoard: React.FC = () => {
                   <GameBoardBoardRow
                     columns={boardColumns}
                     width={boardContentWidth}
+                    rowGap={boardRowGap}
                     overlay={
                       <GameBoardLeaderZoneSection
                         playerRole={topRole}
@@ -851,7 +856,7 @@ const GameBoard: React.FC = () => {
                 <div style={{ width: `${boardContentWidth}px`, minWidth: 0, display: 'flex', flexDirection: 'column', gap: boardColumnStackGap, alignItems: 'flex-start' }}>
                   <GameBoardTopHandSection {...topReadOnlyHandSectionProps} />
 
-                  <GameBoardBoardRow columns={boardColumns} width={boardContentWidth}>
+                  <GameBoardBoardRow columns={boardColumns} width={boardContentWidth} rowGap={boardRowGap}>
                     <GameBoardSearchableStackSection
                       zoneProps={{ id: `cemetery-${topRole}`, label: t('gameBoard.zones.cemetery', { label: topLabel }), cards: getCards(`cemetery-${topRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                       searchLabel={t('gameBoard.zones.search')}
@@ -880,6 +885,7 @@ const GameBoard: React.FC = () => {
                   <GameBoardBoardRow
                     columns={boardColumns}
                     width={boardContentWidth}
+                    rowGap={boardRowGap}
                     overlay={
                       <GameBoardLeaderZoneSection
                         playerRole={topRole}
@@ -954,6 +960,7 @@ const GameBoard: React.FC = () => {
 	                <GameBoardBoardRow
                     columns={boardColumns}
                     width={boardContentWidth}
+                    rowGap={boardRowGap}
                     overlay={
                       <GameBoardLeaderZoneSection
                         playerRole={bottomRole}
@@ -998,7 +1005,7 @@ const GameBoard: React.FC = () => {
                     data-testid="bottom-board-row-secondary-wrap"
                     style={{ marginTop: bottomBoardRowSecondaryMarginTop }}
                   >
-                  <GameBoardBoardRow columns={boardColumns} width={boardContentWidth}>
+                  <GameBoardBoardRow columns={boardColumns} width={boardContentWidth} rowGap={boardRowGap}>
                   <GameBoardSearchableStackSection
                     zoneProps={{ id: `banish-${bottomRole}`, label: t('gameBoard.zones.banish', { label: bottomLabel }), cards: getCards(`banish-${bottomRole}`), cardDetailLookup, layout: 'stack', onInspectCard: handleInspectCard, onModifyCounter: handleModifyCounter, onSendToBottom: handleSendToBottom, onCemetery: handleSendToCemetery, viewerRole, containerStyle: { minWidth: `${sideZoneWidth}px`, minHeight: stackZoneMinHeight }, isDebug }}
                     searchLabel={t('common.buttons.search')}

--- a/src/pages/gameBoardLayout.test.ts
+++ b/src/pages/gameBoardLayout.test.ts
@@ -6,6 +6,7 @@ import {
   centerZoneWidth,
   getBoardDensityForViewportWidth,
   getLayoutProfileForViewportWidth,
+  resolveBoardLayoutSpacing,
   resolveBoardLayout,
   sidePanelWidth,
   sideZoneWidth,
@@ -89,5 +90,43 @@ describe('gameBoardLayout', () => {
     expect(getBoardDensityForViewportWidth(1920, 1200, 'fine')).toBe('overview');
     expect(getBoardDensityForViewportWidth(1024, 900, 'fine')).toBe('standard');
     expect(getBoardDensityForViewportWidth(1024, 900, 'coarse')).toBe('standard');
+  });
+
+  it('centralizes compact overview spacing without changing card sizes', () => {
+    expect(resolveBoardLayoutSpacing('fine', 'desktop', 'overview')).toMatchObject({
+      boardShellPadding: '0.44rem',
+      boardShellGap: '0.36rem',
+      playmatPadding: '0.38rem',
+      playmatGap: '0.18rem',
+      boardSectionPadding: '0.22rem 0.26rem',
+      boardSectionGap: '0.18rem',
+      boardColumnStackGap: '0.24rem',
+      boardRowGap: '0.5rem',
+      boardSectionDividerMargin: '0.12rem 0',
+      stackZoneMinHeight: '96px',
+      fieldZoneMinHeight: '106px',
+      handZoneMinHeight: '100px',
+      bottomHandZoneMinHeight: '106px',
+      leaderZoneMinHeight: '110px',
+    });
+  });
+
+  it('centralizes tablet spacing around touch-safe zone heights', () => {
+    expect(resolveBoardLayoutSpacing('coarse', 'tablet', 'standard')).toMatchObject({
+      boardShellPadding: '0.42rem',
+      boardShellGap: '0.34rem',
+      playmatPadding: '0.32rem',
+      playmatGap: '0.18rem',
+      boardSectionPadding: '0.2rem 0.24rem',
+      boardSectionGap: '0.16rem',
+      boardColumnStackGap: '0.28rem',
+      boardRowGap: '0.42rem',
+      boardSectionDividerMargin: '0.24rem 0',
+      stackZoneMinHeight: '104px',
+      fieldZoneMinHeight: '116px',
+      handZoneMinHeight: '108px',
+      bottomHandZoneMinHeight: '116px',
+      leaderZoneMinHeight: '120px',
+    });
   });
 });

--- a/src/pages/gameBoardLayout.ts
+++ b/src/pages/gameBoardLayout.ts
@@ -15,6 +15,26 @@ export type GameBoardLayout = {
   boardShellColumns: string;
 };
 
+export type GameBoardLayoutSpacing = {
+  boardShellPadding: string;
+  boardShellGap: string;
+  playmatPadding: string;
+  playmatGap: string;
+  boardSectionPadding: string;
+  boardSectionGap: string;
+  boardShellColumnGap: string;
+  bottomPanelMarginLeft: string;
+  boardColumnStackGap: string;
+  bottomBoardRowSecondaryMarginTop: string;
+  boardSectionDividerMargin: string;
+  boardRowGap: string;
+  stackZoneMinHeight: string;
+  fieldZoneMinHeight: string;
+  handZoneMinHeight: string;
+  bottomHandZoneMinHeight: string;
+  leaderZoneMinHeight: string;
+};
+
 const TABLET_MIN_WIDTH = 900;
 const DESKTOP_MIN_WIDTH = 1280;
 const BOARD_SHELL_COLUMN_GAP = 16;
@@ -131,6 +151,102 @@ export const getBoardDensityForViewportWidth = (
     ? 'overview'
     : 'standard'
 );
+
+export const resolveBoardLayoutSpacing = (
+  inputProfile: GameBoardLayoutInputProfile = 'coarse',
+  layoutProfile: GameBoardLayoutProfile = 'desktop',
+  boardDensity: GameBoardBoardDensity = 'standard'
+): GameBoardLayoutSpacing => {
+  const isCompactBoard = inputProfile === 'coarse';
+  const isTabletCompactBoard = isCompactBoard && layoutProfile === 'tablet';
+  const isOverviewBoard = boardDensity === 'overview';
+
+  if (isTabletCompactBoard) {
+    return {
+      boardShellPadding: '0.42rem',
+      boardShellGap: '0.34rem',
+      playmatPadding: '0.32rem',
+      playmatGap: '0.18rem',
+      boardSectionPadding: '0.2rem 0.24rem',
+      boardSectionGap: '0.16rem',
+      boardShellColumnGap: '0.5rem',
+      bottomPanelMarginLeft: '1.35rem',
+      boardColumnStackGap: '0.28rem',
+      bottomBoardRowSecondaryMarginTop: '0.2rem',
+      boardSectionDividerMargin: '0.24rem 0',
+      boardRowGap: '0.42rem',
+      stackZoneMinHeight: '104px',
+      fieldZoneMinHeight: '116px',
+      handZoneMinHeight: '108px',
+      bottomHandZoneMinHeight: '116px',
+      leaderZoneMinHeight: '120px',
+    };
+  }
+
+  if (isOverviewBoard) {
+    return {
+      boardShellPadding: '0.44rem',
+      boardShellGap: '0.36rem',
+      playmatPadding: '0.38rem',
+      playmatGap: '0.18rem',
+      boardSectionPadding: '0.22rem 0.26rem',
+      boardSectionGap: '0.18rem',
+      boardShellColumnGap: '0.56rem',
+      bottomPanelMarginLeft: '1.5rem',
+      boardColumnStackGap: '0.24rem',
+      bottomBoardRowSecondaryMarginTop: '0',
+      boardSectionDividerMargin: '0.12rem 0',
+      boardRowGap: '0.5rem',
+      stackZoneMinHeight: '96px',
+      fieldZoneMinHeight: '106px',
+      handZoneMinHeight: '100px',
+      bottomHandZoneMinHeight: '106px',
+      leaderZoneMinHeight: '110px',
+    };
+  }
+
+  if (isCompactBoard) {
+    return {
+      boardShellPadding: '0.52rem',
+      boardShellGap: '0.48rem',
+      playmatPadding: '0.42rem',
+      playmatGap: '0.24rem',
+      boardSectionPadding: '0.28rem 0.32rem',
+      boardSectionGap: '0.22rem',
+      boardShellColumnGap: '0.5rem',
+      bottomPanelMarginLeft: '1.1rem',
+      boardColumnStackGap: '0.34rem',
+      bottomBoardRowSecondaryMarginTop: '0',
+      boardSectionDividerMargin: '0.4rem 0',
+      boardRowGap: '0.5rem',
+      stackZoneMinHeight: '110px',
+      fieldZoneMinHeight: '124px',
+      handZoneMinHeight: '116px',
+      bottomHandZoneMinHeight: '124px',
+      leaderZoneMinHeight: '150px',
+    };
+  }
+
+  return {
+    boardShellPadding: '1rem',
+    boardShellGap: '1rem',
+    playmatPadding: '1rem',
+    playmatGap: '0.5rem',
+    boardSectionPadding: '0.55rem 0.6rem',
+    boardSectionGap: '0.5rem',
+    boardShellColumnGap: '1rem',
+    bottomPanelMarginLeft: '1.25rem',
+    boardColumnStackGap: '0.65rem',
+    bottomBoardRowSecondaryMarginTop: '0',
+    boardSectionDividerMargin: '1rem 0',
+    boardRowGap: '0.75rem',
+    stackZoneMinHeight: '150px',
+    fieldZoneMinHeight: '160px',
+    handZoneMinHeight: '150px',
+    bottomHandZoneMinHeight: '160px',
+    leaderZoneMinHeight: '150px',
+  };
+};
 
 // Keep legacy exports as desktop defaults to avoid changing the existing PC path.
 export const sidePanelWidth = desktopGameBoardLayout.sidePanelWidth;


### PR DESCRIPTION
## Summary

GameBoard の PC / tablet 表示で、盤面全体の縦幅とゾーン間隔を改善しました。

主な変更点:

- GameBoard の spacing / zone height を `resolveBoardLayoutSpacing` に集約
- PC overview / tablet 向けに playmat, board section, zone の余白と高さを圧縮
- board row / hand row の gap を共通 token で制御
- PC overview では検索・メインデッキアクションを zone 内 overlay 表示にして縦幅を削減
- メインデッキアクションがカードスタックに隠れないよう z-index を調整
- 墓地 / 消滅のカードホバー quick action を無効化し、ドラッグとクリック詳細は維持
- 消滅検索モーダルから墓地へ送れる操作を追加
- 直近操作ログを固定高さ + 内部スクロールに変更し、ログ増加でヘッダ下が広がらないよう修正
- zone ラベルをわずかに大きくして視認性を改善

## Regression Risk

主なリスクは UI レイアウトです。

- PC / tablet の特定解像度で zone や overlay ボタンの重なりが出る可能性があります
- 墓地 / 消滅のホバー操作は意図的に無効化しているため、従来操作に慣れたユーザーには操作感の変化があります
- P2P の実ブラウザ間操作感とタブレット実機の細かい見え方は手動確認余地があります

カード移動や同期ロジック本体への変更は限定的です。

## Test Plan

- [x] `npm run lint`
- [x] `npx tsc --noEmit -p tsconfig.app.json`
- [x] `npx vitest run`
- [x] `npm run build`
- [x] `npm run test:e2e`

## Notes

E2E は Chromium / solo flow 中心です。リリース前に可能であれば、PC と tablet で以下を軽く目視確認してください。

- PC overview で全体の縦スクロール量が減っていること
- メインデッキの Actions ボタンがカードに隠れないこと
- 墓地 / 消滅のカードクリック詳細とドラッグが残っていること
- 直近ログが増えてもヘッダ下が伸びず、パネル内スクロールになること
