### PR TITLE
Codex/add spectator

### DIFF
--- a/src/components/GameBoardHeader.tsx
+++ b/src/components/GameBoardHeader.tsx
@@ -16,6 +16,8 @@ type GameBoardHeaderProps = {
   role: PlayerRole;
   status: string;
   connectionState: GameBoardConnectionState;
+  spectatorCount: number;
+  maxSpectatorConnections: number;
   connectionBadgeTone: ConnectionBadgeTone;
   isRoomCopied: boolean;
   gameState: SyncState;
@@ -45,6 +47,8 @@ const GameBoardHeader: React.FC<GameBoardHeaderProps> = ({
   role,
   status,
   connectionState,
+  spectatorCount,
+  maxSpectatorConnections,
   connectionBadgeTone,
   isRoomCopied,
   gameState,
@@ -104,6 +108,8 @@ const GameBoardHeader: React.FC<GameBoardHeaderProps> = ({
         isHost={isHost}
         status={status}
         connectionState={connectionState}
+        spectatorCount={spectatorCount}
+        maxSpectatorConnections={maxSpectatorConnections}
         connectionBadgeTone={connectionBadgeTone}
         isRoomCopied={isRoomCopied}
         onCopyRoomId={onCopyRoomId}

--- a/src/components/GameBoardRoomStatus.tsx
+++ b/src/components/GameBoardRoomStatus.tsx
@@ -17,6 +17,8 @@ type GameBoardRoomStatusProps = {
   isHost: boolean;
   status: string;
   connectionState: ConnectionState;
+  spectatorCount?: number;
+  maxSpectatorConnections?: number;
   connectionBadgeTone: ConnectionBadgeTone;
   isRoomCopied: boolean;
   onCopyRoomId: () => void;
@@ -29,6 +31,8 @@ const GameBoardRoomStatus: React.FC<GameBoardRoomStatusProps> = ({
   isHost,
   status,
   connectionState,
+  spectatorCount = 0,
+  maxSpectatorConnections = 0,
   connectionBadgeTone,
   isRoomCopied,
   onCopyRoomId,
@@ -108,6 +112,26 @@ const GameBoardRoomStatus: React.FC<GameBoardRoomStatusProps> = ({
           }}
         >
           {connectionBadgeTone.label}
+        </span>
+      )}
+      {!isSoloMode && isHost && maxSpectatorConnections > 0 && (
+        <span
+          data-testid="spectator-count-badge"
+          style={{
+            padding: isOverviewControls ? '0.18rem 0.44rem' : '0.22rem 0.55rem',
+            borderRadius: '999px',
+            border: '1px solid rgba(125, 211, 252, 0.36)',
+            background: 'rgba(14, 165, 233, 0.12)',
+            color: '#bae6fd',
+            fontSize: pillFontSize,
+            fontWeight: 'bold',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {t('gameBoard.room.spectators', {
+            count: spectatorCount,
+            max: maxSpectatorConnections,
+          })}
         </span>
       )}
       <span

--- a/src/components/GameBoardStatusUi.test.tsx
+++ b/src/components/GameBoardStatusUi.test.tsx
@@ -75,6 +75,44 @@ describe('GameBoard extracted UI components - status and preparation', () => {
     expect(onCopyRoomId).toHaveBeenCalledTimes(1);
   });
 
+  it('shows spectator count only for host room status', () => {
+    const props = {
+      room: 'ROOM123',
+      isSoloMode: false,
+      status: 'Connected',
+      connectionState: 'connected' as const,
+      spectatorCount: 2,
+      maxSpectatorConnections: 4,
+      connectionBadgeTone: {
+        label: 'Connected',
+        background: 'rgba(16, 185, 129, 0.16)',
+        border: 'rgba(16, 185, 129, 0.4)',
+        color: '#d1fae5',
+      },
+      isRoomCopied: false,
+      onCopyRoomId: vi.fn(),
+      onReconnect: vi.fn(),
+    };
+
+    const { rerender } = render(
+      <GameBoardRoomStatus
+        {...props}
+        isHost={true}
+      />
+    );
+
+    expect(screen.getByTestId('spectator-count-badge')).toHaveTextContent('Spectators 2 / 4');
+
+    rerender(
+      <GameBoardRoomStatus
+        {...props}
+        isHost={false}
+      />
+    );
+
+    expect(screen.queryByTestId('spectator-count-badge')).not.toBeInTheDocument();
+  });
+
   it('renders reconnect action for disconnected guest state', () => {
     const onReconnect = vi.fn();
 

--- a/src/hooks/__tests__/gameBoardTestUtils.tsx
+++ b/src/hooks/__tests__/gameBoardTestUtils.tsx
@@ -243,6 +243,7 @@ export function HookHarness() {
     canInteract,
     canView,
     isSpectator,
+    spectatorCount,
     gameState,
     hasUndoableMove,
     canUndoTurn,
@@ -308,6 +309,7 @@ export function HookHarness() {
       <div data-testid="can-interact">{String(canInteract)}</div>
       <div data-testid="can-view">{String(canView)}</div>
       <div data-testid="is-spectator">{String(isSpectator)}</div>
+      <div data-testid="spectator-count">{String(spectatorCount)}</div>
       <div data-testid="host-hp">{gameState.host.hp}</div>
       <div data-testid="host-hand-count">{gameState.cards.filter((card: CardInstance) => card.zone === 'hand-host').length}</div>
       <div data-testid="host-ex-count">{gameState.cards.filter((card: CardInstance) => card.zone === 'ex-host').length}</div>

--- a/src/hooks/useGameBoardConnectionLifecycleState.ts
+++ b/src/hooks/useGameBoardConnectionLifecycleState.ts
@@ -3,25 +3,29 @@ import type { DataConnection } from 'peerjs';
 
 type UseGameBoardConnectionLifecycleStateArgs = {
   activeConnectionTokenRef: React.RefObject<string | null>;
-  activeSpectatorConnectionTokenRef: React.RefObject<string | null>;
   awaitingInitialSnapshotRef: React.RefObject<boolean>;
   clearPendingSnapshotMessage: () => void;
   clearReconnectTimer: () => void;
   clearSnapshotRequestTimer: () => void;
   connRef: React.RefObject<DataConnection | null>;
-  spectatorConnRef: React.RefObject<DataConnection | null>;
+  spectatorConnectionsRef: React.RefObject<Map<string, DataConnection>>;
+  setSpectatorCount: React.Dispatch<React.SetStateAction<number>>;
 };
 
 export const useGameBoardConnectionLifecycleState = ({
   activeConnectionTokenRef,
-  activeSpectatorConnectionTokenRef,
   awaitingInitialSnapshotRef,
   clearPendingSnapshotMessage,
   clearReconnectTimer,
   clearSnapshotRequestTimer,
   connRef,
-  spectatorConnRef,
+  spectatorConnectionsRef,
+  setSpectatorCount,
 }: UseGameBoardConnectionLifecycleStateArgs) => {
+  const updateSpectatorCount = React.useCallback(() => {
+    setSpectatorCount(spectatorConnectionsRef.current.size);
+  }, [setSpectatorCount, spectatorConnectionsRef]);
+
   const clearActiveConnectionLifecycleState = React.useCallback(() => {
     connRef.current = null;
     activeConnectionTokenRef.current = null;
@@ -37,9 +41,16 @@ export const useGameBoardConnectionLifecycleState = ({
   ]);
 
   const clearSpectatorConnectionLifecycleState = React.useCallback(() => {
-    spectatorConnRef.current = null;
-    activeSpectatorConnectionTokenRef.current = null;
-  }, [activeSpectatorConnectionTokenRef, spectatorConnRef]);
+    spectatorConnectionsRef.current.clear();
+    updateSpectatorCount();
+  }, [spectatorConnectionsRef, updateSpectatorCount]);
+
+  const removeSpectatorConnection = React.useCallback((token: string, conn: DataConnection) => {
+    if (spectatorConnectionsRef.current.get(token) !== conn) return;
+
+    spectatorConnectionsRef.current.delete(token);
+    updateSpectatorCount();
+  }, [spectatorConnectionsRef, updateSpectatorCount]);
 
   const prepareActiveConnection = React.useCallback((conn: DataConnection, token: string) => {
     activeConnectionTokenRef.current = token;
@@ -65,22 +76,14 @@ export const useGameBoardConnectionLifecycleState = ({
   ]);
 
   const prepareSpectatorConnection = React.useCallback((conn: DataConnection, token: string) => {
-    activeSpectatorConnectionTokenRef.current = token;
-
-    if (spectatorConnRef.current && spectatorConnRef.current !== conn) {
-      try {
-        spectatorConnRef.current.close();
-      } catch {
-        // Ignore close races on replaced spectator connections.
-      }
-    }
-
-    spectatorConnRef.current = conn;
-  }, [activeSpectatorConnectionTokenRef, spectatorConnRef]);
+    spectatorConnectionsRef.current.set(token, conn);
+    updateSpectatorCount();
+  }, [spectatorConnectionsRef, updateSpectatorCount]);
 
   return {
     clearActiveConnectionLifecycleState,
     clearSpectatorConnectionLifecycleState,
+    removeSpectatorConnection,
     prepareActiveConnection,
     prepareSpectatorConnection,
   };

--- a/src/hooks/useGameBoardConnectionLifecycleState.ts
+++ b/src/hooks/useGameBoardConnectionLifecycleState.ts
@@ -8,6 +8,7 @@ type UseGameBoardConnectionLifecycleStateArgs = {
   clearReconnectTimer: () => void;
   clearSnapshotRequestTimer: () => void;
   connRef: React.RefObject<DataConnection | null>;
+  openedSpectatorConnectionTokensRef: React.RefObject<Set<string>>;
   spectatorConnectionsRef: React.RefObject<Map<string, DataConnection>>;
   setSpectatorCount: React.Dispatch<React.SetStateAction<number>>;
 };
@@ -19,6 +20,7 @@ export const useGameBoardConnectionLifecycleState = ({
   clearReconnectTimer,
   clearSnapshotRequestTimer,
   connRef,
+  openedSpectatorConnectionTokensRef,
   spectatorConnectionsRef,
   setSpectatorCount,
 }: UseGameBoardConnectionLifecycleStateArgs) => {
@@ -42,15 +44,39 @@ export const useGameBoardConnectionLifecycleState = ({
 
   const clearSpectatorConnectionLifecycleState = React.useCallback(() => {
     spectatorConnectionsRef.current.clear();
+    openedSpectatorConnectionTokensRef.current.clear();
     updateSpectatorCount();
-  }, [spectatorConnectionsRef, updateSpectatorCount]);
+  }, [openedSpectatorConnectionTokensRef, spectatorConnectionsRef, updateSpectatorCount]);
+
+  const markSpectatorConnectionOpen = React.useCallback((token: string, conn: DataConnection) => {
+    if (spectatorConnectionsRef.current.get(token) !== conn) return;
+
+    openedSpectatorConnectionTokensRef.current.add(token);
+  }, [openedSpectatorConnectionTokensRef, spectatorConnectionsRef]);
 
   const removeSpectatorConnection = React.useCallback((token: string, conn: DataConnection) => {
     if (spectatorConnectionsRef.current.get(token) !== conn) return;
 
     spectatorConnectionsRef.current.delete(token);
+    openedSpectatorConnectionTokensRef.current.delete(token);
     updateSpectatorCount();
-  }, [spectatorConnectionsRef, updateSpectatorCount]);
+  }, [openedSpectatorConnectionTokensRef, spectatorConnectionsRef, updateSpectatorCount]);
+
+  const pruneInactiveSpectatorConnections = React.useCallback(() => {
+    let didPrune = false;
+
+    spectatorConnectionsRef.current.forEach((conn, token) => {
+      if (conn.open || !openedSpectatorConnectionTokensRef.current.has(token)) return;
+
+      spectatorConnectionsRef.current.delete(token);
+      openedSpectatorConnectionTokensRef.current.delete(token);
+      didPrune = true;
+    });
+
+    if (didPrune) {
+      updateSpectatorCount();
+    }
+  }, [openedSpectatorConnectionTokensRef, spectatorConnectionsRef, updateSpectatorCount]);
 
   const prepareActiveConnection = React.useCallback((conn: DataConnection, token: string) => {
     activeConnectionTokenRef.current = token;
@@ -83,6 +109,8 @@ export const useGameBoardConnectionLifecycleState = ({
   return {
     clearActiveConnectionLifecycleState,
     clearSpectatorConnectionLifecycleState,
+    markSpectatorConnectionOpen,
+    pruneInactiveSpectatorConnections,
     removeSpectatorConnection,
     prepareActiveConnection,
     prepareSpectatorConnection,

--- a/src/hooks/useGameBoardConnectionSetup.ts
+++ b/src/hooks/useGameBoardConnectionSetup.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { DataConnection } from 'peerjs';
 import { getPeerIncomingConnectionDecision } from '../utils/gameBoardPeerIncomingConnection';
+import { MAX_SPECTATOR_CONNECTIONS } from '../utils/gameBoardSpectators';
 
 type ConnectionRole = 'guest' | 'spectator';
 
@@ -11,7 +12,6 @@ type DataConnectionWithMetadata = DataConnection & {
 };
 
 type UseGameBoardConnectionSetupArgs = {
-  clearSpectatorConnectionLifecycleState: () => void;
   handleConnectionLifecycleEvent: (token: string, kind: 'close' | 'error') => void;
   handleConnectionOpen: (conn: DataConnection, token: string) => void;
   handleIncomingConnectionData: (conn: DataConnection, token: string, rawData: unknown) => void;
@@ -19,12 +19,13 @@ type UseGameBoardConnectionSetupArgs = {
   isActiveSpectatorConnectionToken: (token: string) => boolean;
   isHost: boolean;
   prepareActiveConnection: (conn: DataConnection, token: string) => void;
+  removeSpectatorConnection: (token: string, conn: DataConnection) => void;
   prepareSpectatorConnection: (conn: DataConnection, token: string) => void;
+  spectatorConnectionsRef: React.RefObject<Map<string, DataConnection>>;
   uuidFactory: () => string;
 };
 
 export const useGameBoardConnectionSetup = ({
-  clearSpectatorConnectionLifecycleState,
   handleConnectionLifecycleEvent,
   handleConnectionOpen,
   handleIncomingConnectionData,
@@ -32,7 +33,9 @@ export const useGameBoardConnectionSetup = ({
   isActiveSpectatorConnectionToken,
   isHost,
   prepareActiveConnection,
+  removeSpectatorConnection,
   prepareSpectatorConnection,
+  spectatorConnectionsRef,
   uuidFactory,
 }: UseGameBoardConnectionSetupArgs) => {
   const setupConnection = React.useCallback((conn: DataConnection) => {
@@ -58,27 +61,33 @@ export const useGameBoardConnectionSetup = ({
     uuidFactory,
   ]);
 
-  const handleSpectatorConnectionLifecycleEvent = React.useCallback((token: string) => {
+  const handleSpectatorConnectionLifecycleEvent = React.useCallback((conn: DataConnection, token: string) => {
     if (!isActiveSpectatorConnectionToken(token)) return;
-    clearSpectatorConnectionLifecycleState();
-  }, [clearSpectatorConnectionLifecycleState, isActiveSpectatorConnectionToken]);
+    removeSpectatorConnection(token, conn);
+  }, [isActiveSpectatorConnectionToken, removeSpectatorConnection]);
 
   const setupSpectatorConnection = React.useCallback((conn: DataConnection) => {
+    if (spectatorConnectionsRef.current.size >= MAX_SPECTATOR_CONNECTIONS) {
+      conn.close();
+      return;
+    }
+
     const token = uuidFactory();
     prepareSpectatorConnection(conn, token);
     conn.on('data', (rawData: unknown) => {
       handleIncomingSpectatorConnectionData(conn, token, rawData);
     });
     conn.on('close', () => {
-      handleSpectatorConnectionLifecycleEvent(token);
+      handleSpectatorConnectionLifecycleEvent(conn, token);
     });
     conn.on('error', () => {
-      handleSpectatorConnectionLifecycleEvent(token);
+      handleSpectatorConnectionLifecycleEvent(conn, token);
     });
   }, [
     handleIncomingSpectatorConnectionData,
     handleSpectatorConnectionLifecycleEvent,
     prepareSpectatorConnection,
+    spectatorConnectionsRef,
     uuidFactory,
   ]);
 

--- a/src/hooks/useGameBoardConnectionSetup.ts
+++ b/src/hooks/useGameBoardConnectionSetup.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { DataConnection } from 'peerjs';
+import type { SyncMessage } from '../types/sync';
 import { getPeerIncomingConnectionDecision } from '../utils/gameBoardPeerIncomingConnection';
 import { MAX_SPECTATOR_CONNECTIONS } from '../utils/gameBoardSpectators';
 
@@ -18,7 +19,9 @@ type UseGameBoardConnectionSetupArgs = {
   handleIncomingSpectatorConnectionData: (conn: DataConnection, token: string, rawData: unknown) => void;
   isActiveSpectatorConnectionToken: (token: string) => boolean;
   isHost: boolean;
+  markSpectatorConnectionOpen: (token: string, conn: DataConnection) => void;
   prepareActiveConnection: (conn: DataConnection, token: string) => void;
+  pruneInactiveSpectatorConnections: () => void;
   removeSpectatorConnection: (token: string, conn: DataConnection) => void;
   prepareSpectatorConnection: (conn: DataConnection, token: string) => void;
   spectatorConnectionsRef: React.RefObject<Map<string, DataConnection>>;
@@ -32,7 +35,9 @@ export const useGameBoardConnectionSetup = ({
   handleIncomingSpectatorConnectionData,
   isActiveSpectatorConnectionToken,
   isHost,
+  markSpectatorConnectionOpen,
   prepareActiveConnection,
+  pruneInactiveSpectatorConnections,
   removeSpectatorConnection,
   prepareSpectatorConnection,
   spectatorConnectionsRef,
@@ -67,6 +72,8 @@ export const useGameBoardConnectionSetup = ({
   }, [isActiveSpectatorConnectionToken, removeSpectatorConnection]);
 
   const setupSpectatorConnection = React.useCallback((conn: DataConnection) => {
+    pruneInactiveSpectatorConnections();
+
     if (spectatorConnectionsRef.current.size >= MAX_SPECTATOR_CONNECTIONS) {
       conn.close();
       return;
@@ -74,7 +81,16 @@ export const useGameBoardConnectionSetup = ({
 
     const token = uuidFactory();
     prepareSpectatorConnection(conn, token);
+    conn.on('open', () => {
+      markSpectatorConnectionOpen(token, conn);
+    });
     conn.on('data', (rawData: unknown) => {
+      const data = rawData as SyncMessage;
+      if (data.type === 'SPECTATOR_LEAVE') {
+        removeSpectatorConnection(token, conn);
+        return;
+      }
+
       handleIncomingSpectatorConnectionData(conn, token, rawData);
     });
     conn.on('close', () => {
@@ -86,7 +102,10 @@ export const useGameBoardConnectionSetup = ({
   }, [
     handleIncomingSpectatorConnectionData,
     handleSpectatorConnectionLifecycleEvent,
+    markSpectatorConnectionOpen,
     prepareSpectatorConnection,
+    pruneInactiveSpectatorConnections,
+    removeSpectatorConnection,
     spectatorConnectionsRef,
     uuidFactory,
   ]);

--- a/src/hooks/useGameBoardLogic.test.tsx
+++ b/src/hooks/useGameBoardLogic.test.tsx
@@ -753,7 +753,7 @@ describe('useGameBoardLogic P2P reconnect', () => {
     expect(spectatorConn.send).not.toHaveBeenCalled();
   });
 
-  it('replaces the previous spectator without replacing the guest connection', () => {
+  it('keeps multiple spectators active without replacing the guest connection', () => {
     renderHarness('/game?host=true&room=ROOM123');
 
     const peer = mockPeerJs.peers[0];
@@ -774,8 +774,9 @@ describe('useGameBoardLogic P2P reconnect', () => {
       secondSpectatorConn.open = true;
     });
 
-    expect(firstSpectatorConn.close).toHaveBeenCalledTimes(1);
+    expect(firstSpectatorConn.close).not.toHaveBeenCalled();
     expect(screen.getByTestId('connection-state')).toHaveTextContent('connected');
+    expect(screen.getByTestId('spectator-count')).toHaveTextContent('2');
 
     guestConn.send.mockClear();
     firstSpectatorConn.send.mockClear();
@@ -789,14 +790,17 @@ describe('useGameBoardLogic P2P reconnect', () => {
       type: 'STATE_SNAPSHOT',
       source: 'host',
     }));
-    expect(firstSpectatorConn.send).not.toHaveBeenCalled();
+    expect(firstSpectatorConn.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'STATE_SNAPSHOT',
+      source: 'host',
+    }));
     expect(secondSpectatorConn.send).toHaveBeenCalledWith(expect.objectContaining({
       type: 'STATE_SNAPSHOT',
       source: 'host',
     }));
   });
 
-  it('ignores snapshot requests from a replaced spectator connection on the host side', () => {
+  it('responds to snapshot requests from every active spectator connection on the host side', () => {
     renderHarness('/game?host=true&room=ROOM123');
 
     const peer = mockPeerJs.peers[0];
@@ -828,8 +832,13 @@ describe('useGameBoardLogic P2P reconnect', () => {
       });
     });
 
-    expect(firstSpectatorConn.send).not.toHaveBeenCalled();
+    expect(firstSpectatorConn.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'STATE_SNAPSHOT',
+      source: 'host',
+    }));
     expect(secondSpectatorConn.send).not.toHaveBeenCalled();
+
+    firstSpectatorConn.send.mockClear();
 
     act(() => {
       secondSpectatorConn.emit('data', {
@@ -839,13 +848,14 @@ describe('useGameBoardLogic P2P reconnect', () => {
       });
     });
 
+    expect(firstSpectatorConn.send).not.toHaveBeenCalled();
     expect(secondSpectatorConn.send).toHaveBeenCalledWith(expect.objectContaining({
       type: 'STATE_SNAPSHOT',
       source: 'host',
     }));
   });
 
-  it('ignores stale closes from a replaced spectator connection on the host side', () => {
+  it('removes only the closed spectator connection on the host side', () => {
     renderHarness('/game?host=true&room=ROOM123');
 
     const peer = mockPeerJs.peers[0];
@@ -874,10 +884,16 @@ describe('useGameBoardLogic P2P reconnect', () => {
 
     act(() => {
       firstSpectatorConn.emit('close');
+      firstSpectatorConn.emit('data', {
+        type: 'REQUEST_SNAPSHOT',
+        lastKnownRevision: 0,
+        source: 'guest',
+      });
       fireEvent.click(screen.getByRole('button', { name: 'Spawn Token to EX' }));
     });
 
     expect(screen.getByTestId('connection-state')).toHaveTextContent('connected');
+    expect(screen.getByTestId('spectator-count')).toHaveTextContent('1');
     expect(guestConn.send).toHaveBeenCalledWith(expect.objectContaining({
       type: 'STATE_SNAPSHOT',
       source: 'host',
@@ -889,7 +905,7 @@ describe('useGameBoardLogic P2P reconnect', () => {
     }));
   });
 
-  it('ignores stale errors from a replaced spectator connection on the host side', () => {
+  it('removes only the errored spectator connection on the host side', () => {
     renderHarness('/game?host=true&room=ROOM123');
 
     const peer = mockPeerJs.peers[0];
@@ -922,6 +938,7 @@ describe('useGameBoardLogic P2P reconnect', () => {
     });
 
     expect(screen.getByTestId('connection-state')).toHaveTextContent('connected');
+    expect(screen.getByTestId('spectator-count')).toHaveTextContent('1');
     expect(guestConn.send).toHaveBeenCalledWith(expect.objectContaining({
       type: 'STATE_SNAPSHOT',
       source: 'host',
@@ -931,6 +948,52 @@ describe('useGameBoardLogic P2P reconnect', () => {
       type: 'STATE_SNAPSHOT',
       source: 'host',
     }));
+  });
+
+  it('rejects a fifth spectator while keeping the first four active', () => {
+    renderHarness('/game?host=true&room=ROOM123');
+
+    const peer = mockPeerJs.peers[0];
+    act(() => {
+      peer.emit('open');
+    });
+
+    const guestConn = mockPeerJs.createConnection('guest');
+    const spectatorConns = Array.from({ length: 5 }, (_, index) => (
+      mockPeerJs.createConnection(`spectator-${index + 1}`, { connectionRole: 'spectator' })
+    ));
+    act(() => {
+      peer.emit('connection', guestConn);
+      guestConn.open = true;
+      guestConn.emit('open');
+      spectatorConns.forEach((spectatorConn) => {
+        peer.emit('connection', spectatorConn);
+        spectatorConn.open = true;
+        spectatorConn.emit('open');
+      });
+    });
+
+    expect(spectatorConns[4].close).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('spectator-count')).toHaveTextContent('4');
+
+    guestConn.send.mockClear();
+    spectatorConns.forEach((spectatorConn) => spectatorConn.send.mockClear());
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Spawn Token to EX' }));
+    });
+
+    expect(guestConn.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'STATE_SNAPSHOT',
+      source: 'host',
+    }));
+    spectatorConns.slice(0, 4).forEach((spectatorConn) => {
+      expect(spectatorConn.send).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'STATE_SNAPSHOT',
+        source: 'host',
+      }));
+    });
+    expect(spectatorConns[4].send).not.toHaveBeenCalled();
   });
 
   it('ignores spectator events on the host side and does not treat spectator close as guest disconnect', () => {

--- a/src/hooks/useGameBoardLogic.test.tsx
+++ b/src/hooks/useGameBoardLogic.test.tsx
@@ -996,6 +996,151 @@ describe('useGameBoardLogic P2P reconnect', () => {
     expect(spectatorConns[4].send).not.toHaveBeenCalled();
   });
 
+  it('sends a leave message and closes the spectator connection on pagehide', () => {
+    renderHarness('/game?spectator=true&room=ROOM123');
+
+    const peer = mockPeerJs.peers[0];
+    act(() => {
+      peer.emit('open');
+    });
+
+    const conn = peer.connections[0];
+    act(() => {
+      conn.open = true;
+      conn.emit('open');
+    });
+
+    conn.send.mockClear();
+
+    act(() => {
+      window.dispatchEvent(new Event('pagehide'));
+    });
+
+    expect(conn.send).toHaveBeenCalledWith({
+      type: 'SPECTATOR_LEAVE',
+    });
+    expect(conn.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes a leaving spectator and lets a new spectator use the freed slot', () => {
+    renderHarness('/game?host=true&room=ROOM123');
+
+    const peer = mockPeerJs.peers[0];
+    act(() => {
+      peer.emit('open');
+    });
+
+    const guestConn = mockPeerJs.createConnection('guest');
+    const spectatorConns = Array.from({ length: 5 }, (_, index) => (
+      mockPeerJs.createConnection(`spectator-${index + 1}`, { connectionRole: 'spectator' })
+    ));
+    act(() => {
+      peer.emit('connection', guestConn);
+      guestConn.open = true;
+      guestConn.emit('open');
+      spectatorConns.slice(0, 4).forEach((spectatorConn) => {
+        peer.emit('connection', spectatorConn);
+        spectatorConn.open = true;
+        spectatorConn.emit('open');
+      });
+      spectatorConns[0].emit('data', {
+        type: 'SPECTATOR_LEAVE',
+      });
+      peer.emit('connection', spectatorConns[4]);
+      spectatorConns[4].open = true;
+      spectatorConns[4].emit('open');
+    });
+
+    expect(screen.getByTestId('spectator-count')).toHaveTextContent('4');
+    expect(spectatorConns[4].close).not.toHaveBeenCalled();
+
+    guestConn.send.mockClear();
+    spectatorConns.forEach((spectatorConn) => spectatorConn.send.mockClear());
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Spawn Token to EX' }));
+    });
+
+    expect(guestConn.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'STATE_SNAPSHOT',
+      source: 'host',
+    }));
+    expect(spectatorConns[0].send).not.toHaveBeenCalled();
+    spectatorConns.slice(1).forEach((spectatorConn) => {
+      expect(spectatorConn.send).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'STATE_SNAPSHOT',
+        source: 'host',
+      }));
+    });
+  });
+
+  it('prunes non-open spectator connections before enforcing the spectator limit', () => {
+    renderHarness('/game?host=true&room=ROOM123');
+
+    const peer = mockPeerJs.peers[0];
+    act(() => {
+      peer.emit('open');
+    });
+
+    const spectatorConns = Array.from({ length: 5 }, (_, index) => (
+      mockPeerJs.createConnection(`spectator-${index + 1}`, { connectionRole: 'spectator' })
+    ));
+    act(() => {
+      spectatorConns.slice(0, 4).forEach((spectatorConn) => {
+        peer.emit('connection', spectatorConn);
+        spectatorConn.open = true;
+        spectatorConn.emit('open');
+      });
+    });
+
+    spectatorConns[0].open = false;
+
+    act(() => {
+      peer.emit('connection', spectatorConns[4]);
+      spectatorConns[4].open = true;
+      spectatorConns[4].emit('open');
+    });
+
+    expect(spectatorConns[4].close).not.toHaveBeenCalled();
+    expect(screen.getByTestId('spectator-count')).toHaveTextContent('4');
+
+    spectatorConns.forEach((spectatorConn) => spectatorConn.send.mockClear());
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Spawn Token to EX' }));
+    });
+
+    expect(spectatorConns[0].send).not.toHaveBeenCalled();
+    spectatorConns.slice(1).forEach((spectatorConn) => {
+      expect(spectatorConn.send).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'STATE_SNAPSHOT',
+        source: 'host',
+      }));
+    });
+  });
+
+  it('does not prune spectator connections that have not opened yet', () => {
+    renderHarness('/game?host=true&room=ROOM123');
+
+    const peer = mockPeerJs.peers[0];
+    act(() => {
+      peer.emit('open');
+    });
+
+    const spectatorConns = Array.from({ length: 5 }, (_, index) => (
+      mockPeerJs.createConnection(`spectator-${index + 1}`, { connectionRole: 'spectator' })
+    ));
+    act(() => {
+      spectatorConns.slice(0, 4).forEach((spectatorConn) => {
+        peer.emit('connection', spectatorConn);
+      });
+      peer.emit('connection', spectatorConns[4]);
+    });
+
+    expect(spectatorConns[4].close).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('spectator-count')).toHaveTextContent('4');
+  });
+
   it('ignores spectator events on the host side and does not treat spectator close as guest disconnect', () => {
     renderHarness('/game?host=true&room=ROOM123');
 

--- a/src/hooks/useGameBoardLogic.ts
+++ b/src/hooks/useGameBoardLogic.ts
@@ -33,6 +33,7 @@ import { getSnapshotRetryTimeoutDecision } from '../utils/gameBoardSnapshotRetry
 import { buildDebugGameBoardState } from '../utils/gameBoardDebugState';
 import { getCanUndoMove, getCanUndoTurn } from '../utils/gameBoardUndoAvailability';
 import { getTurnMessageDecision } from '../utils/gameBoardTurnMessage';
+import { MAX_SPECTATOR_CONNECTIONS } from '../utils/gameBoardSpectators';
 
 import { getCanInteractWithGameBoard, getCanViewGameBoard } from '../utils/gameBoardInteraction';
 import {
@@ -122,6 +123,7 @@ export const useGameBoardLogic = () => {
   const [statusKey, setStatusKey] = useState<GameBoardStatusKey>('gameBoard.status.initializing');
   const status = t(statusKey);
   const [connectionState, setConnectionState] = useState<ConnectionState>('idle');
+  const [spectatorCount, setSpectatorCount] = useState(0);
   const canInteract = getCanInteractWithGameBoard({ isSoloMode, isHost, isSpectator, connectionState });
   const canView = getCanViewGameBoard({ isSoloMode, isHost, connectionState });
   const [gameState, setGameState] = useState<SyncState>(initialState);
@@ -143,7 +145,7 @@ export const useGameBoardLogic = () => {
 
   const peerRef = useRef<Peer | null>(null);
   const connRef = useRef<DataConnection | null>(null);
-  const spectatorConnRef = useRef<DataConnection | null>(null);
+  const spectatorConnectionsRef = useRef<Map<string, DataConnection>>(new Map());
   const setupConnectionRef = useRef<(conn: DataConnection) => void>(() => undefined);
   const gameStateRef = useRef<SyncState>(initialState);
   const {
@@ -160,7 +162,6 @@ export const useGameBoardLogic = () => {
   const topDeckTargetRoleRef = useRef<PlayerRole>(role);
   const awaitingInitialSnapshotRef = useRef(false);
   const activeConnectionTokenRef = useRef<string | null>(null);
-  const activeSpectatorConnectionTokenRef = useRef<string | null>(null);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const snapshotRequestTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const snapshotRetryCountRef = useRef(0);
@@ -208,7 +209,7 @@ export const useGameBoardLogic = () => {
 
   const { sendMessage, clearPendingSnapshotMessage } = useGameBoardSnapshotMessaging({
     connRef,
-    spectatorConnRef,
+    spectatorConnectionsRef,
   });
 
   const clearReconnectTimer = useCallback(() => {
@@ -871,7 +872,7 @@ export const useGameBoardLogic = () => {
   }, []);
 
   const isActiveSpectatorConnectionToken = useCallback((token: string) => {
-    return activeSpectatorConnectionTokenRef.current === token;
+    return spectatorConnectionsRef.current.has(token);
   }, []);
 
   const isCurrentActiveConnection = useCallback((conn: DataConnection, token: string) => {
@@ -944,17 +945,18 @@ export const useGameBoardLogic = () => {
   const {
     clearActiveConnectionLifecycleState,
     clearSpectatorConnectionLifecycleState,
+    removeSpectatorConnection,
     prepareActiveConnection,
     prepareSpectatorConnection,
   } = useGameBoardConnectionLifecycleState({
     activeConnectionTokenRef,
-    activeSpectatorConnectionTokenRef,
     awaitingInitialSnapshotRef,
     clearPendingSnapshotMessage,
     clearReconnectTimer,
     clearSnapshotRequestTimer,
     connRef,
-    spectatorConnRef,
+    spectatorConnectionsRef,
+    setSpectatorCount,
   });
 
   const handleConnectionTermination = useCallback((kind: 'close' | 'error') => {
@@ -1000,7 +1002,6 @@ export const useGameBoardLogic = () => {
   }, [handleConnectionTermination, isActiveConnectionToken]);
 
   const { setupConnection, handlePeerIncomingConnection } = useGameBoardConnectionSetup({
-    clearSpectatorConnectionLifecycleState,
     handleConnectionLifecycleEvent,
     handleConnectionOpen,
     handleIncomingConnectionData,
@@ -1008,7 +1009,9 @@ export const useGameBoardLogic = () => {
     isActiveSpectatorConnectionToken,
     isHost,
     prepareActiveConnection,
+    removeSpectatorConnection,
     prepareSpectatorConnection,
+    spectatorConnectionsRef,
     uuidFactory: uuid,
   });
 
@@ -1280,7 +1283,7 @@ export const useGameBoardLogic = () => {
   ];
 
   return {
-    room, mode, isSoloMode, isHost, isSpectator, role, status, connectionState, canInteract, canView, attemptReconnect, gameState, savedSessionCandidate, resumeSavedSession, discardSavedSession, searchZone, setSearchZone,
+    room, mode, isSoloMode, isHost, isSpectator, role, status, connectionState, spectatorCount, maxSpectatorConnections: MAX_SPECTATOR_CONNECTIONS, canInteract, canView, attemptReconnect, gameState, savedSessionCandidate, resumeSavedSession, discardSavedSession, searchZone, setSearchZone,
     showResetConfirm, setShowResetConfirm, coinMessage, turnMessage, cardPlayMessage, attackMessage, attackHistory, eventHistory, attackVisual, revealedCardsOverlay,
     cardStatLookup, cardDetailLookup,
     isRollingDice, diceValue, mulliganOrder, isMulliganModalOpen, setIsMulliganModalOpen,

--- a/src/hooks/useGameBoardLogic.ts
+++ b/src/hooks/useGameBoardLogic.ts
@@ -162,6 +162,7 @@ export const useGameBoardLogic = () => {
   const topDeckTargetRoleRef = useRef<PlayerRole>(role);
   const awaitingInitialSnapshotRef = useRef(false);
   const activeConnectionTokenRef = useRef<string | null>(null);
+  const openedSpectatorConnectionTokensRef = useRef<Set<string>>(new Set());
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const snapshotRequestTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const snapshotRetryCountRef = useRef(0);
@@ -945,6 +946,8 @@ export const useGameBoardLogic = () => {
   const {
     clearActiveConnectionLifecycleState,
     clearSpectatorConnectionLifecycleState,
+    markSpectatorConnectionOpen,
+    pruneInactiveSpectatorConnections,
     removeSpectatorConnection,
     prepareActiveConnection,
     prepareSpectatorConnection,
@@ -955,6 +958,7 @@ export const useGameBoardLogic = () => {
     clearReconnectTimer,
     clearSnapshotRequestTimer,
     connRef,
+    openedSpectatorConnectionTokensRef,
     spectatorConnectionsRef,
     setSpectatorCount,
   });
@@ -1008,7 +1012,9 @@ export const useGameBoardLogic = () => {
     handleIncomingSpectatorConnectionData,
     isActiveSpectatorConnectionToken,
     isHost,
+    markSpectatorConnectionOpen,
     prepareActiveConnection,
+    pruneInactiveSpectatorConnections,
     removeSpectatorConnection,
     prepareSpectatorConnection,
     spectatorConnectionsRef,
@@ -1018,6 +1024,23 @@ export const useGameBoardLogic = () => {
   useEffect(() => {
     setupConnectionRef.current = setupConnection;
   }, [setupConnection]);
+
+  useEffect(() => {
+    if (!isSpectator) return undefined;
+
+    const leaveSpectatorRoom = () => {
+      const conn = connRef.current;
+      if (!conn?.open) return;
+
+      conn.send({ type: 'SPECTATOR_LEAVE' });
+      conn.close();
+    };
+
+    window.addEventListener('pagehide', leaveSpectatorRoom);
+    return () => {
+      window.removeEventListener('pagehide', leaveSpectatorRoom);
+    };
+  }, [isSpectator]);
 
   const handlePeerOpen = useCallback(() => {
     const openDecision = getPeerOpenDecision({ isHost });

--- a/src/hooks/useGameBoardSnapshotMessaging.ts
+++ b/src/hooks/useGameBoardSnapshotMessaging.ts
@@ -9,12 +9,12 @@ type SnapshotMessage = Extract<SyncMessage, { type: 'STATE_SNAPSHOT' }>;
 
 type UseGameBoardSnapshotMessagingArgs = {
   connRef: React.RefObject<DataConnection | null>;
-  spectatorConnRef: React.RefObject<DataConnection | null>;
+  spectatorConnectionsRef: React.RefObject<Map<string, DataConnection>>;
 };
 
 export const useGameBoardSnapshotMessaging = ({
   connRef,
-  spectatorConnRef,
+  spectatorConnectionsRef,
 }: UseGameBoardSnapshotMessagingArgs) => {
   const snapshotFlushTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingSnapshotMessageRef = React.useRef<SnapshotMessage | null>(null);
@@ -38,9 +38,11 @@ export const useGameBoardSnapshotMessaging = ({
   }, [connRef]);
 
   const sendSpectatorImmediate = React.useCallback((message: SyncMessage) => {
-    if (!spectatorConnRef.current?.open) return;
-    spectatorConnRef.current.send(message);
-  }, [spectatorConnRef]);
+    spectatorConnectionsRef.current.forEach((spectatorConn) => {
+      if (!spectatorConn.open) return;
+      spectatorConn.send(message);
+    });
+  }, [spectatorConnectionsRef]);
 
   const scheduleSnapshotFlush = React.useCallback((flush: () => void) => {
     snapshotFlushTimeoutRef.current = setTimeout(() => {

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -433,7 +433,8 @@
       "roomId": "Room ID",
       "copyAria": "Copy Room ID",
       "copy": "Copy",
-      "copied": "Copied"
+      "copied": "Copied",
+      "spectators": "Spectators {{count}} / {{max}}"
     },
     "board": {
       "leaderLabel": "{{label}} Leader",

--- a/src/i18n/ja/translation.json
+++ b/src/i18n/ja/translation.json
@@ -379,7 +379,8 @@
       "roomId": "ルームID",
       "copyAria": "ルームIDをコピー",
       "copy": "コピー",
-      "copied": "コピー済み"
+      "copied": "コピー済み",
+      "spectators": "観戦者 {{count}} / {{max}}"
     },
     "board": {
       "leaderLabel": "{{label}} リーダー",

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -133,7 +133,7 @@ const GameBoard: React.FC = () => {
   );
   const { t } = useTranslation();
   const {
-    room, isSoloMode, isHost, isSpectator, role, status, connectionState, canInteract, canView, attemptReconnect, gameState, savedSessionCandidate, resumeSavedSession, discardSavedSession, searchZone, setSearchZone,
+    room, isSoloMode, isHost, isSpectator, role, status, connectionState, spectatorCount, maxSpectatorConnections, canInteract, canView, attemptReconnect, gameState, savedSessionCandidate, resumeSavedSession, discardSavedSession, searchZone, setSearchZone,
     showResetConfirm, setShowResetConfirm, coinMessage, turnMessage, cardPlayMessage, attackMessage, eventHistory, attackVisual, revealedCardsOverlay,
     cardStatLookup, cardDetailLookup,
     isRollingDice, diceValue, mulliganOrder, isMulliganModalOpen, setIsMulliganModalOpen,
@@ -653,6 +653,8 @@ const GameBoard: React.FC = () => {
           role={role}
           status={status}
           connectionState={connectionState}
+          spectatorCount={spectatorCount}
+          maxSpectatorConnections={maxSpectatorConnections}
           connectionBadgeTone={connectionBadgeTone}
           isRoomCopied={isRoomCopied}
           gameState={gameState}

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -109,6 +109,7 @@ export type SharedUiEffect =
 export type SyncMessage =
   | { type: 'EVENT'; event: GameSyncEvent }
   | { type: 'REQUEST_SNAPSHOT'; lastKnownRevision: number; source: PlayerRole }
+  | { type: 'SPECTATOR_LEAVE' }
   | { type: 'WAITING_FOR_HOST_SESSION'; source: PlayerRole }
   | { type: 'STATE_SNAPSHOT'; state: SyncState; source: PlayerRole; pendingEffects?: SharedUiEffect[] }
   | { type: 'SHARED_UI_EFFECT'; effect: SharedUiEffect };

--- a/src/utils/gameBoardSpectators.ts
+++ b/src/utils/gameBoardSpectators.ts
@@ -1,0 +1,1 @@
+export const MAX_SPECTATOR_CONNECTIONS = 4;


### PR DESCRIPTION
## Summary

- 観戦者接続を単一管理から最大4人までの複数接続管理に変更
- ホスト画面のルーム情報に観戦者数 `n / 4` を表示
- 観戦タブ終了時に `SPECTATOR_LEAVE` を送信し、ホスト側で該当観戦枠を解放
- 新規観戦者の上限判定前に、open 済みかつ現在 inactive な観戦接続を prune

## Tests

- `npm run lint`
- `npx tsc --noEmit -p tsconfig.app.json`
- `npx vitest run`
- `npm run build`

## Notes

- 観戦接続管理の主な契約は `src/hooks/useGameBoardLogic.test.tsx` でカバー
- UI 表示は `src/components/GameBoardStatusUi.test.tsx` でカバー
- heartbeat は入れず、誤切断リスクの低い退室通知と stale prune に限定
- 強制終了や `conn.open === true` のまま残る stale 接続までは完全には解決しない
