### PR TITLE
ラベルと 攻撃ボタンがかぶるのを修正

### DIFF
--- a/src/components/Card.test.tsx
+++ b/src/components/Card.test.tsx
@@ -874,4 +874,24 @@ describe('Card', () => {
     expect(cardElement).toHaveStyle({ zIndex: '1' });
   });
 
+  it('notifies the parent zone when fine-input quick actions are hovered', () => {
+    const onQuickActionsHoverChange = vi.fn();
+    render(
+      <Card
+        card={createCard({ zone: 'field-host', isTapped: true })}
+        baseStats={{ atk: 3, hp: 4 }}
+        onTap={vi.fn()}
+        onQuickActionsHoverChange={onQuickActionsHoverChange}
+      />
+    );
+
+    const cardElement = screen.getByAltText('Test Card').closest('.game-card') as HTMLElement;
+
+    fireEvent.pointerEnter(cardElement);
+    expect(onQuickActionsHoverChange).toHaveBeenCalledWith('card-1', true);
+
+    fireEvent.pointerLeave(cardElement);
+    expect(onQuickActionsHoverChange).toHaveBeenCalledWith('card-1', false);
+  });
+
 });

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -62,6 +62,7 @@ interface Props {
   onCemetery?: (id: string) => void;
   onPlayToField?: (id: string) => void;
   onCardTapAction?: (card: CardInstance, anchor: CardTapAnchor) => boolean | void;
+  onQuickActionsHoverChange?: (id: string, isHovered: boolean) => void;
   isHidden?: boolean; // if true, STRICTLY render card back only
   isLocked?: boolean; // if true, prevent dragging and operating (opponent's hand/deck/ex)
   quickActionsDisabled?: boolean;
@@ -69,7 +70,7 @@ interface Props {
   debugIndex?: number;
 }
 
-const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideCurrentStats, highlightTone, onInspect, onAttack, onTap, onModifyCounter, onModifyGenericCounter, onSendToBottom, onBanish, onReturnEvolve, onCemetery, onPlayToField, onCardTapAction, isHidden, isLocked, quickActionsDisabled, disableCombatAndCounterControls, debugIndex }) => {
+const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideCurrentStats, highlightTone, onInspect, onAttack, onTap, onModifyCounter, onModifyGenericCounter, onSendToBottom, onBanish, onReturnEvolve, onCemetery, onPlayToField, onCardTapAction, onQuickActionsHoverChange, isHidden, isLocked, quickActionsDisabled, disableCombatAndCounterControls, debugIndex }) => {
   const { t } = useTranslation();
   const inspectPointerStartRef = React.useRef<{ x: number; y: number } | null>(null);
   const cardElementRef = React.useRef<HTMLElement | null>(null);
@@ -394,10 +395,14 @@ const Card: React.FC<Props> = ({ card, baseStats, detail, displayCounters, hideC
       onPointerEnter={() => {
         if (!isCoarseInput && canShowQuickActionOverlay) {
           setIsDesktopQuickActionsHovered(true);
+          onQuickActionsHoverChange?.(card.id, true);
         }
       }}
       onPointerLeave={() => {
         setIsDesktopQuickActionsHovered(false);
+        if (!isCoarseInput && canShowQuickActionOverlay) {
+          onQuickActionsHoverChange?.(card.id, false);
+        }
       }}
       onContextMenu={(e) => {
         e.preventDefault();

--- a/src/components/Zone.test.tsx
+++ b/src/components/Zone.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Zone from './Zone';
 import type { CardInstance } from './Card';
@@ -36,10 +36,12 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('./Card', () => ({
-  default: ({ card, isHidden, isLocked, quickActionsDisabled, debugIndex, hideCurrentStats, displayCounters, baseStats, onSendToBottom, onBanish, onCemetery, onReturnEvolve }: { card: CardInstance; isHidden?: boolean; isLocked?: boolean; quickActionsDisabled?: boolean; debugIndex?: number; hideCurrentStats?: boolean; displayCounters?: { atk: number; hp: number }; baseStats?: { atk: number; hp: number }; onSendToBottom?: (id: string) => void; onBanish?: (id: string) => void; onCemetery?: (id: string) => void; onReturnEvolve?: (id: string) => void }) => (
+  default: ({ card, isHidden, isLocked, quickActionsDisabled, debugIndex, hideCurrentStats, displayCounters, baseStats, onSendToBottom, onBanish, onCemetery, onReturnEvolve, onQuickActionsHoverChange }: { card: CardInstance; isHidden?: boolean; isLocked?: boolean; quickActionsDisabled?: boolean; debugIndex?: number; hideCurrentStats?: boolean; displayCounters?: { atk: number; hp: number }; baseStats?: { atk: number; hp: number }; onSendToBottom?: (id: string) => void; onBanish?: (id: string) => void; onCemetery?: (id: string) => void; onReturnEvolve?: (id: string) => void; onQuickActionsHoverChange?: (id: string, isHovered: boolean) => void }) => (
     <div
       data-testid="mock-card"
       data-card-id={card.id}
+      onPointerEnter={() => onQuickActionsHoverChange?.(card.id, true)}
+      onPointerLeave={() => onQuickActionsHoverChange?.(card.id, false)}
       data-hidden={String(Boolean(isHidden))}
       data-locked={String(Boolean(isLocked))}
       data-quick-actions-disabled={String(Boolean(quickActionsDisabled))}
@@ -414,6 +416,26 @@ describe('Zone', () => {
 
     const zoneLabel = screen.getByText('Field');
     expect(zoneLabel.parentElement).toHaveStyle({ top: '-6px' });
+  });
+
+  it('raises the hovered card zone above adjacent zone labels', () => {
+    renderWithInputProfile(
+      'fine',
+      <Zone
+        id="field-host"
+        label="Field"
+        cards={[createCard('host-card')]}
+      />
+    );
+
+    const zone = screen.getByTestId('zone-field-host');
+    expect(zone.style.zIndex).toBe('');
+
+    fireEvent.pointerEnter(screen.getByTestId('mock-card'));
+    expect(zone).toHaveStyle({ zIndex: '240' });
+
+    fireEvent.pointerLeave(screen.getByTestId('mock-card'));
+    expect(zone.style.zIndex).toBe('');
   });
 
   it('uses tighter zone label chrome in desktop overview so evolve labels fit more naturally', () => {

--- a/src/components/Zone.tsx
+++ b/src/components/Zone.tsx
@@ -44,6 +44,7 @@ interface Props {
 
 const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLookup, onInspectCard, onAttack, onTap, onModifyCounter, onModifyGenericCounter, onSendToBottom, onBanish, onReturnEvolve, onCemetery, onPlayToField, onCardTapAction, onZoneTapAction, hideCards, layout = 'horizontal', isProtected, lockCards, disableQuickActionsForCard, getHighlightTone, viewerRole, containerStyle, isDebug }) => {
   const zoneTapPointerStartRef = React.useRef<{ x: number; y: number } | null>(null);
+  const [quickActionsHoveredCardId, setQuickActionsHoveredCardId] = React.useState<string | null>(null);
   const inputProfile = useGameBoardInputProfile();
   const boardDensity = useGameBoardBoardDensity();
   const isCompactInput = inputProfile === 'coarse';
@@ -80,6 +81,18 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
     cards.filter(c => c.linkedTo && cards.some(parent => parent.id === c.linkedTo)).map(c => c.id)
   );
   const topLevelCards = cards.filter(c => !validAttachedIds.has(c.id) && !validLinkedIds.has(c.id));
+  const handleQuickActionsHoverChange = React.useCallback((cardId: string, isHovered: boolean) => {
+    setQuickActionsHoveredCardId(current => {
+      if (isHovered) return cardId;
+      return current === cardId ? null : current;
+    });
+  }, []);
+
+  React.useEffect(() => {
+    if (!quickActionsHoveredCardId) return;
+    if (cards.some(card => card.id === quickActionsHoveredCardId)) return;
+    setQuickActionsHoveredCardId(null);
+  }, [cards, quickActionsHoveredCardId]);
 
   const renderLinkedCards = React.useCallback((linkedCards: CardInstance[], attachmentCount: number) => {
     if (linkedCards.length === 0) return null;
@@ -112,11 +125,12 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
           quickActionsDisabled={shouldDisableZoneQuickActions || disableQuickActionsForCard?.(linkedCard)}
           disableCombatAndCounterControls={true}
           onCardTapAction={onCardTapAction}
+          onQuickActionsHoverChange={handleQuickActionsHoverChange}
           debugIndex={isDebug ? index : undefined}
         />
       </div>
     ));
-  }, [attachmentLeftOffset, attachmentTopOffset, cardDetailLookup, cardStatLookup, disableQuickActionsForCard, getHighlightTone, hideCards, isDebug, isProtected, isReadOnlySpectator, linkedCardLeftOffset, linkedCardTopOffset, lockCards, onBanish, onCardTapAction, onCemetery, onInspectCard, onReturnEvolve, onSendToBottom, shouldDisableZoneQuickActions, viewerRole]);
+  }, [attachmentLeftOffset, attachmentTopOffset, cardDetailLookup, cardStatLookup, disableQuickActionsForCard, getHighlightTone, handleQuickActionsHoverChange, hideCards, isDebug, isProtected, isReadOnlySpectator, linkedCardLeftOffset, linkedCardTopOffset, lockCards, onBanish, onCardTapAction, onCemetery, onInspectCard, onReturnEvolve, onSendToBottom, shouldDisableZoneQuickActions, viewerRole]);
 
   return (
     <div
@@ -166,6 +180,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
               : '0.5rem',
         flexWrap: isStack ? 'nowrap' : 'wrap',
         alignItems: isStack ? 'center' : 'flex-start',
+        zIndex: quickActionsHoveredCardId ? 240 : undefined,
         transition: 'var(--transition-fast)',
         ...containerStyle
       }}
@@ -286,6 +301,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                       quickActionsDisabled={shouldDisableZoneQuickActions || disableQuickActionsForCard?.(card)}
                       disableCombatAndCounterControls={hasCardOnTop(card.id)}
                       onCardTapAction={onCardTapAction}
+                      onQuickActionsHoverChange={handleQuickActionsHoverChange}
                       debugIndex={isDebug ? index : undefined}
                     />
                     {renderLinkedCards(linkedCards, attachments.length)}
@@ -315,6 +331,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                           quickActionsDisabled={shouldDisableZoneQuickActions || disableQuickActionsForCard?.(attachedCard)}
                           disableCombatAndCounterControls={hasCardOnTop(attachedCard.id)}
                           onCardTapAction={onCardTapAction}
+                          onQuickActionsHoverChange={handleQuickActionsHoverChange}
                           debugIndex={isDebug ? i : undefined}
                         />
                       </div>
@@ -360,6 +377,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                 quickActionsDisabled={shouldDisableZoneQuickActions || disableQuickActionsForCard?.(card)}
                 disableCombatAndCounterControls={hasCardOnTop(card.id)}
                 onCardTapAction={onCardTapAction}
+                onQuickActionsHoverChange={handleQuickActionsHoverChange}
                 debugIndex={isDebug ? topLevelCards.indexOf(card) : undefined}
               />
               {renderLinkedCards(linkedCards, attachments.length)}
@@ -389,6 +407,7 @@ const Zone: React.FC<Props> = ({ id, label, cards, cardStatLookup, cardDetailLoo
                     quickActionsDisabled={shouldDisableZoneQuickActions || disableQuickActionsForCard?.(attachedCard)}
                     disableCombatAndCounterControls={hasCardOnTop(attachedCard.id)}
                     onCardTapAction={onCardTapAction}
+                    onQuickActionsHoverChange={handleQuickActionsHoverChange}
                     debugIndex={isDebug ? i : undefined}
                   />
                 </div>


### PR DESCRIPTION
gameboard のボタンが zone ラベルと被る問題を修正