### PR TITLE
Codex/add card 20260518

### DIFF
--- a/src/utils/deckBuilderRules.test.ts
+++ b/src/utils/deckBuilderRules.test.ts
@@ -325,6 +325,35 @@ const deeplyChainedRelatedToken: DeckBuilderCardData = {
   image: '/deeply-chained-token.png',
 };
 
+const allowedRelatedTokenWhite: DeckBuilderCardData = {
+  ...tokenCard,
+  id: 'TK01-030',
+  name: '新約・白の章',
+  image: '/white-chapter.png',
+  related_cards: [
+    { id: 'TK01-031', name: '新約・黒の章' },
+  ],
+};
+
+const allowedRelatedTokenBlack: DeckBuilderCardData = {
+  ...tokenCard,
+  id: 'TK01-031',
+  name: '新約・黒の章',
+  image: '/black-chapter.png',
+  related_cards: [
+    { id: 'TK01-030', name: '新約・白の章' },
+  ],
+};
+
+const mainCardWithAllowedRelatedToken: DeckBuilderCardData = {
+  ...mainCard,
+  id: 'BP01-030',
+  name: 'Source Allowed Related Token Card',
+  related_cards: [
+    { id: allowedRelatedTokenWhite.id, name: allowedRelatedTokenWhite.name },
+  ],
+};
+
 const cyclicRelatedTokenA: DeckBuilderCardData = {
   ...tokenCard,
   id: 'TK01-020',
@@ -719,7 +748,43 @@ describe('deckBuilderRules', () => {
     ]);
   });
 
-  it('appends token related tokens with bounded recursion and ignores non-token relations', () => {
+  it('appends allowlisted token related tokens and stops when the allowlisted relation cycles back', () => {
+    const deckState = appendRelatedTokensToDeckState({
+      mainDeck: [mainCardWithAllowedRelatedToken],
+      evolveDeck: [],
+      leaderCards: [],
+      tokenDeck: [],
+    }, [
+      mainCardWithAllowedRelatedToken,
+      allowedRelatedTokenWhite,
+      allowedRelatedTokenBlack,
+    ], constructedRoyalRule);
+
+    expect(deckState.tokenDeck.map(card => card.id)).toEqual([
+      allowedRelatedTokenWhite.id,
+      allowedRelatedTokenBlack.id,
+    ]);
+  });
+
+  it('expands allowlisted token relations when the direct token is already present', () => {
+    const deckState = appendRelatedTokensToDeckState({
+      mainDeck: [mainCardWithAllowedRelatedToken],
+      evolveDeck: [],
+      leaderCards: [],
+      tokenDeck: [allowedRelatedTokenWhite],
+    }, [
+      mainCardWithAllowedRelatedToken,
+      allowedRelatedTokenWhite,
+      allowedRelatedTokenBlack,
+    ], constructedRoyalRule);
+
+    expect(deckState.tokenDeck.map(card => card.id)).toEqual([
+      allowedRelatedTokenWhite.id,
+      allowedRelatedTokenBlack.id,
+    ]);
+  });
+
+  it('does not append non-allowlisted token related tokens or non-token relations', () => {
     const shallowChainedToken = {
       ...tokenCardWithRelatedTokens,
       related_cards: [
@@ -751,11 +816,10 @@ describe('deckBuilderRules', () => {
     expect(deckState.tokenDeck.map(card => card.id)).toEqual([
       shallowChainedToken.id,
       secondaryRelatedToken.id,
-      twoHopChainedToken.id,
     ]);
   });
 
-  it('stops recursive token expansion when token relations form a cycle', () => {
+  it('does not follow non-allowlisted token cycles', () => {
     const deckState = appendRelatedTokensToDeckState({
       mainDeck: [mainCardWithCyclicRelatedToken],
       evolveDeck: [],
@@ -769,7 +833,6 @@ describe('deckBuilderRules', () => {
 
     expect(deckState.tokenDeck.map(card => card.id)).toEqual([
       cyclicRelatedTokenA.id,
-      cyclicRelatedTokenB.id,
     ]);
   });
 

--- a/src/utils/deckBuilderRules.test.ts
+++ b/src/utils/deckBuilderRules.test.ts
@@ -318,6 +318,42 @@ const tokenCardWithRelatedTokens: DeckBuilderCardData = {
   ],
 };
 
+const deeplyChainedRelatedToken: DeckBuilderCardData = {
+  ...tokenCard,
+  id: 'TK01-014',
+  name: 'Deeply Chained Token',
+  image: '/deeply-chained-token.png',
+};
+
+const cyclicRelatedTokenA: DeckBuilderCardData = {
+  ...tokenCard,
+  id: 'TK01-020',
+  name: 'Cyclic Token A',
+  image: '/cyclic-token-a.png',
+  related_cards: [
+    { id: 'TK01-021', name: 'Cyclic Token B' },
+  ],
+};
+
+const cyclicRelatedTokenB: DeckBuilderCardData = {
+  ...tokenCard,
+  id: 'TK01-021',
+  name: 'Cyclic Token B',
+  image: '/cyclic-token-b.png',
+  related_cards: [
+    { id: 'TK01-020', name: 'Cyclic Token A' },
+  ],
+};
+
+const mainCardWithCyclicRelatedToken: DeckBuilderCardData = {
+  ...mainCard,
+  id: 'BP01-020',
+  name: 'Source Cyclic Token Card',
+  related_cards: [
+    { id: cyclicRelatedTokenA.id, name: cyclicRelatedTokenA.name },
+  ],
+};
+
 const cutthroatCard: DeckBuilderCardData = {
   id: 'BP19-110',
   name: '機鋒の咎人・カットスロート',
@@ -680,6 +716,60 @@ describe('deckBuilderRules', () => {
     expect(deckState.tokenDeck.map(card => card.id)).toEqual([
       relatedTokenVariantB.id,
       secondaryRelatedToken.id,
+    ]);
+  });
+
+  it('appends token related tokens with bounded recursion and ignores non-token relations', () => {
+    const shallowChainedToken = {
+      ...tokenCardWithRelatedTokens,
+      related_cards: [
+        { id: chainedRelatedToken.id, name: chainedRelatedToken.name },
+        { id: mainCard.id, name: mainCard.name },
+      ],
+    };
+    const twoHopChainedToken = {
+      ...chainedRelatedToken,
+      related_cards: [
+        { id: deeplyChainedRelatedToken.id, name: deeplyChainedRelatedToken.name },
+      ],
+    };
+
+    const deckState = appendRelatedTokensToDeckState({
+      mainDeck: [mainCardWithRelatedTokens],
+      evolveDeck: [],
+      leaderCards: [],
+      tokenDeck: [],
+    }, [
+      mainCardWithRelatedTokens,
+      shallowChainedToken,
+      secondaryRelatedToken,
+      twoHopChainedToken,
+      deeplyChainedRelatedToken,
+      mainCard,
+    ], constructedRoyalRule);
+
+    expect(deckState.tokenDeck.map(card => card.id)).toEqual([
+      shallowChainedToken.id,
+      secondaryRelatedToken.id,
+      twoHopChainedToken.id,
+    ]);
+  });
+
+  it('stops recursive token expansion when token relations form a cycle', () => {
+    const deckState = appendRelatedTokensToDeckState({
+      mainDeck: [mainCardWithCyclicRelatedToken],
+      evolveDeck: [],
+      leaderCards: [],
+      tokenDeck: [],
+    }, [
+      mainCardWithCyclicRelatedToken,
+      cyclicRelatedTokenA,
+      cyclicRelatedTokenB,
+    ], constructedRoyalRule);
+
+    expect(deckState.tokenDeck.map(card => card.id)).toEqual([
+      cyclicRelatedTokenA.id,
+      cyclicRelatedTokenB.id,
     ]);
   });
 

--- a/src/utils/deckBuilderRules.ts
+++ b/src/utils/deckBuilderRules.ts
@@ -591,6 +591,13 @@ const getRelatedTokenIdentityKey = (card: Pick<DeckBuilderCardData, 'id' | 'name
   return normalizedName.length > 0 ? `name:${normalizedName}` : `id:${card.id}`;
 };
 
+const MAX_RELATED_TOKEN_EXPANSION_DEPTH = 2;
+
+type RelatedTokenExpansionEntry = {
+  card: DeckBuilderCardData;
+  depth: number;
+};
+
 export const appendRelatedTokensToDeckState = (
   deckState: DeckState,
   availableCards: DeckBuilderCardData[],
@@ -601,25 +608,37 @@ export const appendRelatedTokensToDeckState = (
   const cardCatalogById = new Map(availableCards.map(card => [card.id, card]));
   const tokenIdentityKeys = new Set(deckState.tokenDeck.map(getRelatedTokenIdentityKey));
   const tokensToAppend: DeckBuilderCardData[] = [];
-
-  [
+  const processedCardIds = new Set<string>();
+  const expansionQueue: RelatedTokenExpansionEntry[] = [
     ...deckState.mainDeck,
     ...deckState.evolveDeck,
     ...deckState.leaderCards,
-  ].forEach(card => {
+  ].map(card => ({ card, depth: 0 }));
+
+  for (let index = 0; index < expansionQueue.length; index += 1) {
+    const { card, depth } = expansionQueue[index];
+    if (processedCardIds.has(card.id)) continue;
+    processedCardIds.add(card.id);
+
     (card.related_cards ?? []).forEach(relatedCard => {
       const relatedToken = cardCatalogById.get(relatedCard.id);
       if (!relatedToken) return;
       if (inferDeckSection(relatedToken) !== 'token') return;
       if (!canAddCardToSection(relatedToken, 'token', ruleConfig)) return;
+      const relatedDepth = depth + 1;
+      if (relatedDepth > MAX_RELATED_TOKEN_EXPANSION_DEPTH) return;
 
       const tokenIdentityKey = getRelatedTokenIdentityKey(relatedToken);
       if (tokenIdentityKeys.has(tokenIdentityKey)) return;
 
       tokenIdentityKeys.add(tokenIdentityKey);
       tokensToAppend.push(relatedToken);
+
+      if (relatedDepth < MAX_RELATED_TOKEN_EXPANSION_DEPTH) {
+        expansionQueue.push({ card: relatedToken, depth: relatedDepth });
+      }
     });
-  });
+  }
 
   if (tokensToAppend.length === 0) return deckState;
 

--- a/src/utils/deckBuilderRules.ts
+++ b/src/utils/deckBuilderRules.ts
@@ -593,10 +593,27 @@ const getRelatedTokenIdentityKey = (card: Pick<DeckBuilderCardData, 'id' | 'name
 
 const MAX_RELATED_TOKEN_EXPANSION_DEPTH = 2;
 
+const ALLOWED_RELATED_TOKEN_EXPANSION_NAME_PAIRS = new Set([
+  '新約・白の章::新約・黒の章',
+  '新約・黒の章::新約・白の章',
+]);
+
 type RelatedTokenExpansionEntry = {
   card: DeckBuilderCardData;
   depth: number;
 };
+
+const getRelatedTokenExpansionPairKey = (
+  sourceToken: DeckBuilderCardData,
+  relatedToken: DeckBuilderCardData
+): string => `${sourceToken.name.trim()}::${relatedToken.name.trim()}`;
+
+const canExpandRelatedTokenFromToken = (
+  sourceToken: DeckBuilderCardData,
+  relatedToken: DeckBuilderCardData
+): boolean => ALLOWED_RELATED_TOKEN_EXPANSION_NAME_PAIRS.has(
+  getRelatedTokenExpansionPairKey(sourceToken, relatedToken)
+);
 
 export const appendRelatedTokensToDeckState = (
   deckState: DeckState,
@@ -627,12 +644,13 @@ export const appendRelatedTokensToDeckState = (
       if (!canAddCardToSection(relatedToken, 'token', ruleConfig)) return;
       const relatedDepth = depth + 1;
       if (relatedDepth > MAX_RELATED_TOKEN_EXPANSION_DEPTH) return;
+      if (depth > 0 && !canExpandRelatedTokenFromToken(card, relatedToken)) return;
 
       const tokenIdentityKey = getRelatedTokenIdentityKey(relatedToken);
-      if (tokenIdentityKeys.has(tokenIdentityKey)) return;
-
-      tokenIdentityKeys.add(tokenIdentityKey);
-      tokensToAppend.push(relatedToken);
+      if (!tokenIdentityKeys.has(tokenIdentityKey)) {
+        tokenIdentityKeys.add(tokenIdentityKey);
+        tokensToAppend.push(relatedToken);
+      }
 
       if (relatedDepth < MAX_RELATED_TOKEN_EXPANSION_DEPTH) {
         expansionQueue.push({ card: relatedToken, depth: relatedDepth });


### PR DESCRIPTION
## Summary

関連カードから tokenDeck に自動追加する処理で、allowlist された token 同士の関連だけを追加で展開するようにしました。

対象は `新約・白の章` / `新約・黒の章` の相互関係のみです。実データ上、全 token 関連を再帰展開するとアイドルマスター系のアクセサリ token が大量に追加されるため、allowlist 制で過剰追加を避けています。

## Changes

- `appendRelatedTokensToDeckState` で token -> token の関連展開を追加
- token -> token 展開は allowlist の名前ペアだけ許可
  - `新約・白の章 -> 新約・黒の章`
  - `新約・黒の章 -> 新約・白の章`
- 既に tokenDeck に直接 token がある場合でも、起点カードから到達した token なら allowlist 関連を展開
- allowlist 外の token 関連、token -> non-token、allowlist 外の循環は辿らない
- 関連ルールのテストを追加

## Verification

- `npm test -- --run src/utils/deckBuilderRules.test.ts`
- `npm test -- --run src/utils/deckBuilderRules.test.ts src/pages/DeckBuilder.test.tsx src/models/deckBuilderCard.test.ts src/utils/deckBuilderPersistence.test.ts`
- `npm run lint`
- `npx tsc --noEmit -p tsconfig.app.json`
- `npm run build`
- `git diff --check`

## Notes

`main` との差分は以下の 2 ファイルのみです。

- `src/utils/deckBuilderRules.ts`
- `src/utils/deckBuilderRules.test.ts`
