### PR TITLE
add spectator

### DIFF
--- a/src/components/GameBoardStatusUi.test.tsx
+++ b/src/components/GameBoardStatusUi.test.tsx
@@ -82,7 +82,7 @@ describe('GameBoard extracted UI components - status and preparation', () => {
       status: 'Connected',
       connectionState: 'connected' as const,
       spectatorCount: 2,
-      maxSpectatorConnections: 4,
+      maxSpectatorConnections: 8,
       connectionBadgeTone: {
         label: 'Connected',
         background: 'rgba(16, 185, 129, 0.16)',
@@ -101,7 +101,7 @@ describe('GameBoard extracted UI components - status and preparation', () => {
       />
     );
 
-    expect(screen.getByTestId('spectator-count-badge')).toHaveTextContent('Spectators 2 / 4');
+    expect(screen.getByTestId('spectator-count-badge')).toHaveTextContent('Spectators 2 / 8');
 
     rerender(
       <GameBoardRoomStatus

--- a/src/hooks/useGameBoardLogic.test.tsx
+++ b/src/hooks/useGameBoardLogic.test.tsx
@@ -950,7 +950,7 @@ describe('useGameBoardLogic P2P reconnect', () => {
     }));
   });
 
-  it('rejects a fifth spectator while keeping the first four active', () => {
+  it('rejects a ninth spectator while keeping the first eight active', () => {
     renderHarness('/game?host=true&room=ROOM123');
 
     const peer = mockPeerJs.peers[0];
@@ -959,7 +959,7 @@ describe('useGameBoardLogic P2P reconnect', () => {
     });
 
     const guestConn = mockPeerJs.createConnection('guest');
-    const spectatorConns = Array.from({ length: 5 }, (_, index) => (
+    const spectatorConns = Array.from({ length: 9 }, (_, index) => (
       mockPeerJs.createConnection(`spectator-${index + 1}`, { connectionRole: 'spectator' })
     ));
     act(() => {
@@ -973,8 +973,8 @@ describe('useGameBoardLogic P2P reconnect', () => {
       });
     });
 
-    expect(spectatorConns[4].close).toHaveBeenCalledTimes(1);
-    expect(screen.getByTestId('spectator-count')).toHaveTextContent('4');
+    expect(spectatorConns[8].close).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('spectator-count')).toHaveTextContent('8');
 
     guestConn.send.mockClear();
     spectatorConns.forEach((spectatorConn) => spectatorConn.send.mockClear());
@@ -987,13 +987,59 @@ describe('useGameBoardLogic P2P reconnect', () => {
       type: 'STATE_SNAPSHOT',
       source: 'host',
     }));
-    spectatorConns.slice(0, 4).forEach((spectatorConn) => {
+    spectatorConns.slice(0, 8).forEach((spectatorConn) => {
       expect(spectatorConn.send).toHaveBeenCalledWith(expect.objectContaining({
         type: 'STATE_SNAPSHOT',
         source: 'host',
       }));
     });
-    expect(spectatorConns[4].send).not.toHaveBeenCalled();
+    expect(spectatorConns[8].send).not.toHaveBeenCalled();
+  });
+
+  it('continues broadcasting to other spectators when one spectator send fails', () => {
+    renderHarness('/game?host=true&room=ROOM123');
+
+    const peer = mockPeerJs.peers[0];
+    act(() => {
+      peer.emit('open');
+    });
+
+    const guestConn = mockPeerJs.createConnection('guest');
+    const spectatorConns = Array.from({ length: 3 }, (_, index) => (
+      mockPeerJs.createConnection(`spectator-${index + 1}`, { connectionRole: 'spectator' })
+    ));
+    act(() => {
+      peer.emit('connection', guestConn);
+      guestConn.open = true;
+      guestConn.emit('open');
+      spectatorConns.forEach((spectatorConn) => {
+        peer.emit('connection', spectatorConn);
+        spectatorConn.open = true;
+        spectatorConn.emit('open');
+      });
+    });
+
+    guestConn.send.mockClear();
+    spectatorConns.forEach((spectatorConn) => spectatorConn.send.mockClear());
+    spectatorConns[0].send.mockImplementationOnce(() => {
+      throw new Error('send failed');
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Spawn Token to EX' }));
+    });
+
+    expect(guestConn.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'STATE_SNAPSHOT',
+      source: 'host',
+    }));
+    expect(spectatorConns[0].send).toHaveBeenCalledTimes(1);
+    spectatorConns.slice(1).forEach((spectatorConn) => {
+      expect(spectatorConn.send).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'STATE_SNAPSHOT',
+        source: 'host',
+      }));
+    });
   });
 
   it('sends a leave message and closes the spectator connection on pagehide', () => {
@@ -1031,14 +1077,14 @@ describe('useGameBoardLogic P2P reconnect', () => {
     });
 
     const guestConn = mockPeerJs.createConnection('guest');
-    const spectatorConns = Array.from({ length: 5 }, (_, index) => (
+    const spectatorConns = Array.from({ length: 9 }, (_, index) => (
       mockPeerJs.createConnection(`spectator-${index + 1}`, { connectionRole: 'spectator' })
     ));
     act(() => {
       peer.emit('connection', guestConn);
       guestConn.open = true;
       guestConn.emit('open');
-      spectatorConns.slice(0, 4).forEach((spectatorConn) => {
+      spectatorConns.slice(0, 8).forEach((spectatorConn) => {
         peer.emit('connection', spectatorConn);
         spectatorConn.open = true;
         spectatorConn.emit('open');
@@ -1046,13 +1092,13 @@ describe('useGameBoardLogic P2P reconnect', () => {
       spectatorConns[0].emit('data', {
         type: 'SPECTATOR_LEAVE',
       });
-      peer.emit('connection', spectatorConns[4]);
-      spectatorConns[4].open = true;
-      spectatorConns[4].emit('open');
+      peer.emit('connection', spectatorConns[8]);
+      spectatorConns[8].open = true;
+      spectatorConns[8].emit('open');
     });
 
-    expect(screen.getByTestId('spectator-count')).toHaveTextContent('4');
-    expect(spectatorConns[4].close).not.toHaveBeenCalled();
+    expect(screen.getByTestId('spectator-count')).toHaveTextContent('8');
+    expect(spectatorConns[8].close).not.toHaveBeenCalled();
 
     guestConn.send.mockClear();
     spectatorConns.forEach((spectatorConn) => spectatorConn.send.mockClear());
@@ -1082,11 +1128,11 @@ describe('useGameBoardLogic P2P reconnect', () => {
       peer.emit('open');
     });
 
-    const spectatorConns = Array.from({ length: 5 }, (_, index) => (
+    const spectatorConns = Array.from({ length: 9 }, (_, index) => (
       mockPeerJs.createConnection(`spectator-${index + 1}`, { connectionRole: 'spectator' })
     ));
     act(() => {
-      spectatorConns.slice(0, 4).forEach((spectatorConn) => {
+      spectatorConns.slice(0, 8).forEach((spectatorConn) => {
         peer.emit('connection', spectatorConn);
         spectatorConn.open = true;
         spectatorConn.emit('open');
@@ -1096,13 +1142,13 @@ describe('useGameBoardLogic P2P reconnect', () => {
     spectatorConns[0].open = false;
 
     act(() => {
-      peer.emit('connection', spectatorConns[4]);
-      spectatorConns[4].open = true;
-      spectatorConns[4].emit('open');
+      peer.emit('connection', spectatorConns[8]);
+      spectatorConns[8].open = true;
+      spectatorConns[8].emit('open');
     });
 
-    expect(spectatorConns[4].close).not.toHaveBeenCalled();
-    expect(screen.getByTestId('spectator-count')).toHaveTextContent('4');
+    expect(spectatorConns[8].close).not.toHaveBeenCalled();
+    expect(screen.getByTestId('spectator-count')).toHaveTextContent('8');
 
     spectatorConns.forEach((spectatorConn) => spectatorConn.send.mockClear());
 
@@ -1127,18 +1173,18 @@ describe('useGameBoardLogic P2P reconnect', () => {
       peer.emit('open');
     });
 
-    const spectatorConns = Array.from({ length: 5 }, (_, index) => (
+    const spectatorConns = Array.from({ length: 9 }, (_, index) => (
       mockPeerJs.createConnection(`spectator-${index + 1}`, { connectionRole: 'spectator' })
     ));
     act(() => {
-      spectatorConns.slice(0, 4).forEach((spectatorConn) => {
+      spectatorConns.slice(0, 8).forEach((spectatorConn) => {
         peer.emit('connection', spectatorConn);
       });
-      peer.emit('connection', spectatorConns[4]);
+      peer.emit('connection', spectatorConns[8]);
     });
 
-    expect(spectatorConns[4].close).toHaveBeenCalledTimes(1);
-    expect(screen.getByTestId('spectator-count')).toHaveTextContent('4');
+    expect(spectatorConns[8].close).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('spectator-count')).toHaveTextContent('8');
   });
 
   it('ignores spectator events on the host side and does not treat spectator close as guest disconnect', () => {

--- a/src/hooks/useGameBoardSnapshotMessaging.ts
+++ b/src/hooks/useGameBoardSnapshotMessaging.ts
@@ -40,7 +40,12 @@ export const useGameBoardSnapshotMessaging = ({
   const sendSpectatorImmediate = React.useCallback((message: SyncMessage) => {
     spectatorConnectionsRef.current.forEach((spectatorConn) => {
       if (!spectatorConn.open) return;
-      spectatorConn.send(message);
+
+      try {
+        spectatorConn.send(message);
+      } catch {
+        // Keep broadcasting to the remaining spectators.
+      }
     });
   }, [spectatorConnectionsRef]);
 

--- a/src/utils/gameBoardSpectators.ts
+++ b/src/utils/gameBoardSpectators.ts
@@ -1,1 +1,1 @@
-export const MAX_SPECTATOR_CONNECTIONS = 4;
+export const MAX_SPECTATOR_CONNECTIONS = 8;


### PR DESCRIPTION
## Summary

- 観戦者上限を 4人から 8人に変更
- ホスト画面の観戦者数表示を `n / 8` に更新
- 観戦者への broadcast で、1接続の `send` が失敗しても他の観戦者への送信を継続するように変更
- 8人接続、9人目拒否、退室後の枠再利用、inactive 接続 prune、send 失敗時の継続送信をテストでカバー

## Tests

- `npx vitest run src/hooks/useGameBoardLogic.test.tsx src/components/GameBoardStatusUi.test.tsx --testNamePattern "ninth|continues broadcasting|leaving|prunes|opened|spectator count"`
- `npx vitest run src/hooks/useGameBoardLogic.test.tsx src/components/GameBoardStatusUi.test.tsx`
- `npx tsc --noEmit -p tsconfig.app.json`
- `npm run lint`
- `npm run build`
- `npx vitest run`

## Notes

- 観戦者数増加に伴うホスト側 fan-out は増えますが、送信失敗が他観戦者へ波及しないよう `try/catch` で保護しています。
- 遅い観戦者の DataChannel バッファ詰まり自体は今回の対象外です。
